### PR TITLE
Expose derivative-aware animation update and baking APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ let anim = engine.load_animation(stored);
 let player = engine.create_player("demo");
 engine.add_instance(player, anim, InstanceCfg::default());
 
-let outputs = engine.update(1.0 / 60.0, Default::default());
+let outputs = engine.update_values(1.0 / 60.0, Default::default());
 println!("changes: {:?}", outputs.changes);
 ```
 
@@ -199,7 +199,7 @@ const anim = eng.loadAnimation({
 }, { format: "stored" });
 const player = eng.createPlayer("demo");
 eng.addInstance(player, anim);
-console.log(eng.update(1 / 60).changes);
+console.log(eng.updateValues(1 / 60).changes);
 ```
 
 ### Sample: Evaluating a node graph core-side

--- a/crates/animation/README.md
+++ b/crates/animation/README.md
@@ -85,7 +85,7 @@ Inside this repository:
 ### Core crate
 
 * Create an `Engine`, load animation data (either `AnimationData` or `StoredAnimation` JSON), create players/instances, and call
-  `update(dt, inputs)` each tick.
+  `update_values(dt, inputs)` (or `update_values_and_derivatives(dt, inputs)`) each tick.
 * Outputs contain `changes` (resolved target key/value pairs) and `events` (playback notifications, keypoint hits, warnings).
 
 ### Bevy plugin
@@ -99,7 +99,8 @@ Inside this repository:
 
 * `await init()` once, then construct `VizijAnimation` or the higher-level `Engine` wrapper from the npm package.
 * Use the same workflow as the Rust engine: load animations, create players/instances, optionally call `prebind` with a resolver
-  callback, and `update(dt)` each frame. Outputs are plain JSON structures suitable for React state or other consumers.
+  callback, and `updateValues(dt)` or `updateValuesAndDerivatives(dt)` each frame. Outputs are plain JSON structures suitable for
+  React state or other consumers.
 
 ## Key Details
 
@@ -129,7 +130,7 @@ let anim = engine.load_animation(stored);
 let player = engine.create_player("demo");
 engine.add_instance(player, anim, InstanceCfg::default());
 
-let outputs = engine.update(1.0 / 60.0, Default::default());
+let outputs = engine.update_values(1.0 / 60.0, Default::default());
 for change in outputs.changes {
     println!("{} => {:?}", change.key, change.value);
 }
@@ -193,7 +194,7 @@ const playerId = eng.createPlayer("demo");
 eng.addInstance(playerId, animId);
 eng.prebind((path) => path); // identity binding
 
-const outputs = eng.update(1 / 60);
+const outputs = eng.updateValues(1 / 60);
 console.log(outputs.changes);
 ```
 

--- a/crates/animation/bevy_vizij_animation/src/systems.rs
+++ b/crates/animation/bevy_vizij_animation/src/systems.rs
@@ -123,7 +123,7 @@ pub fn fixed_update_core_system(
     dt: Res<FixedDt>,
     mut pending: ResMut<PendingOutputs>,
 ) {
-    let out = eng.0.update(dt.0, Inputs::default());
+    let out = eng.0.update_values(dt.0, Inputs::default());
     // Replace pending changes with this tick's changes
     pending.changes.clear();
     pending.changes.extend(out.changes.iter().cloned());

--- a/crates/animation/bevy_vizij_animation/tests/plugin_smoke.rs
+++ b/crates/animation/bevy_vizij_animation/tests/plugin_smoke.rs
@@ -26,7 +26,7 @@ fn fixedupdate_ticks_engine() {
     fn fixed_sys(mut eng: ResMut<VizijEngine>, mut ticks: ResMut<Ticks>) {
         let _ = eng
             .0
-            .update(1.0 / 60.0, vizij_animation_core::inputs::Inputs::default());
+            .update_values(1.0 / 60.0, vizij_animation_core::inputs::Inputs::default());
         ticks.0 += 1;
     }
 

--- a/crates/animation/vizij-animation-core/README.md
+++ b/crates/animation/vizij-animation-core/README.md
@@ -157,13 +157,20 @@ assert_eq!(anim.tracks.len(), 1);
 ### Baking animations
 
 ```rust
-use vizij_animation_core::baking::{bake_animation_data, BakingConfig, export_baked_json};
+use vizij_animation_core::baking::{
+    bake_animation_data_with_derivatives,
+    BakingConfig,
+    export_baked_json,
+    export_baked_with_derivatives_json,
+};
 
 let anim = vizij_animation_core::AnimationData::default();
 let cfg = BakingConfig { frame_rate: 60.0, start_time: 0.0, end_time: None };
