### PR TITLE
feat: add derivative-aware animation update and baking APIs

### DIFF
--- a/crates/animation/bevy_vizij_animation/src/systems.rs
+++ b/crates/animation/bevy_vizij_animation/src/systems.rs
@@ -123,7 +123,7 @@ pub fn fixed_update_core_system(
     dt: Res<FixedDt>,
     mut pending: ResMut<PendingOutputs>,
 ) {
-    let out = eng.0.update(dt.0, Inputs::default());
+    let out = eng.0.update_values(dt.0, Inputs::default());
     // Replace pending changes with this tick's changes
     pending.changes.clear();
     pending.changes.extend(out.changes.iter().cloned());

--- a/crates/animation/vizij-animation-core/src/accumulate.rs
+++ b/crates/animation/vizij-animation-core/src/accumulate.rs
@@ -287,3 +287,37 @@ impl Accumulator {
         out
     }
 }
+
+/// Accumulator variant that tracks both values and optional derivatives.
+#[derive(Default)]
+pub struct AccumulatorWithDerivatives {
+    values: Accumulator,
+    derivatives: Accumulator,
+}
+
+impl AccumulatorWithDerivatives {
+    pub fn new() -> Self {
+        Self {
+            values: Accumulator::new(),
+            derivatives: Accumulator::new(),
+        }
+    }
+
+    pub fn add(&mut self, handle: &str, value: &Value, derivative: Option<&Value>, weight: f32) {
+        self.values.add(handle, value, weight);
+        if let Some(deriv) = derivative {
+            self.derivatives.add(handle, deriv, weight);
+        }
+    }
+
+    pub fn finalize(self) -> HashMap<String, (Value, Option<Value>)> {
+        let values = self.values.finalize();
+        let derivs = self.derivatives.finalize();
+        let mut out = HashMap::new();
+        for (key, value) in values.into_iter() {
+            let derivative = derivs.get(&key).cloned();
+            out.insert(key, (value, derivative));
+        }
+        out
+    }
+}

--- a/crates/animation/vizij-animation-core/src/lib.rs
+++ b/crates/animation/vizij-animation-core/src/lib.rs
@@ -22,7 +22,7 @@ pub mod stored_animation;
 pub mod value;
 
 // Re-exports for consumers (adapters)
-pub use baking::{BakedAnimationData, BakingConfig};
+pub use baking::{BakedAnimationData, BakedAnimationDerivatives, BakingConfig};
 pub use binding::{BindingSet, BindingTable, ChannelKey, TargetHandle, TargetResolver};
 pub use config::Config;
 pub use data::{AnimationData, Keypoint, Track, Transitions, Vec2};
@@ -30,7 +30,7 @@ pub use engine::{Engine, InstanceCfg, Player};
 pub use ids::{AnimId, InstId, PlayerId};
 pub use inputs::{Inputs, InstanceUpdate, LoopMode, PlayerCommand};
 pub use interp::InterpRegistry;
-pub use outputs::{Change, CoreEvent, Outputs};
+pub use outputs::{Change, ChangeWithDerivative, CoreEvent, Outputs, OutputsWithDerivatives};
 pub use sampling::sample_track;
 pub use scratch::Scratch;
 pub use stored_animation::parse_stored_animation_json;

--- a/crates/animation/vizij-animation-core/src/outputs.rs
+++ b/crates/animation/vizij-animation-core/src/outputs.rs
@@ -97,3 +97,40 @@ impl Outputs {
         self.changes.is_empty() && self.events.is_empty()
     }
 }
+
+/// A change that carries both the current value and its derivative when available.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ChangeWithDerivative {
+    pub player: PlayerId,
+    pub key: String,
+    pub value: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub derivative: Option<Value>,
+}
+
+/// Outputs returned by Engine::update_with_derivatives().
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct OutputsWithDerivatives {
+    #[serde(default)]
+    pub changes: Vec<ChangeWithDerivative>,
+    #[serde(default)]
+    pub events: Vec<CoreEvent>,
+}
+
+impl OutputsWithDerivatives {
+    #[inline]
+    pub fn clear(&mut self) {
+        self.changes.clear();
+        self.events.clear();
+    }
+
+    #[inline]
+    pub fn push_change(&mut self, change: ChangeWithDerivative) {
+        self.changes.push(change);
+    }
+
+    #[inline]
+    pub fn push_event(&mut self, event: CoreEvent) {
+        self.events.push(event);
+    }
+}

