### PR TITLE
Add derivative outputs to animation APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_vizij_animation"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bevy",
  "bevy_vizij_api",
@@ -3864,7 +3864,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vizij-animation-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "vizij-animation-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/crates/animation/bevy_vizij_animation/Cargo.toml
+++ b/crates/animation/bevy_vizij_animation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "bevy_vizij_animation"
-version = "0.2.0"
+version = "0.3.0"
 edition     = "2021"
 license     = "MIT OR Apache-2.0"
 description = "Bevy plugin that wraps the Vizij animation core."
@@ -12,7 +12,7 @@ keywords    = ["vizij", "animation", "bevy", "plugin"]
 categories  = ["game-engines", "rendering", "wasm"]
 
 [dependencies]
-vizij-animation-core = { version = "0.2.0", path = "../vizij-animation-core" }
+vizij-animation-core = { version = "0.3.0", path = "../vizij-animation-core" }
 bevy                = { workspace = true }
 vizij-api-core      = { path = "../../api/vizij-api-core" }
 bevy_vizij_api      = { path = "../../api/bevy_vizij_api" }

--- a/crates/animation/bevy_vizij_animation/src/systems.rs
+++ b/crates/animation/bevy_vizij_animation/src/systems.rs
@@ -123,7 +123,7 @@ pub fn fixed_update_core_system(
     dt: Res<FixedDt>,
     mut pending: ResMut<PendingOutputs>,
 ) {
-    let out = eng.0.update(dt.0, Inputs::default());
+    let out = eng.0.update_values(dt.0, Inputs::default());
     // Replace pending changes with this tick's changes
     pending.changes.clear();
     pending.changes.extend(out.changes.iter().cloned());

--- a/crates/animation/bevy_vizij_animation/tests/plugin_smoke.rs
+++ b/crates/animation/bevy_vizij_animation/tests/plugin_smoke.rs
@@ -26,7 +26,7 @@ fn fixedupdate_ticks_engine() {
     fn fixed_sys(mut eng: ResMut<VizijEngine>, mut ticks: ResMut<Ticks>) {
         let _ = eng
             .0
-            .update(1.0 / 60.0, vizij_animation_core::inputs::Inputs::default());
+            .update_values(1.0 / 60.0, vizij_animation_core::inputs::Inputs::default());
         ticks.0 += 1;
     }
 

--- a/crates/animation/vizij-animation-core/Cargo.toml
+++ b/crates/animation/vizij-animation-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "vizij-animation-core"
-version = "0.2.0"          # bump when releasing a new version
+version = "0.3.0"          # bump when releasing a new version
 edition     = "2021"
 license     = "MIT OR Apache-2.0"
 description = "Core animation logic for Vizij (engine‑agnostic)."

--- a/crates/animation/vizij-animation-core/src/derivative.rs
+++ b/crates/animation/vizij-animation-core/src/derivative.rs
@@ -1,0 +1,81 @@
+#![allow(dead_code)]
+//! Helpers for computing time derivatives of animation [`Value`]s.
+
+use vizij_api_core::Value;
+
+fn diff_vec(dst: &mut [f32], a: &[f32], b: &[f32], inv_dt: f32) {
+    for (out, (cur, prev)) in dst.iter_mut().zip(a.iter().zip(b.iter())) {
+        *out = (cur - prev) * inv_dt;
+    }
+}
+
+/// Compute the time derivative `(current - previous) / dt` for a [`Value`].
+///
+/// Returns `None` for value kinds where derivatives are not well defined
+/// (booleans, text, enums, complex aggregates, etc.) or when `dt <= 0`.
+pub(crate) fn derivative_value(current: &Value, previous: &Value, dt: f32) -> Option<Value> {
+    if dt <= 0.0 {
+        return None;
+    }
+    let inv_dt = dt.recip();
+    match (current, previous) {
+        (Value::Float(c), Value::Float(p)) => Some(Value::Float((c - p) * inv_dt)),
+        (Value::Vec2(c), Value::Vec2(p)) => {
+            let mut out = [0.0; 2];
+            diff_vec(&mut out, c, p, inv_dt);
+            Some(Value::Vec2(out))
+        }
+        (Value::Vec3(c), Value::Vec3(p)) => {
+            let mut out = [0.0; 3];
+            diff_vec(&mut out, c, p, inv_dt);
+            Some(Value::Vec3(out))
+        }
+        (Value::Vec4(c), Value::Vec4(p)) => {
+            let mut out = [0.0; 4];
+            diff_vec(&mut out, c, p, inv_dt);
+            Some(Value::Vec4(out))
+        }
+        (Value::Quat(c), Value::Quat(p)) => {
+            let mut out = [0.0; 4];
+            diff_vec(&mut out, c, p, inv_dt);
+            Some(Value::Quat(out))
+        }
+        (Value::ColorRgba(c), Value::ColorRgba(p)) => {
+            let mut out = [0.0; 4];
+            diff_vec(&mut out, c, p, inv_dt);
+            Some(Value::ColorRgba(out))
+        }
+        (
+            Value::Transform {
+                pos: c_pos,
+                rot: c_rot,
+                scale: c_scale,
+            },
+            Value::Transform {
+                pos: p_pos,
+                rot: p_rot,
+                scale: p_scale,
+            },
+        ) => {
+            let mut d_pos = [0.0; 3];
+            diff_vec(&mut d_pos, c_pos, p_pos, inv_dt);
+            let mut d_rot = [0.0; 4];
+            diff_vec(&mut d_rot, c_rot, p_rot, inv_dt);
+            let mut d_scale = [0.0; 3];
+            diff_vec(&mut d_scale, c_scale, p_scale, inv_dt);
+            Some(Value::Transform {
+                pos: d_pos,
+                rot: d_rot,
+                scale: d_scale,
+            })
+        }
+        (Value::Vector(c), Value::Vector(p)) if c.len() == p.len() => {
+            let mut out = Vec::with_capacity(c.len());
+            for (cur, prev) in c.iter().zip(p.iter()) {
+                out.push((cur - prev) * inv_dt);
+            }
+            Some(Value::Vector(out))
+        }
+        _ => None,
+    }
+}

--- a/crates/animation/vizij-animation-core/src/lib.rs
+++ b/crates/animation/vizij-animation-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod baking;
 pub mod binding;
 pub mod config;
 pub mod data;
+mod derivative;
 pub mod engine;
 pub mod ids;
 pub mod inputs;
@@ -22,7 +23,10 @@ pub mod stored_animation;
 pub mod value;
 
 // Re-exports for consumers (adapters)
-pub use baking::{BakedAnimationData, BakingConfig};
+pub use baking::{
+    bake_animation_with_derivatives, BakedAnimationData, BakedDerivativeAnimation,
+    BakedDerivativeTrack, BakingConfig,
+};
 pub use binding::{BindingSet, BindingTable, ChannelKey, TargetHandle, TargetResolver};
 pub use config::Config;
 pub use data::{AnimationData, Keypoint, Track, Transitions, Vec2};
@@ -30,7 +34,7 @@ pub use engine::{Engine, InstanceCfg, Player};
 pub use ids::{AnimId, InstId, PlayerId};
 pub use inputs::{Inputs, InstanceUpdate, LoopMode, PlayerCommand};
 pub use interp::InterpRegistry;
-pub use outputs::{Change, CoreEvent, Outputs};
+pub use outputs::{Change, CoreEvent, DerivativeChange, Outputs, OutputsWithDerivatives};
 pub use sampling::sample_track;
 pub use scratch::Scratch;
 pub use stored_animation::parse_stored_animation_json;

--- a/crates/animation/vizij-animation-core/src/outputs.rs
+++ b/crates/animation/vizij-animation-core/src/outputs.rs
@@ -18,6 +18,14 @@ pub struct Change {
     pub value: Value,
 }
 
+/// Derivative for a changed target value.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DerivativeChange {
+    pub player: PlayerId,
+    pub key: String,
+    pub value: Value,
+}
+
 /// Discrete semantic signals emitted during stepping.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -66,11 +74,23 @@ pub enum CoreEvent {
     },
 }
 