-let baked = bake_animation_data(vizij_animation_core::AnimId(0), &anim, &cfg);
-let json = export_baked_json(&baked);
-println!("{}", json);
+let (values, derivatives) = bake_animation_data_with_derivatives(vizij_animation_core::AnimId(0), &anim, &cfg);
+let values_json = export_baked_json(&values);
+let bundle_json = export_baked_with_derivatives_json(&values, &derivatives);
+println!("values: {}", values_json);
+println!("values + derivatives: {}", bundle_json);
 ```
 
 ## Testing

--- a/crates/animation/vizij-animation-core/src/lib.rs
+++ b/crates/animation/vizij-animation-core/src/lib.rs
@@ -22,7 +22,11 @@ pub mod stored_animation;
 pub mod value;
 
 // Re-exports for consumers (adapters)
-pub use baking::{BakedAnimationData, BakingConfig};
+pub use baking::{
+    bake_animation_data, bake_animation_data_with_derivatives, export_baked_json,
+    export_baked_with_derivatives_json, BakedAnimationData, BakedDerivativeAnimationData,
+    BakedDerivativeTrack, BakingConfig,
+};
 pub use binding::{BindingSet, BindingTable, ChannelKey, TargetHandle, TargetResolver};
 pub use config::Config;
 pub use data::{AnimationData, Keypoint, Track, Transitions, Vec2};
@@ -30,8 +34,8 @@ pub use engine::{Engine, InstanceCfg, Player};
 pub use ids::{AnimId, InstId, PlayerId};
 pub use inputs::{Inputs, InstanceUpdate, LoopMode, PlayerCommand};
 pub use interp::InterpRegistry;
-pub use outputs::{Change, CoreEvent, Outputs};
-pub use sampling::sample_track;
+pub use outputs::{Change, ChangeWithDerivative, CoreEvent, Outputs, OutputsWithDerivatives};
+pub use sampling::{sample_track, sample_track_with_derivative};
 pub use scratch::Scratch;
 pub use stored_animation::parse_stored_animation_json;
 pub use vizij_api_core::{Value, ValueKind};

--- a/crates/animation/vizij-animation-core/src/outputs.rs
+++ b/crates/animation/vizij-animation-core/src/outputs.rs
@@ -18,6 +18,16 @@ pub struct Change {
     pub value: Value,
 }
 
+/// Change paired with a derivative value.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ChangeWithDerivative {
+    pub player: PlayerId,
+    pub key: String,
+    pub value: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub derivative: Option<Value>,
+}
+
 /// Discrete semantic signals emitted during stepping.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -75,6 +85,15 @@ pub struct Outputs {
     pub events: Vec<CoreEvent>,
 }
 
+/// Outputs returned when derivatives are requested.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct OutputsWithDerivatives {
+    #[serde(default)]
+    pub changes: Vec<ChangeWithDerivative>,
+    #[serde(default)]
+    pub events: Vec<CoreEvent>,
+}
+
 impl Outputs {
     #[inline]
     pub fn clear(&mut self) {
@@ -84,6 +103,29 @@ impl Outputs {
 
     #[inline]
     pub fn push_change(&mut self, change: Change) {
+        self.changes.push(change);
+    }
+
+    #[inline]
+    pub fn push_event(&mut self, event: CoreEvent) {
+        self.events.push(event);
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.changes.is_empty() && self.events.is_empty()
+    }
+}
+
+impl OutputsWithDerivatives {
+    #[inline]
+    pub fn clear(&mut self) {
+        self.changes.clear();
+        self.events.clear();
+    }
+
+    #[inline]
+    pub fn push_change(&mut self, change: ChangeWithDerivative) {
         self.changes.push(change);
     }
 

--- a/crates/animation/vizij-animation-wasm/README.md
+++ b/crates/animation/vizij-animation-wasm/README.md
@@ -70,7 +70,11 @@ The npm wrapper exports:
   * `createPlayer(name: string)` – Returns `PlayerId`.
   * `addInstance(player, anim, cfg?)` – Adds an instance with optional `InstanceCfg` JSON.
   * `prebind(resolver)` – Resolve canonical target paths to application-defined keys.
-  * `update(dtSeconds, inputs?)` – Steps the simulation and returns `{ changes, events }`.
+  * `updateValues(dtSeconds, inputs?)` – Steps the simulation and returns `{ changes, events }`.
+  * `updateValuesAndDerivatives(dtSeconds, inputs?)` – Same as above but each change also includes an optional `derivative` field.
+  * `bakeAnimation(animId, cfg?)` – Returns baked samples for a clip.
+  * `bakeAnimationWithDerivatives(animId, cfg?)` – Returns baked samples plus per-sample derivatives.
+  * `update(...)` – Alias for `updateValues(...)` for backwards compatibility.
 * Low-level class `VizijAnimation` mirrors the above methods with slightly more explicit JSON handling.
 
 ### StoredAnimation format
@@ -116,8 +120,9 @@ interpolation.
 
 * **Bindings and prebinding** – `prebind(resolver)` receives canonical target paths such as `"node/Transform.translation"` and
   should return the key you want in `change.key`. Return `null`/`undefined` to leave a path unresolved.
-* **Outputs** – `update` returns `{ changes: Change[], events: CoreEvent[] }`. `Change.value` is a tagged union (Scalar, Vec3,
-  Quat, Transform, Bool, Text, etc.). Events mirror the Rust core’s playback events.
+* **Outputs** – `updateValues` returns `{ changes: Change[], events: CoreEvent[] }`. `updateValuesAndDerivatives` mirrors that
+  shape but each change also carries an optional `derivative` value for numeric tracks. Events mirror the Rust core’s playback
+  events.
 * **Inputs** – Optional `Inputs` payload supports player commands (Play/Pause/Seek/SetLoopMode/etc.) and per-instance updates
   (weight, time scale, enable flag, etc.).
 * **ABI guard** – `abi_version()` helps consumers detect mismatches between the wasm binary and the JS wrapper. The npm package’s
@@ -152,7 +157,7 @@ const playerId = eng.createPlayer("demo");
 eng.addInstance(playerId, animId);
 eng.prebind((path) => path); // identity mapping
 
-const outputs = eng.update(1 / 60);
+const outputs = eng.updateValues(1 / 60);
 console.log(outputs.changes);
 ```
 
