### PR TITLE
Add blend helper nodes and case routing to graph core

### DIFF
--- a/crates/node-graph/vizij-graph-core/src/types.rs
+++ b/crates/node-graph/vizij-graph-core/src/types.rs
@@ -77,6 +77,18 @@ pub enum NodeType {
     VectorMedian,
     VectorMode,
 
+    // Blend helpers
+    WeightedSumVector,
+    BlendWeightedAverage,
+    BlendAdditive,
+    BlendMultiply,
+    BlendWeightedOverlay,
+    BlendWeightedAverageOverlay,
+    BlendMax,
+
+    // Routing
+    Case,
+
     // Robotics
     InverseKinematics,
     UrdfIkPosition,
@@ -137,6 +149,10 @@ pub struct NodeParams {
     // Example: "robot1/Arm/Joint3.translation"
     #[serde(default)]
     pub path: Option<TypedPath>,
+
+    // Case routing labels
+    #[serde(default)]
+    pub case_labels: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- add dedicated node types for weighted sum and blend operations alongside a case router
- implement evaluation helpers mirroring blend math and register nodes in the schema
- cover the new math and routing behaviour with unit tests that re-derive the expected results

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --workspace

------
https://chatgpt.com/codex/tasks/task_e_68cf5eab02688320b64f855c7524cc3d