### PR TITLE
feat: add blend nodes to graph core

### DIFF
--- a/crates/node-graph/vizij-graph-core/src/types.rs
+++ b/crates/node-graph/vizij-graph-core/src/types.rs
@@ -51,6 +51,7 @@ pub enum NodeType {
     Equal,
     NotEqual,
     If,
+    Case,
 
     // Ranges
     Clamp,
@@ -76,6 +77,15 @@ pub enum NodeType {
     VectorMean,
     VectorMedian,
     VectorMode,
+
+    // Blend support
+    WeightedSumVector,
+    BlendWeightedAverage,
+    BlendAdditive,
+    BlendMultiply,
+    BlendWeightedOverlay,
+    BlendWeightedAverageOverlay,
+    BlendMax,
 
     // Robotics
     InverseKinematics,
@@ -137,6 +147,10 @@ pub struct NodeParams {
     // Example: "robot1/Arm/Joint3.translation"
     #[serde(default)]
     pub path: Option<TypedPath>,
+
+    // Labels used by nodes that route inputs by name (e.g. Case).
+    #[serde(default)]
+    pub labels: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- add new Case and blend-related node types to the schema and type registry
- implement evaluation helpers for weighted blend math and string-based case routing
- extend node graph tests to cover weighted sum, blend operations, and case routing math

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --workspace --color never


------
https://chatgpt.com/codex/tasks/task_e_68cf5eab02688320b64f855c7524cc3d