@@ -180,7 +185,7 @@ const animId = raw.load_stored_animation(JSON.stringify({
 }));
 const player = raw.create_player("demo");
 raw.add_instance(player, animId, null);
-const result = raw.update(0.016, null);
+const result = raw.update_values(0.016, null);
 console.log(result);
 ```
 

--- a/crates/animation/vizij-animation-wasm/tests/wasm_api_tests.rs
+++ b/crates/animation/vizij-animation-wasm/tests/wasm_api_tests.rs
@@ -73,7 +73,7 @@ fn load_create_add_and_update() {
     eng.prebind(resolver);
 
     // Update with no inputs (undefined) at small dt
-    let outputs = eng.update(0.016, JsValue::UNDEFINED).unwrap();
+    let outputs = eng.update_values(0.016, JsValue::UNDEFINED).unwrap();
     // Outputs should be an object with { changes, events }
     let obj = js_sys::Object::from(outputs);
     let changes = js_sys::Reflect::get(&obj, &JsValue::from_str("changes")).unwrap();
@@ -120,5 +120,39 @@ fn prebind_resolver_throwing_is_ignored() {
     eng.prebind(resolver);
 
     // Update should still succeed
-    let _outputs = eng.update(0.016, JsValue::UNDEFINED).unwrap();
+    let _outputs = eng.update_values(0.016, JsValue::UNDEFINED).unwrap();
+}
+
+#[wasm_bindgen_test]
+fn update_with_derivatives_returns_optional_derivative() {
+    let mut eng = VizijAnimation::new(JsValue::NULL).unwrap();
+    let anim_id = eng.load_animation(test_animation_json()).unwrap();
+    let player_id = eng.create_player("p".into());
+    let _ = eng
+        .add_instance(player_id, anim_id, JsValue::UNDEFINED)
+        .unwrap();
+
+    let outputs = eng
+        .update_values_and_derivatives(0.016, JsValue::UNDEFINED)
+        .unwrap();
+    let obj = js_sys::Object::from(outputs);
+    let changes = js_sys::Reflect::get(&obj, &JsValue::from_str("changes")).unwrap();
+    let array = js_sys::Array::from(&changes);
+    assert!(array.length() > 0);
+    let first = array.get(0);
+    let derivative = js_sys::Reflect::get(&first, &JsValue::from_str("derivative")).unwrap();
+    assert!(derivative.is_null() || derivative.is_object());
+}
+
+#[wasm_bindgen_test]
+fn bake_animation_with_derivatives_returns_bundle() {
+    let mut eng = VizijAnimation::new(JsValue::NULL).unwrap();
+    let anim_id = eng.load_animation(test_animation_json()).unwrap();
+
+    let bundle = eng
+        .bake_animation_with_derivatives(anim_id, JsValue::UNDEFINED)
+        .unwrap();
+    let obj = js_sys::Object::from(bundle);
+    assert!(js_sys::Reflect::has(&obj, &JsValue::from_str("values")).unwrap());
+    assert!(js_sys::Reflect::has(&obj, &JsValue::from_str("derivatives")).unwrap());
 }

--- a/crates/animation/vizij-animation-wasm/tests/wasm_bool_text.rs
+++ b/crates/animation/vizij-animation-wasm/tests/wasm_bool_text.rs
@@ -95,7 +95,7 @@ fn wasm_bool_text_outputs_and_step() {
         .unwrap();
 
     // Initial tick at 0.0
-    let out0 = eng.update(0.0, JsValue::UNDEFINED).unwrap();
+    let out0 = eng.update_values(0.0, JsValue::UNDEFINED).unwrap();
     let v_flag0 = get_change_value(&out0, "node.flag").expect("node.flag");
     let v_label0 = get_change_value(&out0, "node.label").expect("node.label");
 
@@ -123,8 +123,8 @@ fn wasm_bool_text_outputs_and_step() {
     assert_eq!(data_label0, "A".to_string());
 
     // Advance to 0.6s (u~=0.6) -> expect true / "B" due to step (hold left)
-    let _ = eng.update(0.6, JsValue::UNDEFINED).unwrap();
-    let out1 = eng.update(0.0, JsValue::UNDEFINED).unwrap();
+    let _ = eng.update_values(0.6, JsValue::UNDEFINED).unwrap();
+    let out1 = eng.update_values(0.0, JsValue::UNDEFINED).unwrap();
     let v_flag1 = get_change_value(&out1, "node.flag").expect("node.flag");
     let v_label1 = get_change_value(&out1, "node.label").expect("node.label");
 

--- a/crates/animation/vizij-animation-wasm/tests/wasm_parity_tests.rs
+++ b/crates/animation/vizij-animation-wasm/tests/wasm_parity_tests.rs
@@ -49,14 +49,14 @@ fn wasm_parity_scalar_ramp() {
         .unwrap();
 
     // Initial tick at dt=0.0 -> value ~ 0.0
-    let out0 = eng.update(0.0, JsValue::UNDEFINED).unwrap();
+    let out0 = eng.update_values(0.0, JsValue::UNDEFINED).unwrap();
     let s0 = get_scalar_by_key(out0, "node.t").expect("node.t");
     approx(s0, 0.0, 1e-6);
 
     // Step 9 ticks of 0.1 -> expect ~ i/10 at each step (avoid wrap at exactly 1.0 in Loop mode)
     let mut t = 0.0f64;
     for i in 1..=9 {
-        let out = eng.update(0.1, JsValue::UNDEFINED).unwrap();
+        let out = eng.update_values(0.1, JsValue::UNDEFINED).unwrap();
         t += 0.1;
         let s = get_scalar_by_key(out, "node.t").expect("node.t");
         approx(s, t, 1e-6);

--- a/crates/animation/vizij-animation-wasm/tests/wasm_stored_animation.rs
+++ b/crates/animation/vizij-animation-wasm/tests/wasm_stored_animation.rs
@@ -49,7 +49,7 @@ fn wasm_loads_new_format_and_samples_initial() {
         .unwrap();
 
     // Initial tick at dt=0.0 -> should emit starting values
-    let out0 = eng.update(0.0, JsValue::UNDEFINED).unwrap();
+    let out0 = eng.update_values(0.0, JsValue::UNDEFINED).unwrap();
 
     // Track "cube-position-x" starts at -2 (see fixture)
     let s0 = get_scalar_by_key(out0, "cube-position-x").expect("cube-position-x");

--- a/npm/@vizij/animation-wasm/README.md
+++ b/npm/@vizij/animation-wasm/README.md
@@ -75,7 +75,7 @@ const playerId = eng.createPlayer("demo");
 eng.addInstance(playerId, animId);
 eng.prebind((path) => path); // optional resolver
 
-const outputs = eng.update(1 / 60);
+const outputs = eng.updateValues(1 / 60);
 console.log(outputs.changes);
 ```
 
