### PR TITLE
feat(node-graph): add blend helper nodes

### DIFF
--- a/crates/node-graph/vizij-graph-core/src/types.rs
+++ b/crates/node-graph/vizij-graph-core/src/types.rs
@@ -51,6 +51,7 @@ pub enum NodeType {
     Equal,
     NotEqual,
     If,
+    Case,
 
     // Ranges
     Clamp,
@@ -76,6 +77,15 @@ pub enum NodeType {
     VectorMean,
     VectorMedian,
     VectorMode,
+
+    // Animation blend support
+    WeightedSumVector,
+    BlendWeightedAverage,
+    BlendAdditive,
+    BlendMultiply,
+    BlendWeightedOverlay,
+    BlendWeightedAverageOverlay,
+    BlendMax,
 
     // Robotics
     InverseKinematics,
@@ -125,6 +135,8 @@ pub struct NodeParams {
     pub index: Option<f32>,
     // For Split sizes (vector of sizes, floored to usize)
     pub sizes: Option<Vec<f32>>,
+    // For Case routing nodes
+    pub case_labels: Option<Vec<String>>,
 
     // Transition parameters
     pub stiffness: Option<f32>,

--- a/crates/node-graph/vizij-graph-wasm/src/lib.rs
+++ b/crates/node-graph/vizij-graph-wasm/src/lib.rs
@@ -619,6 +619,30 @@ impl WasmGraph {
             Ok(out)
         }
 
+        fn parse_string_list(node_id: &str, key: &str, v: &Value) -> Result<Vec<String>, JsValue> {
+            match v {
+                Value::List(items) | Value::Array(items) | Value::Tuple(items) => {
+                    let mut out = Vec::with_capacity(items.len());
+                    for item in items {
+                        if let Value::Text(s) = item {
+                            out.push(s.clone());
+                        } else {
+                            return Err(JsValue::from_str(&format!(
+                                "set_param: node '{}' key '{}' expects list of Text",
+                                node_id, key
+                            )));
+                        }
+                    }
+                    Ok(out)
+                }
+                Value::Text(s) => Ok(vec![s.clone()]),
+                _ => Err(JsValue::from_str(&format!(
+                    "set_param: node '{}' key '{}' expects Text or list of Text",
+                    node_id, key
+                ))),
+            }
+        }
+
         if let Some(node) = self.spec.nodes.iter_mut().find(|n| n.id == node_id) {
             match key {
                 "value" => {
@@ -692,6 +716,9 @@ impl WasmGraph {
                 }
                 "joint_defaults" => {
                     node.params.joint_defaults = Some(parse_pairs(node_id, key, &val)?);
+                }
+                "case_labels" => {
+                    node.params.case_labels = Some(parse_string_list(node_id, key, &val)?);
                 }
 
                 _ => {


### PR DESCRIPTION
## Summary
- add dedicated node kinds for weighted sums, each blend mode, and a case-based router so graphs can reproduce the TS blend logic
- document the new ports/params in the schema so tooling can wire the helper nodes correctly
- extend wasm parameter parsing to accept case label lists and cover the math with targeted unit tests

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --workspace

------
https://chatgpt.com/codex/tasks/task_e_68cf5eab02688320b64f855c7524cc3d