-/// Outputs returned by Engine::update().
+/// Outputs returned by [`Engine::update_values`](crate::engine::Engine::update_values).
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Outputs {
     #[serde(default)]
     pub changes: Vec<Change>,
+    #[serde(default)]
+    pub events: Vec<CoreEvent>,
+}
+
+/// Outputs plus per-target derivatives returned by
+/// [`Engine::update_values_with_derivatives`](crate::engine::Engine::update_values_with_derivatives).
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct OutputsWithDerivatives {
+    #[serde(default)]
+    pub changes: Vec<Change>,
+    #[serde(default)]
+    pub derivatives: Vec<DerivativeChange>,
     #[serde(default)]
     pub events: Vec<CoreEvent>,
 }

--- a/crates/animation/vizij-animation-core/tests/bool_text_step.rs
+++ b/crates/animation/vizij-animation-core/tests/bool_text_step.rs
@@ -91,7 +91,7 @@ fn step_sampling_for_bool_and_text_tracks() {
     let _i = eng.add_instance(p, a, InstanceCfg::default());
 
     // Initial tick at 0.0
-    let out0 = eng.update(0.0, Inputs::default());
+    let out0 = eng.update_values(0.0, Inputs::default());
     let flag0 = out0
         .changes
         .iter()
@@ -116,8 +116,8 @@ fn step_sampling_for_bool_and_text_tracks() {
     }
 
     // Advance by 0.6s (engine maps seconds via duration_ms=1.0s) -> expect B/true
-    let _ = eng.update(0.6, Inputs::default());
-    let out1 = eng.update(0.0, Inputs::default());
+    let _ = eng.update_values(0.6, Inputs::default());
+    let out1 = eng.update_values(0.0, Inputs::default());
     let flag1 = out1
         .changes
         .iter()

--- a/crates/animation/vizij-animation-core/tests/multi_players.rs
+++ b/crates/animation/vizij-animation-core/tests/multi_players.rs
@@ -93,7 +93,7 @@ fn durations_are_independent_per_player() {
     assert!((d2 - 6.0).abs() < 1e-6, "P2 total_duration should be 6.0");
 
     // Apply window to P2 that is smaller than span; duration should clamp to window
-    let _ = eng.update(
+    let _ = eng.update_values(
         0.0,
         vizij_animation_core::Inputs {
             player_cmds: vec![vizij_animation_core::PlayerCommand::SetWindow {

--- a/crates/animation/vizij-animation-core/tests/parity_outputs.rs
+++ b/crates/animation/vizij-animation-core/tests/parity_outputs.rs
@@ -42,10 +42,10 @@ fn parity_scalar_ramp_values() {
         player: pid,
         mode: LoopMode::Once,
     });
-    let _ = eng.update(0.0, init);
+    let _ = eng.update_values(0.0, init);
 
     // Initial sample at t=0.0
-    let out0 = eng.update(0.0, Inputs::default());
+    let out0 = eng.update_values(0.0, Inputs::default());
     let v0 = out0
         .changes
         .iter()
@@ -62,7 +62,7 @@ fn parity_scalar_ramp_values() {
     // Step dt=0.1 for 10 ticks, expect values ~ i/10
     let mut t = 0.0f32;
     for i in 1..=10 {
-        let out = eng.update(0.1, Inputs::default());
+        let out = eng.update_values(0.1, Inputs::default());
         t += 0.1;
         let v = out
             .changes
@@ -98,7 +98,7 @@ fn parity_const_vec3_values() {
     let _iid = eng.add_instance(pid, aid, InstanceCfg::default());
 
     // Sample any tick; expect translation [1,2,3]
-    let out = eng.update(0.016, Inputs::default());
+    let out = eng.update_values(0.016, Inputs::default());
     let v = out
         .changes
         .iter()
@@ -140,7 +140,7 @@ fn parity_window_and_seek() {
         player: pid,
         time: 1.0,
     });
-    let out = eng.update(0.0, inputs);
+    let out = eng.update_values(0.0, inputs);
     let v = out
         .changes
         .iter()
@@ -164,7 +164,7 @@ fn parity_window_and_seek() {
         player: pid,
         time: -0.25,
     });
-    let out2 = eng.update(0.0, inputs2);
+    let out2 = eng.update_values(0.0, inputs2);
     let v2 = out2
         .changes
         .iter()
@@ -197,8 +197,8 @@ fn parity_determinism_same_sequence() {
     // Same dt sequence
     let seq = [0.016, 0.016, 0.032, 0.0, 0.1, 0.25];
     for dt in seq {
-        let o1 = e1.update(dt, Inputs::default());
-        let o2 = e2.update(dt, Inputs::default());
+        let o1 = e1.update_values(dt, Inputs::default());
+        let o2 = e2.update_values(dt, Inputs::default());
         let j1 = serde_json::to_string(o1).unwrap();
         let j2 = serde_json::to_string(o2).unwrap();
         assert_eq!(j1, j2, "Outputs JSON must match for dt={dt}");
@@ -292,7 +292,7 @@ fn parity_quat_layered_normalized() {
         },
     );
 
-    let out = eng.update(0.0, Inputs::default());
+    let out = eng.update_values(0.0, Inputs::default());
     let v = out
         .changes
         .iter()

--- a/crates/animation/vizij-animation-core/tests/time_math.rs
+++ b/crates/animation/vizij-animation-core/tests/time_math.rs
@@ -83,7 +83,7 @@ fn total_duration_multiple_instances_basic() {
         "initial total duration should be 2.0 (max span)"
     );
     // Apply a window larger than spans: [0, 10] -> total_duration should remain 2.0 (min(10,2))
-    eng.update(
+    eng.update_values(
         0.0,
         vizij_animation_core::Inputs {
             player_cmds: vec![vizij_animation_core::PlayerCommand::SetWindow {
@@ -98,8 +98,8 @@ fn total_duration_multiple_instances_basic() {
     // We can't read total_duration directly; instead simulate advance and ensure
     // local time maps without panic.
     let mut eng_local = eng;
-    let _out = eng_local.update(1.99, vizij_animation_core::Inputs::default());
-    let _out2 = eng_local.update(0.02, vizij_animation_core::Inputs::default());
+    let _out = eng_local.update_values(1.99, vizij_animation_core::Inputs::default());
+    let _out2 = eng_local.update_values(0.02, vizij_animation_core::Inputs::default());
 
     // Verify duration accessor still returns ~2.0 after window set
     let dur1 = eng_local.player_total_duration(p).expect("player duration");
@@ -141,7 +141,7 @@ fn total_duration_with_offsets_and_negative_scale() {
     );
 
     // Apply small window to force total_duration to be min(window_len, max_span)
-    eng.update(
+    eng.update_values(
         0.0,
         vizij_animation_core::Inputs {
             player_cmds: vec![vizij_animation_core::PlayerCommand::SetWindow {
@@ -160,7 +160,7 @@ fn total_duration_with_offsets_and_negative_scale() {
         "total duration should be 0.4 after window"
     );
     // Flip to Once mode
-    eng.update(
+    eng.update_values(
         0.0,
         vizij_animation_core::Inputs {
             player_cmds: vec![vizij_animation_core::PlayerCommand::SetLoopMode {
@@ -173,7 +173,7 @@ fn total_duration_with_offsets_and_negative_scale() {
 
     // Run for 1.0s without panicking; local mapping should handle reverse/forward correctly
     let mut eng2 = eng;
-    let _ = eng2.update(1.0, vizij_animation_core::Inputs::default());
+    let _ = eng2.update_values(1.0, vizij_animation_core::Inputs::default());
 }
 
 #[test]

--- a/crates/animation/vizij-animation-wasm/Cargo.toml
+++ b/crates/animation/vizij-animation-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "vizij-animation-wasm"
-version = "0.2.0"
+version = "0.3.0"
 edition     = "2021"
 license     = "MIT OR Apache-2.0"
 description = "wasm‑bindgen interface for Vizij animation."
@@ -21,7 +21,7 @@ serde                = { workspace = true }
 serde-wasm-bindgen   = "0.6"
 serde_json           = "1"
 console_error_panic_hook = "0.1"
-vizij-animation-core = { path = "../vizij-animation-core", version = "0.2.0" }
+vizij-animation-core = { path = "../vizij-animation-core", version = "0.3.0" }
 vizij-api-core       = { path = "../../api/vizij-api-core" }
 vizij-api-wasm       = { path = "../../api/vizij-api-wasm" }
 

--- a/crates/animation/vizij-animation-wasm/src/lib.rs
+++ b/crates/animation/vizij-animation-wasm/src/lib.rs
@@ -4,8 +4,8 @@ use wasm_bindgen::prelude::*;
 
 use serde_json::{json, to_value, Map};
 use vizij_animation_core::{
-    parse_stored_animation_json, AnimId, AnimationData, Config, Engine, Inputs, InstId,
-    InstanceCfg, Outputs, PlayerId, TargetResolver,
+    baking::BakingConfig, parse_stored_animation_json, AnimId, AnimationData, Config, Engine,
+    Inputs, InstId, InstanceCfg, Outputs, OutputsWithDerivatives, PlayerId, TargetResolver,
 };
 
 #[wasm_bindgen]
@@ -134,15 +134,83 @@ impl VizijAnimation {
     }
 
     /// Step the simulation by dt (seconds) with inputs JSON. Returns Outputs JSON.
-    #[wasm_bindgen]
-    pub fn update(&mut self, dt: f32, inputs_json: JsValue) -> Result<JsValue, JsError> {
+    #[wasm_bindgen(js_name = update_values)]
+    pub fn update_values(&mut self, dt: f32, inputs_json: JsValue) -> Result<JsValue, JsError> {
         let inputs: Inputs = if jsvalue_is_undefined_or_null(&inputs_json) {
             Inputs::default()
         } else {
             swb::from_value(inputs_json).map_err(|e| JsError::new(&format!("inputs error: {e}")))?
         };
-        let out: &Outputs = self.core.update(dt, inputs);
+        let out: &Outputs = self.core.update_values(dt, inputs);
         swb::to_value(out).map_err(|e| JsError::new(&format!("outputs error: {e}")))
+    }
+
+    /// Step the simulation and also return per-target derivatives.
+    #[wasm_bindgen(js_name = update_values_with_derivatives)]
+    pub fn update_values_with_derivatives(
+        &mut self,
+        dt: f32,
+        inputs_json: JsValue,
+    ) -> Result<JsValue, JsError> {
+        let inputs: Inputs = if jsvalue_is_undefined_or_null(&inputs_json) {
+            Inputs::default()
+        } else {
+            swb::from_value(inputs_json).map_err(|e| JsError::new(&format!("inputs error: {e}")))?
+        };
+        let out: OutputsWithDerivatives = self.core.update_values_with_derivatives(dt, inputs);
+        swb::to_value(&out).map_err(|e| JsError::new(&format!("outputs error: {e}")))
+    }
+
+    /// Backwards compatible alias for `update_values`.
+    #[wasm_bindgen(js_name = update)]
+    pub fn update(&mut self, dt: f32, inputs_json: JsValue) -> Result<JsValue, JsError> {
+        self.update_values(dt, inputs_json)
+    }
+
+    /// Bake animation samples for a loaded clip.
+    #[wasm_bindgen(js_name = bake_animation)]
+    pub fn bake_animation(&self, anim_id: u32, cfg_json: JsValue) -> Result<JsValue, JsError> {
+        let cfg: BakingConfig = if jsvalue_is_undefined_or_null(&cfg_json) {
+            BakingConfig::default()
+        } else {
+            swb::from_value(cfg_json)
+                .map_err(|e| JsError::new(&format!("baking config error: {e}")))?
+        };
+        let anim = AnimId(anim_id);
+        match self.core.bake_animation(anim, &cfg) {
+            Some(baked) => swb::to_value(&baked)
+                .map_err(|e| JsError::new(&format!("serialize baked animation error: {e}"))),
+            None => Err(JsError::new("bake_animation: animation id not found")),
+        }
+    }
+
+    /// Bake animation samples along with derivatives for a loaded clip.
+    #[wasm_bindgen(js_name = bake_animation_with_derivatives)]
+    pub fn bake_animation_with_derivatives(
+        &self,
+        anim_id: u32,
+        cfg_json: JsValue,
+    ) -> Result<JsValue, JsError> {
+        let cfg: BakingConfig = if jsvalue_is_undefined_or_null(&cfg_json) {
+            BakingConfig::default()
+        } else {
+            swb::from_value(cfg_json)
+                .map_err(|e| JsError::new(&format!("baking config error: {e}")))?
+        };
+        let anim = AnimId(anim_id);
+        match self.core.bake_animation_with_derivatives(anim, &cfg) {
+            Some((values, derivatives)) => {
+                let payload = json!({
+                    "animation": values,
+                    "derivatives": derivatives,
+                });
+                swb::to_value(&payload)
+                    .map_err(|e| JsError::new(&format!("serialize baked derivatives error: {e}")))
+            }
+            None => Err(JsError::new(
+                "bake_animation_with_derivatives: animation id not found",
+            )),
+        }
     }
 
     /// Step the simulation and return a nodes+writes JSON object compatible with

--- a/crates/animation/vizij-animation-wasm/tests/wasm_bool_text.rs
+++ b/crates/animation/vizij-animation-wasm/tests/wasm_bool_text.rs
@@ -95,7 +95,7 @@ fn wasm_bool_text_outputs_and_step() {
         .unwrap();
 
     // Initial tick at 0.0
-    let out0 = eng.update(0.0, JsValue::UNDEFINED).unwrap();
+    let out0 = eng.update_values(0.0, JsValue::UNDEFINED).unwrap();
     let v_flag0 = get_change_value(&out0, "node.flag").expect("node.flag");
     let v_label0 = get_change_value(&out0, "node.label").expect("node.label");
 
@@ -123,8 +123,8 @@ fn wasm_bool_text_outputs_and_step() {
     assert_eq!(data_label0, "A".to_string());
 
     // Advance to 0.6s (u~=0.6) -> expect true / "B" due to step (hold left)
-    let _ = eng.update(0.6, JsValue::UNDEFINED).unwrap();
-    let out1 = eng.update(0.0, JsValue::UNDEFINED).unwrap();
+    let _ = eng.update_values(0.6, JsValue::UNDEFINED).unwrap();
+    let out1 = eng.update_values(0.0, JsValue::UNDEFINED).unwrap();
     let v_flag1 = get_change_value(&out1, "node.flag").expect("node.flag");
     let v_label1 = get_change_value(&out1, "node.label").expect("node.label");
 

--- a/crates/animation/vizij-animation-wasm/tests/wasm_parity_tests.rs
+++ b/crates/animation/vizij-animation-wasm/tests/wasm_parity_tests.rs
@@ -49,14 +49,14 @@ fn wasm_parity_scalar_ramp() {
         .unwrap();
 
     // Initial tick at dt=0.0 -> value ~ 0.0
-    let out0 = eng.update(0.0, JsValue::UNDEFINED).unwrap();
+    let out0 = eng.update_values(0.0, JsValue::UNDEFINED).unwrap();
     let s0 = get_scalar_by_key(out0, "node.t").expect("node.t");
     approx(s0, 0.0, 1e-6);
 
     // Step 9 ticks of 0.1 -> expect ~ i/10 at each step (avoid wrap at exactly 1.0 in Loop mode)
     let mut t = 0.0f64;
     for i in 1..=9 {
-        let out = eng.update(0.1, JsValue::UNDEFINED).unwrap();
+        let out = eng.update_values(0.1, JsValue::UNDEFINED).unwrap();
         t += 0.1;
         let s = get_scalar_by_key(out, "node.t").expect("node.t");
         approx(s, t, 1e-6);

--- a/crates/animation/vizij-animation-wasm/tests/wasm_stored_animation.rs
+++ b/crates/animation/vizij-animation-wasm/tests/wasm_stored_animation.rs
@@ -49,7 +49,7 @@ fn wasm_loads_new_format_and_samples_initial() {
         .unwrap();
 
     // Initial tick at dt=0.0 -> should emit starting values
-    let out0 = eng.update(0.0, JsValue::UNDEFINED).unwrap();
+    let out0 = eng.update_values(0.0, JsValue::UNDEFINED).unwrap();
 
     // Track "cube-position-x" starts at -2 (see fixture)
     let s0 = get_scalar_by_key(out0, "cube-position-x").expect("cube-position-x");

--- a/npm/@vizij/animation-wasm/package.json
+++ b/npm/@vizij/animation-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizij/animation-wasm",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "WASM bindings for Vizij animation core.",
   "license": "MIT",
   "repository": {

--- a/npm/@vizij/animation-wasm/src/types.d.ts
+++ b/npm/@vizij/animation-wasm/src/types.d.ts
@@ -105,6 +105,12 @@ export interface Change {
   value: Value;
 }
 
+export interface DerivativeChange {
+  player: PlayerId;
+  key: string;
+  value: Value;
+}
+
 export type CoreEvent =
   | { PlaybackStarted: { player: PlayerId; animation?: string | null } }
   | { PlaybackPaused: { player: PlayerId } }
@@ -134,6 +140,48 @@ export type CoreEvent =
 export interface Outputs {
   changes: Change[];
   events: CoreEvent[];
+}
+
+export interface OutputsWithDerivatives {
+  changes: Change[];
+  derivatives: DerivativeChange[];
+  events: CoreEvent[];
+}
+
+/* -----------------------------------------------------------
+   Baked animation data
+----------------------------------------------------------- */
+
+export interface BakedTrack {
+  target_path: string;
+  values: Value[];
+}
+
+export interface BakedAnimationData {
+  anim: AnimId;
+  frame_rate: number;
+  start_time: number;
+  end_time: number;
+  tracks: BakedTrack[];
+}
+
+export interface BakingConfig {
+  frame_rate?: number;
+  start_time?: number;
+  end_time?: number | null;
+}
+
+export interface BakedDerivativeTrack {
+  target_path: string;
+  derivatives: Array<Value | null>;
+}
+
+export interface BakedDerivativeAnimation {
+  anim: AnimId;
+  frame_rate: number;
+  start_time: number;
+  end_time: number;
+  tracks: BakedDerivativeTrack[];
 }
 
 /* -----------------------------------------------------------


### PR DESCRIPTION
## Summary
- add derivative calculation helper in the core engine, expose update methods that return derivatives, and extend baking support
- plumb the new APIs through the wasm bindings and npm wrapper, including types for derivative outputs and baked data
- refresh tests to cover derivative updates and baking behaviour across Rust and wasm layers

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --workspace

------
https://chatgpt.com/codex/tasks/task_e_68d63ac402948320b3398eaef628604c