@@ -89,23 +89,26 @@ const raw = new VizijAnimation();
 const animId = raw.load_stored_animation(JSON.stringify(storedAnimationJson));
 const player = raw.create_player("demo");
 raw.add_instance(player, animId, undefined);
-const outputs = JSON.parse(raw.update(0.016, undefined));
+const outputs = JSON.parse(raw.update_values(0.016, undefined));
+const rich = JSON.parse(raw.update_values_and_derivatives(0.016, undefined));
 ```
 
 ## Key Details
 
 * **StoredAnimation JSON** – Duration in milliseconds, track keypoints with normalized `stamp` values (0..1), per-keypoint cubic
   bezier control points via `transitions.in/out`, and support for scalar/vector/quat/color/bool/text values.
-* **Outputs** – `{ changes: Change[], events: CoreEvent[] }`. Each `Change` includes the resolved key and a tagged union value
-  (Scalar, Vec3, Transform, etc.). Events mirror the Rust engine’s playback notifications (started, paused, keypoint reached,
-  warnings, etc.).
+* **Outputs** – `updateValues` returns `{ changes: Change[], events: CoreEvent[] }`. `updateValuesAndDerivatives` augments each
+  change with an optional `derivative` field when the engine can compute one. Events mirror the Rust engine’s playback
+  notifications (started, paused, keypoint reached, warnings, etc.).
 * **Inputs** – Optional `Inputs` payload supports player commands (play/pause/seek/loop) and per-instance updates (weights,
   timescale, enabled flag, start offset).
 * **Environment detection** – Browser builds load the `.wasm` via fetch relative to the module URL; Node builds read from disk.
   Bundlers may log that Node modules (`node:path`, `fs`) were externalized—this is expected.
 * **ABI guard** – `abi_version()` ensures the JS wrapper and WASM binary agree. The `Engine` wrapper throws if the numbers differ
   after `init()`.
-* **TypeScript support** – `src/types.d.ts` exports `Value`, `StoredAnimation`, `Inputs`, `Outputs`, and helper types.
+* **Baking helpers** – `bakeAnimation` and `bakeAnimationWithDerivatives` expose the core baking API for tooling.
+* **TypeScript support** – `src/types.d.ts` exports `Value`, `StoredAnimation`, `Inputs`, `Outputs`, derivative-aware outputs,
+  and baking result types.
 
 ## Examples
 
@@ -133,7 +136,7 @@ const storedAnimation = {
 ### Player commands & instance updates
 
 ```ts