--- a/npm/@vizij/animation-wasm/src/index.ts
+++ b/npm/@vizij/animation-wasm/src/index.ts
@@ -8,6 +8,7 @@ import type {
   Inputs,
   InstanceUpdate,
   Outputs,
+  OutputsWithDerivatives,
   AnimationData,
   StoredAnimation,
   AnimId,
@@ -16,9 +17,13 @@ import type {
   Value,
   CoreEvent,
   Change,
+  ChangeWithDerivative,
   AnimationInfo,
   PlayerInfo,
   InstanceInfo,
+  BakedAnimationData,
+  BakedAnimationDerivatives,
+  BakedAnimationWithDerivatives,
 } from "./types";
 
 export type {
@@ -27,6 +32,7 @@ export type {
   Inputs,
   InstanceUpdate,
   Outputs,
+  OutputsWithDerivatives,
   AnimationData,
   StoredAnimation,
   AnimId,
@@ -35,9 +41,13 @@ export type {
   Value,
   CoreEvent,
   Change,
+  ChangeWithDerivative,
   AnimationInfo,
   PlayerInfo,
   InstanceInfo,
+  BakedAnimationData,
+  BakedAnimationDerivatives,
+  BakedAnimationWithDerivatives,
 };
 
 export { VizijAnimation, abi_version };
@@ -181,7 +191,29 @@ export class Engine {
 
   /** Step the simulation by dt (seconds) with optional Inputs; returns Outputs */
   update(dt: number, inputs?: Inputs): Outputs {
-    return (this.inner.update(dt, (inputs ?? undefined) as any) as unknown) as Outputs;
+    return this.updateValues(dt, inputs);
+  }
+
+  /** Step the simulation by dt (seconds) with optional Inputs; returns Outputs */
+  updateValues(dt: number, inputs?: Inputs): Outputs {
+    const inner: any = this.inner;
+    if (typeof inner.update_values !== "function") {
+      throw new Error(
+        "Current WASM build does not expose update_values; rebuild vizij-animation-wasm with updated bindings."
+      );
+    }
+    return inner.update_values(dt, (inputs ?? undefined) as any) as Outputs;
+  }
+
+  /** Step the simulation returning values plus derivatives */
+  updateWithDerivatives(dt: number, inputs?: Inputs): OutputsWithDerivatives {
+    const inner: any = this.inner;
+    if (typeof inner.update_with_derivatives !== "function") {
+      throw new Error(
+        "Current WASM build does not expose update_with_derivatives; rebuild vizij-animation-wasm with updated bindings."
+      );
+    }
+    return inner.update_with_derivatives(dt, (inputs ?? undefined) as any) as OutputsWithDerivatives;
   }
 
   /** Remove a player and all its instances */
@@ -245,6 +277,28 @@ export class Engine {
       throw new Error("list_player_keys not available; rebuild vizij-animation-wasm");
     }
     return (inner.list_player_keys(player as number) as unknown) as string[];
+  }
+
+  /** Bake animation values using the core engine */
+  bakeAnimation(anim: AnimId, cfg?: unknown): BakedAnimationData {
+    const inner: any = this.inner;
+    if (typeof inner.bake_animation !== "function") {
+      throw new Error(
+        "Current WASM build does not expose bake_animation; rebuild vizij-animation-wasm with updated bindings."
+      );
+    }
+    return inner.bake_animation(anim as number, (cfg ?? undefined) as any) as BakedAnimationData;
+  }
+
+  /** Bake animation values and derivatives */
+  bakeAnimationWithDerivatives(anim: AnimId, cfg?: unknown): BakedAnimationWithDerivatives {
+    const inner: any = this.inner;
+    if (typeof inner.bake_animation_with_derivatives !== "function") {
+      throw new Error(
+        "Current WASM build does not expose bake_animation_with_derivatives; rebuild vizij-animation-wasm with updated bindings."
+      );
+    }
+    return inner.bake_animation_with_derivatives(anim as number, (cfg ?? undefined) as any) as BakedAnimationWithDerivatives;
   }
 }
 

--- a/npm/@vizij/animation-wasm/src/types.d.ts
+++ b/npm/@vizij/animation-wasm/src/types.d.ts
@@ -105,6 +105,10 @@ export interface Change {
   value: Value;
 }
 
+export interface ChangeWithDerivative extends Change {
+  derivative?: Value | null;
+}
+
 export type CoreEvent =
   | { PlaybackStarted: { player: PlayerId; animation?: string | null } }
   | { PlaybackPaused: { player: PlayerId } }
@@ -133,6 +137,11 @@ export type CoreEvent =
 
 export interface Outputs {
   changes: Change[];
+  events: CoreEvent[];
+}
+
+export interface OutputsWithDerivatives {
+  changes: ChangeWithDerivative[];
   events: CoreEvent[];
 }
 
@@ -196,6 +205,41 @@ export interface StoredAnimation {
    Left intentionally broad; use when supplying core-format clips.
 ----------------------------------------------------------- */
 export type AnimationData = unknown;
+
+/* -----------------------------------------------------------
+   Baked animation output structures
+----------------------------------------------------------- */
+
+export interface BakedTrack {
+  target_path: string;
+  values: Value[];
+}
+
+export interface BakedAnimationData {
+  anim: AnimId;
+  frame_rate: number;
+  start_time: number;
+  end_time: number;
+  tracks: BakedTrack[];
+}
+
+export interface BakedDerivativeTrack {
+  target_path: string;
+  derivatives: Array<Value | null>;
+}
+
+export interface BakedAnimationDerivatives {
+  anim: AnimId;
+  frame_rate: number;
+  start_time: number;
+  end_time: number;
+  tracks: BakedDerivativeTrack[];
+}
+
+export interface BakedAnimationWithDerivatives {
+  values: BakedAnimationData;
+  derivatives: BakedAnimationDerivatives;
+}
 
 /* -----------------------------------------------------------
    Engine inspection (authoritative state from core)


### PR DESCRIPTION
## Summary
- add accumulator support for derivatives and expose Engine::update_with_derivatives alongside baking helpers that return derivative tracks
- extend wasm bindings and TypeScript wrapper to surface value-only and derivative update paths plus baked derivative data
- update Bevy adapter to call the value-only update helper

## Testing
- cargo test --workspace

------
https://chatgpt.com/codex/tasks/task_e_68d63ac402948320b3398eaef628604c