### PR TITLE
Add blend helper nodes to graph runtime

### DIFF
--- a/crates/node-graph/vizij-graph-core/src/types.rs
+++ b/crates/node-graph/vizij-graph-core/src/types.rs
@@ -76,6 +76,22 @@ pub enum NodeType {
     VectorMean,
     VectorMedian,
     VectorMode,
+    #[serde(rename = "vector_weighted_sum")]
+    VectorWeightedSum,
+
+    // Blend utilities
+    #[serde(rename = "blend_weighted_average")]
+    BlendWeightedAverage,
+    #[serde(rename = "blend_additive")]
+    BlendAdditive,
+    #[serde(rename = "blend_multiply")]
+    BlendMultiply,
+    #[serde(rename = "blend_weighted_overlay")]
+    BlendWeightedOverlay,
+    #[serde(rename = "blend_weighted_average_overlay")]
+    BlendWeightedAverageOverlay,
+    #[serde(rename = "blend_max")]
+    BlendMax,
 
     // Robotics
     InverseKinematics,
@@ -87,6 +103,9 @@ pub enum NodeType {
     Input,
     // Sinks (for external binding in hosts)
     Output,
+
+    // Control-flow helpers
+    Case,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Summary
- add dedicated node types for vector weighted sums, blend variants, and string-based case routing
- implement evaluation logic that mirrors the TS blend node behaviour, including weighted math helpers and case dispatch
- document the new nodes in the schema registry so they surface in tooling and authoring flows
- cover the new nodes with tests that validate the expected arithmetic for each blend mode and routing path

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68cf5eab02688320b64f855c7524cc3d