-eng.update(1 / 60, {
+eng.updateValues(1 / 60, {
   player_cmds: [
     { Play: { player: playerId } },
     { SetLoopMode: { player: playerId, mode: "Loop" } },

--- a/npm/@vizij/animation-wasm/src/index.ts
+++ b/npm/@vizij/animation-wasm/src/index.ts
@@ -5,9 +5,11 @@ import initWasm, { VizijAnimation, abi_version } from "../pkg/vizij_animation_wa
 import type {
   InitInput,
   Config,
+  BakingConfig,
   Inputs,
   InstanceUpdate,
   Outputs,
+  OutputsWithDerivatives,
   AnimationData,
   StoredAnimation,
   AnimId,
@@ -16,17 +18,23 @@ import type {
   Value,
   CoreEvent,
   Change,
+  ChangeWithDerivative,
   AnimationInfo,
   PlayerInfo,
   InstanceInfo,
+  BakedAnimationData,
+  BakedDerivativeAnimationData,
+  BakedAnimationBundle,
 } from "./types";
 
 export type {
   InitInput,
   Config,
+  BakingConfig,
   Inputs,
   InstanceUpdate,
   Outputs,
+  OutputsWithDerivatives,
   AnimationData,
   StoredAnimation,
   AnimId,
@@ -35,9 +43,13 @@ export type {
   Value,
   CoreEvent,
   Change,
+  ChangeWithDerivative,
   AnimationInfo,
   PlayerInfo,
   InstanceInfo,
+  BakedAnimationData,
+  BakedDerivativeAnimationData,
+  BakedAnimationBundle,
 };
 
 export { VizijAnimation, abi_version };
@@ -180,8 +192,34 @@ export class Engine {
   }
 
   /** Step the simulation by dt (seconds) with optional Inputs; returns Outputs */
+  updateValues(dt: number, inputs?: Inputs): Outputs {
+    return (this.inner.update_values(dt, (inputs ?? undefined) as any) as unknown) as Outputs;
+  }
+
+  /** Step the simulation by dt returning both values and derivatives */
+  updateValuesAndDerivatives(dt: number, inputs?: Inputs): OutputsWithDerivatives {
+    return (this.inner.update_values_and_derivatives(
+      dt,
+      (inputs ?? undefined) as any,
+    ) as unknown) as OutputsWithDerivatives;
+  }
+
+  /** Backwards-compatible alias for updateValues */
   update(dt: number, inputs?: Inputs): Outputs {
-    return (this.inner.update(dt, (inputs ?? undefined) as any) as unknown) as Outputs;
+    return this.updateValues(dt, inputs);
+  }
+
+  /** Bake animation samples for a loaded animation */
+  bakeAnimation(anim: AnimId, cfg?: BakingConfig): BakedAnimationData {
+    return (this.inner.bake_animation(anim as number, (cfg ?? undefined) as any) as unknown) as BakedAnimationData;
+  }
+
+  /** Bake animation samples plus derivatives */
+  bakeAnimationWithDerivatives(anim: AnimId, cfg?: BakingConfig): BakedAnimationBundle {
+    return (this.inner.bake_animation_with_derivatives(
+      anim as number,
+      (cfg ?? undefined) as any,
+    ) as unknown) as BakedAnimationBundle;
   }
 
   /** Remove a player and all its instances */

--- a/npm/@vizij/animation-wasm/src/types.d.ts
+++ b/npm/@vizij/animation-wasm/src/types.d.ts
@@ -42,6 +42,12 @@ export interface Config {
   features?: Features;
 }
 
+export interface BakingConfig {
+  frame_rate?: number;
+  start_time?: number;
+  end_time?: number | null;
+}
+
 /* -----------------------------------------------------------
    Inputs (vizij-animation-core/src/inputs.rs)
    serde default represents enums as { "Variant": { ... } }
@@ -105,6 +111,10 @@ export interface Change {
   value: Value;
 }
 
+export interface ChangeWithDerivative extends Change {
+  derivative?: Value | null;
+}
+
 export type CoreEvent =
   | { PlaybackStarted: { player: PlayerId; animation?: string | null } }
   | { PlaybackPaused: { player: PlayerId } }
@@ -133,6 +143,11 @@ export type CoreEvent =
 
 export interface Outputs {
   changes: Change[];
+  events: CoreEvent[];
+}
+
+export interface OutputsWithDerivatives {
+  changes: ChangeWithDerivative[];
   events: CoreEvent[];
 }
 
@@ -196,6 +211,40 @@ export interface StoredAnimation {
    Left intentionally broad; use when supplying core-format clips.
 ----------------------------------------------------------- */
 export type AnimationData = unknown;
+
+/* -----------------------------------------------------------
+   Baked animation data
+----------------------------------------------------------- */
+export interface BakedTrack {
+  target_path: string;
+  values: Value[];
+}
+
+export interface BakedDerivativeTrack {
+  target_path: string;
+  values: Array<Value | null>;
+}
+
+export interface BakedAnimationData {
+  anim: AnimId;
+  frame_rate: number;
+  start_time: number;
+  end_time: number;
+  tracks: BakedTrack[];
+}
+
+export interface BakedDerivativeAnimationData {
+  anim: AnimId;
+  frame_rate: number;
+  start_time: number;
+  end_time: number;
+  tracks: BakedDerivativeTrack[];
+}
+
+export interface BakedAnimationBundle {
+  values: BakedAnimationData;
+  derivatives: BakedDerivativeAnimationData;
+}
 
 /* -----------------------------------------------------------
    Engine inspection (authoritative state from core)


### PR DESCRIPTION
## Summary
- add derivative-aware accumulation, sampling, and baking outputs throughout `vizij-animation-core`
- expose matching update and baking methods in the WASM bindings and TypeScript wrapper, and extend docs accordingly
- update adapters and tests to use the new `updateValues` APIs and cover derivative/baking behaviour

## Testing
- `cargo fmt --all`
- `cargo test -p vizij-animation-core`


------
https://chatgpt.com/codex/tasks/task_e_68d63ac402948320b3398eaef628604c