### PR TITLE
feat: expose derivative animation APIs across core and wasm

### DIFF
--- a/crates/animation/bevy_vizij_animation/src/systems.rs
+++ b/crates/animation/bevy_vizij_animation/src/systems.rs
@@ -123,7 +123,7 @@ pub fn fixed_update_core_system(
     dt: Res<FixedDt>,
     mut pending: ResMut<PendingOutputs>,
 ) {
-    let out = eng.0.update(dt.0, Inputs::default());
+    let out = eng.0.update_values(dt.0, Inputs::default());
     // Replace pending changes with this tick's changes
     pending.changes.clear();
     pending.changes.extend(out.changes.iter().cloned());

--- a/crates/animation/bevy_vizij_animation/tests/plugin_smoke.rs
+++ b/crates/animation/bevy_vizij_animation/tests/plugin_smoke.rs
@@ -26,7 +26,7 @@ fn fixedupdate_ticks_engine() {
     fn fixed_sys(mut eng: ResMut<VizijEngine>, mut ticks: ResMut<Ticks>) {
         let _ = eng
             .0
-            .update(1.0 / 60.0, vizij_animation_core::inputs::Inputs::default());
+            .update_values(1.0 / 60.0, vizij_animation_core::inputs::Inputs::default());
         ticks.0 += 1;
     }
 

--- a/crates/animation/vizij-animation-core/src/baking.rs
+++ b/crates/animation/vizij-animation-core/src/baking.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::data::AnimationData;
 use crate::ids::AnimId;
-use crate::sampling::sample_track;
+use crate::sampling::sample_track_with_derivative;
 use vizij_api_core::Value;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -37,6 +37,12 @@ pub struct BakedTrack {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BakedDerivativeTrack {
+    pub target_path: String,
+    pub derivatives: Vec<Option<Value>>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BakedAnimationData {
     pub anim: AnimId,
     pub frame_rate: f32,
@@ -45,12 +51,30 @@ pub struct BakedAnimationData {
     pub tracks: Vec<BakedTrack>,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BakedAnimationDerivatives {
+    pub anim: AnimId,
+    pub frame_rate: f32,
+    pub start_time: f32,
+    pub end_time: f32,
+    pub tracks: Vec<BakedDerivativeTrack>,
+}
+
 /// Bake a single AnimationData using the provided config.
 pub fn bake_animation_data(
     anim_id: AnimId,
     data: &AnimationData,
     cfg: &BakingConfig,
 ) -> BakedAnimationData {
+    bake_animation_data_with_derivatives(anim_id, data, cfg).0
+}
+
+/// Bake animation data and also compute per-sample derivatives.
+pub fn bake_animation_data_with_derivatives(
+    anim_id: AnimId,
+    data: &AnimationData,
+    cfg: &BakingConfig,
+) -> (BakedAnimationData, BakedAnimationDerivatives) {
     let sr = cfg.frame_rate.max(1.0);
     let start = cfg.start_time.max(0.0);
     // Convert canonical duration (ms) to seconds for baking time domain
@@ -61,8 +85,10 @@ pub fn bake_animation_data(
     let frame_count = frames_f as usize + 1; // inclusive of end
 
     let mut tracks = Vec::with_capacity(data.tracks.len());
+    let mut derivative_tracks = Vec::with_capacity(data.tracks.len());
     for track in &data.tracks {
         let mut values = Vec::with_capacity(frame_count);
+        let mut derivatives = Vec::with_capacity(frame_count);
         for f in 0..frame_count {
             let t = start + (f as f32) / sr; // seconds in clip space
             let u = if duration_s > 0.0 {
@@ -70,25 +96,44 @@ pub fn bake_animation_data(
             } else {
                 0.0
             };
-            let v = sample_track(track, u);
-            values.push(v);
+            let sampled = sample_track_with_derivative(track, u, duration_s);
+            values.push(sampled.value);
+            derivatives.push(sampled.derivative);
         }
         tracks.push(BakedTrack {
             target_path: track.animatable_id.clone(),
             values,
         });
+        derivative_tracks.push(BakedDerivativeTrack {
+            target_path: track.animatable_id.clone(),
+            derivatives,
+        });
     }
 
-    BakedAnimationData {
-        anim: anim_id,
-        frame_rate: sr,
-        start_time: start,
-        end_time: end,
-        tracks,
-    }
+    (
+        BakedAnimationData {
+            anim: anim_id,
+            frame_rate: sr,
+            start_time: start,
+            end_time: end,
+            tracks,
+        },
+        BakedAnimationDerivatives {
+            anim: anim_id,
+            frame_rate: sr,
+            start_time: start,
+            end_time: end,
+            tracks: derivative_tracks,
+        },
+    )
 }
 
 /// Export baked data as serde_json::Value (stable schema for FFI/serialization).
 pub fn export_baked_json(baked: &BakedAnimationData) -> serde_json::Value {
     serde_json::to_value(baked).unwrap_or(serde_json::Value::Null)
+}
+
+/// Export baked derivative data as serde_json::Value.
+pub fn export_baked_derivatives_json(derivatives: &BakedAnimationDerivatives) -> serde_json::Value {
+    serde_json::to_value(derivatives).unwrap_or(serde_json::Value::Null)
 }

--- a/crates/animation/vizij-animation-core/src/lib.rs
+++ b/crates/animation/vizij-animation-core/src/lib.rs
@@ -22,7 +22,10 @@ pub mod stored_animation;
 pub mod value;
 
 // Re-exports for consumers (adapters)
-pub use baking::{BakedAnimationData, BakingConfig};
+pub use baking::{
+    bake_animation_data_with_derivatives, export_baked_derivatives_json, BakedAnimationData,
+    BakedAnimationDerivatives, BakedDerivativeTrack, BakingConfig,
+};
 pub use binding::{BindingSet, BindingTable, ChannelKey, TargetHandle, TargetResolver};
 pub use config::Config;
 pub use data::{AnimationData, Keypoint, Track, Transitions, Vec2};
@@ -30,8 +33,8 @@ pub use engine::{Engine, InstanceCfg, Player};
 pub use ids::{AnimId, InstId, PlayerId};
 pub use inputs::{Inputs, InstanceUpdate, LoopMode, PlayerCommand};
 pub use interp::InterpRegistry;
-pub use outputs::{Change, CoreEvent, Outputs};
-pub use sampling::sample_track;
+pub use outputs::{Change, ChangeWithDerivative, CoreEvent, Outputs, OutputsWithDerivatives};
+pub use sampling::{sample_track, sample_track_with_derivative, SampledValue};
 pub use scratch::Scratch;
 pub use stored_animation::parse_stored_animation_json;
 pub use vizij_api_core::{Value, ValueKind};

--- a/crates/animation/vizij-animation-core/src/outputs.rs
+++ b/crates/animation/vizij-animation-core/src/outputs.rs
@@ -18,6 +18,15 @@ pub struct Change {
     pub value: Value,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ChangeWithDerivative {
+    pub player: PlayerId,
+    pub key: String,
+    pub value: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub derivative: Option<Value>,
+}
+
 /// Discrete semantic signals emitted during stepping.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -75,6 +84,14 @@ pub struct Outputs {
     pub events: Vec<CoreEvent>,
 }
 
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct OutputsWithDerivatives {
+    #[serde(default)]
+    pub changes: Vec<ChangeWithDerivative>,
+    #[serde(default)]
+    pub events: Vec<CoreEvent>,
+}
+
 impl Outputs {
     #[inline]
     pub fn clear(&mut self) {
@@ -95,5 +112,23 @@ impl Outputs {
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.changes.is_empty() && self.events.is_empty()
+    }
+}
+
+impl OutputsWithDerivatives {
+    #[inline]
+    pub fn clear(&mut self) {
+        self.changes.clear();
+        self.events.clear();
+    }
+
+    #[inline]
+    pub fn push_change(&mut self, change: ChangeWithDerivative) {
+        self.changes.push(change);
+    }
+
+    #[inline]
+    pub fn push_event(&mut self, event: CoreEvent) {
+        self.events.push(event);
     }
 }

--- a/crates/animation/vizij-animation-core/src/sampling.rs
+++ b/crates/animation/vizij-animation-core/src/sampling.rs
@@ -16,6 +16,14 @@ use crate::data::{Keypoint, Track};
 use crate::interp::functions::{bezier_value, step_value};
 use vizij_api_core::{Value, ValueKind};
 
+const DERIV_EPSILON: f32 = 1e-3;
+
+#[derive(Clone, Debug)]
+pub struct SampledValue {
+    pub value: Value,
+    pub derivative: Option<Value>,
+}
+
 const DEFAULT_OUT_X: f32 = 0.42;
 const DEFAULT_OUT_Y: f32 = 0.0;
 const DEFAULT_IN_X: f32 = 0.58;
@@ -92,4 +100,127 @@ pub fn sample_track(track: &Track, u: f32) -> Value {
             bezier_value(&left.value, &right.value, lt, [x1, y1, x2, y2])
         }
     }
+}
+
+fn quaternion_adjust(a: [f32; 4], mut b: [f32; 4]) -> [f32; 4] {
+    let dot = a[0] * b[0] + a[1] * b[1] + a[2] * b[2] + a[3] * b[3];
+    if dot < 0.0 {
+        b[0] = -b[0];
+        b[1] = -b[1];
+        b[2] = -b[2];
+        b[3] = -b[3];
+    }
+    b
+}
+
+fn derivative_between(a: &Value, b: &Value, dt: f32) -> Option<Value> {
+    if dt <= 0.0 {
+        return None;
+    }
+    let inv_dt = dt.recip();
+    match (a, b) {
+        (Value::Float(va), Value::Float(vb)) => Some(Value::Float((vb - va) * inv_dt)),
+        (Value::Vec2(va), Value::Vec2(vb)) => Some(Value::Vec2([
+            (vb[0] - va[0]) * inv_dt,
+            (vb[1] - va[1]) * inv_dt,
+        ])),
+        (Value::Vec3(va), Value::Vec3(vb)) => Some(Value::Vec3([
+            (vb[0] - va[0]) * inv_dt,
+            (vb[1] - va[1]) * inv_dt,
+            (vb[2] - va[2]) * inv_dt,
+        ])),
+        (Value::Vec4(va), Value::Vec4(vb)) => Some(Value::Vec4([
+            (vb[0] - va[0]) * inv_dt,
+            (vb[1] - va[1]) * inv_dt,
+            (vb[2] - va[2]) * inv_dt,
+            (vb[3] - va[3]) * inv_dt,
+        ])),
+        (Value::Quat(qa), Value::Quat(qb)) => {
+            let qb_adj = quaternion_adjust(*qa, *qb);
+            Some(Value::Quat([
+                (qb_adj[0] - qa[0]) * inv_dt,
+                (qb_adj[1] - qa[1]) * inv_dt,
+                (qb_adj[2] - qa[2]) * inv_dt,
+                (qb_adj[3] - qa[3]) * inv_dt,
+            ]))
+        }
+        (Value::ColorRgba(ca), Value::ColorRgba(cb)) => Some(Value::ColorRgba([
+            (cb[0] - ca[0]) * inv_dt,
+            (cb[1] - ca[1]) * inv_dt,
+            (cb[2] - ca[2]) * inv_dt,
+            (cb[3] - ca[3]) * inv_dt,
+        ])),
+        (
+            Value::Transform {
+                pos: pa,
+                rot: ra,
+                scale: sa,
+            },
+            Value::Transform {
+                pos: pb,
+                rot: rb,
+                scale: sb,
+            },
+        ) => {
+            let rb_adj = quaternion_adjust(*ra, *rb);
+            Some(Value::Transform {
+                pos: [
+                    (pb[0] - pa[0]) * inv_dt,
+                    (pb[1] - pa[1]) * inv_dt,
+                    (pb[2] - pa[2]) * inv_dt,
+                ],
+                rot: [
+                    (rb_adj[0] - ra[0]) * inv_dt,
+                    (rb_adj[1] - ra[1]) * inv_dt,
+                    (rb_adj[2] - ra[2]) * inv_dt,
+                    (rb_adj[3] - ra[3]) * inv_dt,
+                ],
+                scale: [
+                    (sb[0] - sa[0]) * inv_dt,
+                    (sb[1] - sa[1]) * inv_dt,
+                    (sb[2] - sa[2]) * inv_dt,
+                ],
+            })
+        }
+        _ => None,
+    }
+}
+
+fn neutral_derivative(value: &Value) -> Option<Value> {
+    match value {
+        Value::Float(_) => Some(Value::Float(0.0)),
+        Value::Vec2(_) => Some(Value::Vec2([0.0, 0.0])),
+        Value::Vec3(_) => Some(Value::Vec3([0.0, 0.0, 0.0])),
+        Value::Vec4(_) => Some(Value::Vec4([0.0, 0.0, 0.0, 0.0])),
+        Value::Quat(_) => Some(Value::Quat([0.0, 0.0, 0.0, 0.0])),
+        Value::ColorRgba(_) => Some(Value::ColorRgba([0.0, 0.0, 0.0, 0.0])),
+        Value::Transform { .. } => Some(Value::Transform {
+            pos: [0.0, 0.0, 0.0],
+            rot: [0.0, 0.0, 0.0, 0.0],
+            scale: [0.0, 0.0, 0.0],
+        }),
+        _ => None,
+    }
+}
+
+pub fn sample_track_with_derivative(track: &Track, u: f32, duration_s: f32) -> SampledValue {
+    let value = sample_track(track, u);
+    let derivative = if duration_s <= 0.0 || track.points.len() <= 1 {
+        neutral_derivative(&value)
+    } else {
+        let delta = DERIV_EPSILON;
+        let mut u0 = (u - delta).clamp(0.0, 1.0);
+        let mut u1 = (u + delta).clamp(0.0, 1.0);
+        if (u1 - u0).abs() < 1e-6 {
+            // Fallback to forward difference near the boundary.
+            u0 = u;
+            u1 = (u + delta).clamp(0.0, 1.0);
+        }
+        let prev = sample_track(track, u0);
+        let next = sample_track(track, u1);
+        let dt = (u1 - u0).abs() * duration_s;
+        derivative_between(&prev, &next, dt).or_else(|| neutral_derivative(&value))
+    };
+
+    SampledValue { value, derivative }
 }

--- a/crates/animation/vizij-animation-core/tests/core_tests.rs
+++ b/crates/animation/vizij-animation-core/tests/core_tests.rs
@@ -923,6 +923,45 @@ fn multi_quat_instances_normalized() {
     }
 }
 
+#[test]
+fn update_with_derivatives_provides_derivative_values() {
+    let mut eng = Engine::new(Config::default());
+    let track = Track {
+        id: "t-deriv".into(),
+        name: "deriv".into(),
+        animatable_id: "node.scalar".into(),
+        points: vec![
+            Keypoint {
+                id: "k0".into(),
+                stamp: 0.0,
+                value: Value::Float(0.0),
+                transitions: None,
+            },
+            Keypoint {
+                id: "k1".into(),
+                stamp: 1.0,
+                value: Value::Float(1.0),
+                transitions: None,
+            },
+        ],
+        settings: None,
+    };
+    let anim = AnimationData {
+        id: None,
+        name: "clip".into(),
+        tracks: vec![track],
+        groups: serde_json::json!({}),
+        duration_ms: 1000,
+    };
+    let anim_id = eng.load_animation(anim);
+    let player_id = eng.create_player("player");
+    eng.add_instance(player_id, anim_id, InstanceCfg::default());
+
+    let outputs = eng.update_with_derivatives(0.016, Inputs::default());
+    assert!(!outputs.changes.is_empty());
+    assert!(outputs.changes[0].derivative.is_some());
+}
+
 /// it should bake empty and single-key tracks with expected sequences
 #[test]
 fn baking_empty_and_single_key_tracks() {

--- a/crates/animation/vizij-animation-wasm/README.md
+++ b/crates/animation/vizij-animation-wasm/README.md
@@ -63,14 +63,18 @@ The npm wrapper exports:
 
 * `async function init(input?: InitInput): Promise<void>` – Loads the WASM module. Optional input allows custom URLs or binary
   sources.
-* `function abi_version(): number` – Returns a numeric ABI guard (currently `1`).
+* `function abi_version(): number` – Returns a numeric ABI guard (currently `2`).
 * `class Engine` – Ergonomic wrapper around the low-level bindings:
   * `constructor(config?: Config)` – Optional capacity hints.
   * `loadAnimation(data, opts?)` – Accepts `StoredAnimation` or `AnimationData`. Returns `AnimId`.
   * `createPlayer(name: string)` – Returns `PlayerId`.
   * `addInstance(player, anim, cfg?)` – Adds an instance with optional `InstanceCfg` JSON.
   * `prebind(resolver)` – Resolve canonical target paths to application-defined keys.
-  * `update(dtSeconds, inputs?)` – Steps the simulation and returns `{ changes, events }`.
+  * `updateValues(dtSeconds, inputs?)` – Steps the simulation and returns `{ changes, events }`.
+  * `updateValuesWithDerivatives(dtSeconds, inputs?)` – Same as above but returns `ChangeWithDerivative` entries with optional
+    derivatives.
+  * `bakeAnimation(animId, config?)` – Samples baked values for a clip.
+  * `bakeAnimationWithDerivatives(animId, config?)` – Samples values plus baked derivatives.
 * Low-level class `VizijAnimation` mirrors the above methods with slightly more explicit JSON handling.
 
 ### StoredAnimation format
@@ -116,8 +120,9 @@ interpolation.
 
 * **Bindings and prebinding** – `prebind(resolver)` receives canonical target paths such as `"node/Transform.translation"` and
   should return the key you want in `change.key`. Return `null`/`undefined` to leave a path unresolved.
-* **Outputs** – `update` returns `{ changes: Change[], events: CoreEvent[] }`. `Change.value` is a tagged union (Scalar, Vec3,
-  Quat, Transform, Bool, Text, etc.). Events mirror the Rust core’s playback events.
+* **Outputs** – `updateValues` returns `{ changes: Change[], events: CoreEvent[] }`. `Change.value` is a tagged union (Scalar,
+  Vec3, Quat, Transform, Bool, Text, etc.). Events mirror the Rust core’s playback events. Use
+  `updateValuesWithDerivatives` when you need per-change derivative samples.
 * **Inputs** – Optional `Inputs` payload supports player commands (Play/Pause/Seek/SetLoopMode/etc.) and per-instance updates
   (weight, time scale, enable flag, etc.).
 * **ABI guard** – `abi_version()` helps consumers detect mismatches between the wasm binary and the JS wrapper. The npm package’s
@@ -152,7 +157,8 @@ const playerId = eng.createPlayer("demo");
 eng.addInstance(playerId, animId);
 eng.prebind((path) => path); // identity mapping
 
-const outputs = eng.update(1 / 60);
+const outputs = eng.updateValues(1 / 60);
+const outputsWithDerivatives = eng.updateValuesWithDerivatives(1 / 60);
 console.log(outputs.changes);
 ```
 
@@ -180,7 +186,7 @@ const animId = raw.load_stored_animation(JSON.stringify({
 }));
 const player = raw.create_player("demo");
 raw.add_instance(player, animId, null);
-const result = raw.update(0.016, null);
+const result = raw.update_values(0.016, null);
 console.log(result);
 ```
 

--- a/crates/animation/vizij-animation-wasm/tests/wasm_api_tests.rs
+++ b/crates/animation/vizij-animation-wasm/tests/wasm_api_tests.rs
@@ -43,8 +43,8 @@ fn test_animation_json() -> JsValue {
 wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
-fn abi_is_1() {
-    assert_eq!(abi_version(), 1);
+fn abi_is_2() {
+    assert_eq!(abi_version(), 2);
 }
 
 #[wasm_bindgen_test]
@@ -73,11 +73,25 @@ fn load_create_add_and_update() {
     eng.prebind(resolver);
 
     // Update with no inputs (undefined) at small dt
-    let outputs = eng.update(0.016, JsValue::UNDEFINED).unwrap();
+    let outputs = eng.update_values(0.016, JsValue::UNDEFINED).unwrap();
     // Outputs should be an object with { changes, events }
     let obj = js_sys::Object::from(outputs);
     let changes = js_sys::Reflect::get(&obj, &JsValue::from_str("changes")).unwrap();
     assert!(changes.is_object() || changes.is_array());
+}
+
+#[wasm_bindgen_test]
+fn bake_animation_with_derivatives_bundle() {
+    let mut eng = VizijAnimation::new(JsValue::NULL).unwrap();
+    let anim_id = eng.load_animation(test_animation_json()).unwrap();
+    let bundle = eng
+        .bake_animation_with_derivatives(anim_id, JsValue::UNDEFINED)
+        .unwrap();
+    let obj = js_sys::Object::from(bundle);
+    let values = js_sys::Reflect::get(&obj, &JsValue::from_str("values")).unwrap();
+    assert!(values.is_object());
+    let derivatives = js_sys::Reflect::get(&obj, &JsValue::from_str("derivatives")).unwrap();
+    assert!(derivatives.is_object());
 }
 
 // Negative/error-path tests
@@ -120,5 +134,16 @@ fn prebind_resolver_throwing_is_ignored() {
     eng.prebind(resolver);
 
     // Update should still succeed
-    let _outputs = eng.update(0.016, JsValue::UNDEFINED).unwrap();
+    let _outputs = eng.update_values(0.016, JsValue::UNDEFINED).unwrap();
+
+    // Update with derivatives
+    let outputs_with_derivatives = eng
+        .update_values_with_derivatives(0.016, JsValue::UNDEFINED)
+        .unwrap();
+    let obj = js_sys::Object::from(outputs_with_derivatives);
+    let changes = js_sys::Reflect::get(&obj, &JsValue::from_str("changes")).unwrap();
+    let first = js_sys::Array::from(&changes).get(0);
+    let derivative =
+        js_sys::Reflect::get(&first, &JsValue::from_str("derivative")).unwrap_or(JsValue::NULL);
+    assert!(derivative.is_null() || derivative.is_object());
 }

--- a/crates/animation/vizij-animation-wasm/tests/wasm_parity_tests.rs
+++ b/crates/animation/vizij-animation-wasm/tests/wasm_parity_tests.rs
@@ -72,5 +72,5 @@ fn wasm_parity_scalar_ramp() {
 /// it should validate the wasm ABI version gate for the parity suite
 #[wasm_bindgen_test]
 fn wasm_parity_abi_is_1() {
-    assert_eq!(abi_version(), 1);
+    assert_eq!(abi_version(), 2);
 }

--- a/npm/@vizij/animation-wasm/README.md
+++ b/npm/@vizij/animation-wasm/README.md
@@ -75,7 +75,8 @@ const playerId = eng.createPlayer("demo");
 eng.addInstance(playerId, animId);
 eng.prebind((path) => path); // optional resolver
 
-const outputs = eng.update(1 / 60);
+const outputs = eng.updateValues(1 / 60);
+const outputsWithDerivatives = eng.updateValuesWithDerivatives(1 / 60);
 console.log(outputs.changes);
 ```
 
@@ -89,7 +90,7 @@ const raw = new VizijAnimation();
 const animId = raw.load_stored_animation(JSON.stringify(storedAnimationJson));
 const player = raw.create_player("demo");
 raw.add_instance(player, animId, undefined);
-const outputs = JSON.parse(raw.update(0.016, undefined));
+const outputs = JSON.parse(raw.update_values(0.016, undefined));
 ```
 
 ## Key Details
@@ -98,14 +99,23 @@ const outputs = JSON.parse(raw.update(0.016, undefined));
   bezier control points via `transitions.in/out`, and support for scalar/vector/quat/color/bool/text values.
 * **Outputs** – `{ changes: Change[], events: CoreEvent[] }`. Each `Change` includes the resolved key and a tagged union value
   (Scalar, Vec3, Transform, etc.). Events mirror the Rust engine’s playback notifications (started, paused, keypoint reached,
-  warnings, etc.).
+  warnings, etc.). Use `updateValuesWithDerivatives` to receive `ChangeWithDerivative` entries that include optional rate-of-
+  change values.
 * **Inputs** – Optional `Inputs` payload supports player commands (play/pause/seek/loop) and per-instance updates (weights,
   timescale, enabled flag, start offset).
 * **Environment detection** – Browser builds load the `.wasm` via fetch relative to the module URL; Node builds read from disk.
   Bundlers may log that Node modules (`node:path`, `fs`) were externalized—this is expected.
 * **ABI guard** – `abi_version()` ensures the JS wrapper and WASM binary agree. The `Engine` wrapper throws if the numbers differ
   after `init()`.
-* **TypeScript support** – `src/types.d.ts` exports `Value`, `StoredAnimation`, `Inputs`, `Outputs`, and helper types.
+* **TypeScript support** – `src/types.d.ts` exports `Value`, `StoredAnimation`, `Inputs`, `Outputs`, derivative-aware variants,
+  and helper types.
+
+### Baking clips
+
+```ts
+const baked = eng.bakeAnimation(animId, { frame_rate: 60 });
+const bakedWithDerivatives = eng.bakeAnimationWithDerivatives(animId);
+```
 
 ## Examples
 

--- a/npm/@vizij/animation-wasm/src/types.d.ts
+++ b/npm/@vizij/animation-wasm/src/types.d.ts
@@ -42,6 +42,12 @@ export interface Config {
   features?: Features;
 }
 
+export interface BakingConfig {
+  frame_rate?: number;
+  start_time?: number;
+  end_time?: number | null;
+}
+
 /* -----------------------------------------------------------
    Inputs (vizij-animation-core/src/inputs.rs)
    serde default represents enums as { "Variant": { ... } }
@@ -105,6 +111,10 @@ export interface Change {
   value: Value;
 }
 
+export interface ChangeWithDerivative extends Change {
+  derivative?: Value | null;
+}
+
 export type CoreEvent =
   | { PlaybackStarted: { player: PlayerId; animation?: string | null } }
   | { PlaybackPaused: { player: PlayerId } }
@@ -133,6 +143,11 @@ export type CoreEvent =
 
 export interface Outputs {
   changes: Change[];
+  events: CoreEvent[];
+}
+
+export interface OutputsWithDerivatives {
+  changes: ChangeWithDerivative[];
   events: CoreEvent[];
 }
 
@@ -196,6 +211,41 @@ export interface StoredAnimation {
    Left intentionally broad; use when supplying core-format clips.
 ----------------------------------------------------------- */
 export type AnimationData = unknown;
+
+/* -----------------------------------------------------------
+   Baked animation data
+----------------------------------------------------------- */
+
+export interface BakedTrack {
+  target_path: string;
+  values: Value[];
+}
+
+export interface BakedDerivativeTrack {
+  target_path: string;
+  derivatives: (Value | null)[];
+}
+
+export interface BakedAnimationData {
+  anim: AnimId;
+  frame_rate: number;
+  start_time: number;
+  end_time: number;
+  tracks: BakedTrack[];
+}
+
+export interface BakedAnimationDerivatives {
+  anim: AnimId;
+  frame_rate: number;
+  start_time: number;
+  end_time: number;
+  tracks: BakedDerivativeTrack[];
+}
+
+export interface BakedAnimationBundle {
+  values: BakedAnimationData;
+  derivatives: BakedAnimationDerivatives;
+}
 
 /* -----------------------------------------------------------
    Engine inspection (authoritative state from core)


### PR DESCRIPTION
## Summary
- add derivative-aware update and baking APIs in vizij-animation-core and re-export helper structs
- update wasm bindings, npm wrapper, and documentation to surface derivative update/bake calls and bump the ABI guard
- switch bevy integration to the new value-only update entry point and add coverage for derivatives

## Testing
- cargo test -p vizij-animation-core
- cargo test -p vizij-animation-wasm

------
https://chatgpt.com/codex/tasks/task_e_68d63ac402948320b3398eaef628604c