### PR TITLE
Fix wasm wrapper init normalization and mainline release state

### DIFF
--- a/.changeset/four-mirrors-talk.md
+++ b/.changeset/four-mirrors-talk.md
@@ -1,0 +1,10 @@
+---
+"@vizij/wasm-loader": patch
+"@vizij/animation-wasm": patch
+"@vizij/node-graph-wasm": patch
+"@vizij/orchestrator-wasm": patch
+---
+
+Fix wasm init normalization so wrapper packages accept `{ module_or_path: ... }`
+inputs without double-wrapping them, and make the shared loader normalize that
+object form consistently in Node and browser contexts.

--- a/crates/node-graph/vizij-graph-core/src/schema.rs
+++ b/crates/node-graph/vizij-graph-core/src/schema.rs
@@ -25,7 +25,7 @@ pub enum ParamType {
     Bool,
     Vec3,
     Vector,
-    Any, // union (Value)
+    Any,  // union (Value)
     Text, // free-form string
 }
 

--- a/crates/node-graph/vizij-graph-wasm/src/lib.rs
+++ b/crates/node-graph/vizij-graph-wasm/src/lib.rs
@@ -1403,7 +1403,6 @@ impl WasmGraph {
             Err(JsValue::from_str("unknown node"))
         }
     }
-
 }
 
 /// Expose the node schema registry as JSON for tooling/UI.

--- a/npm/@vizij/animation-wasm/src/index.ts
+++ b/npm/@vizij/animation-wasm/src/index.ts
@@ -10,7 +10,6 @@ import {
 } from "@vizij/wasm-loader";
 import { loadBindings as loadWasmBindingsBrowser } from "@vizij/wasm-loader/browser";
 import type {
-  InitInput,
   Config,
   BakingConfig,
   Inputs,
@@ -35,7 +34,6 @@ import type {
 } from "./types";
 
 export type {
-  InitInput,
   Config,
   BakingConfig,
   Inputs,
@@ -151,6 +149,8 @@ const loadBindingsImpl =
   typeof window === "undefined"
     ? loadWasmBindings
     : (loadWasmBindingsBrowser as typeof loadWasmBindings);
+
+export type InitInput = LoaderInitInput;
 
 async function loadBindings(input?: LoaderInitInput): Promise<WasmBindings> {
   await loadBindingsImpl<WasmBindings>(

--- a/npm/@vizij/animation-wasm/src/index.ts
+++ b/npm/@vizij/animation-wasm/src/index.ts
@@ -103,6 +103,13 @@ let wasmModulePromise: Promise<WasmBindings | unknown> | null = null;
 let wasmUrlCache: string | null = null;
 
 function toWasmBindgenInitOptions(initArg: unknown): { module_or_path: unknown } {
+  if (
+    initArg &&
+    typeof initArg === "object" &&
+    "module_or_path" in (initArg as Record<string, unknown>)
+  ) {
+    return initArg as { module_or_path: unknown };
+  }
   return { module_or_path: initArg };
 }
 

--- a/npm/@vizij/animation-wasm/tests/all.test.ts
+++ b/npm/@vizij/animation-wasm/tests/all.test.ts
@@ -255,7 +255,7 @@ process.env.RUST_BACKTRACE = "1";
 
 (async () => {
   try {
-    await init(pkgWasmUrl());
+    await init({ module_or_path: pkgWasmUrl() });
     await testLoadAnimationFromTypescriptObject();
     await testLoadAnimationFromVectorFixture();
     await testLoadAnimationStateToggleFixture();

--- a/npm/@vizij/node-graph-wasm/src/index.ts
+++ b/npm/@vizij/node-graph-wasm/src/index.ts
@@ -74,6 +74,13 @@ let wasmModulePromise: Promise<WasmBindings | unknown> | null = null;
 let wasmUrlCache: string | null = null;
 
 function toWasmBindgenInitOptions(initArg: unknown): { module_or_path: unknown } {
+  if (
+    initArg &&
+    typeof initArg === "object" &&
+    "module_or_path" in (initArg as Record<string, unknown>)
+  ) {
+    return initArg as { module_or_path: unknown };
+  }
   return { module_or_path: initArg };
 }
 

--- a/npm/@vizij/node-graph-wasm/tests/all.test.ts
+++ b/npm/@vizij/node-graph-wasm/tests/all.test.ts
@@ -483,7 +483,7 @@ function assertText(write: WriteOpJSON, expected: string): void {
 /* ---------- Entrypoint: run all grouped checks ---------- */
 (async () => {
   try {
-    await init(pkgWasmUrl());
+    await init({ module_or_path: pkgWasmUrl() });
 
     const registry = getNodeRegistry();
     assert.ok(Array.isArray(registry.nodes) && registry.nodes.length > 0, "registry should contain nodes");

--- a/npm/@vizij/orchestrator-wasm/CHANGELOG.md
+++ b/npm/@vizij/orchestrator-wasm/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @vizij/orchestrator-wasm
 
+## 0.3.1
+
+### Patch Changes
+
+- 6d9b035: Publish a new orchestrator-wasm build that recognizes the newly-added node-graph noise node variants (`simplenoise`, `perlinnoise`, `simplexnoise`) when registering graph specs.
+
+  This resolves runtime graph registration failures when `@vizij/node-graph-wasm@0.6.x` graphs are passed through orchestrator.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/npm/@vizij/orchestrator-wasm/package.json
+++ b/npm/@vizij/orchestrator-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizij/orchestrator-wasm",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "WASM bindings for Vizij orchestrator core (JS wrapper)",
   "license": "MIT",
   "repository": {

--- a/npm/@vizij/orchestrator-wasm/src/index.ts
+++ b/npm/@vizij/orchestrator-wasm/src/index.ts
@@ -58,6 +58,13 @@ let wasmModulePromise: Promise<WasmBindings | unknown> | null = null;
 let wasmUrlCache: string | null = null;
 
 function toWasmBindgenInitOptions(initArg: unknown): { module_or_path: unknown } {
+  if (
+    initArg &&
+    typeof initArg === "object" &&
+    "module_or_path" in (initArg as Record<string, unknown>)
+  ) {
+    return initArg as { module_or_path: unknown };
+  }
   return { module_or_path: initArg };
 }
 

--- a/npm/@vizij/orchestrator-wasm/tests/all.test.ts
+++ b/npm/@vizij/orchestrator-wasm/tests/all.test.ts
@@ -623,7 +623,7 @@ process.env.RUST_BACKTRACE = "1";
 
 (async () => {
   try {
-    await init(pkgWasmUrl());
+    await init({ module_or_path: pkgWasmUrl() });
     await testScalarRampPipeline();
     await testChainedSlewPipeline();
     await testChainSignSlewFixture();

--- a/npm/@vizij/wasm-loader/src/shared.ts
+++ b/npm/@vizij/wasm-loader/src/shared.ts
@@ -4,13 +4,17 @@
  * The helpers in this module coordinate module import, initialization, ABI checks, and cached
  * binding reuse across the browser and Node-facing loader entrypoints.
  */
-export type InitInput =
+type InitInputValue =
   | string
   | URL
   | ArrayBufferView
   | ArrayBuffer
   | WebAssembly.Module
   | Response;
+
+export type InitInput =
+  | InitInputValue
+  | { module_or_path: InitInputValue };
 
 export interface LoadBindingsOptions<TBindings> {
   cache: { current: TBindings | null };
@@ -36,7 +40,18 @@ export async function loadBindingsInternal<TBindings>(
     typeof initInput === "undefined"
       ? options.defaultWasmUrl()
       : initInput;
-  initArg = await maybeReadFileBytes(initArg);
+  if (
+    initArg &&
+    typeof initArg === "object" &&
+    "module_or_path" in (initArg as Record<string, unknown>)
+  ) {
+    const moduleOrPath = await maybeReadFileBytes(
+      (initArg as { module_or_path: unknown }).module_or_path,
+    );
+    initArg = { module_or_path: moduleOrPath };
+  } else {
+    initArg = await maybeReadFileBytes(initArg);
+  }
 
   await options.init(module, initArg);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 0.1.0
       '@vizij/wasm-loader':
         specifier: workspace:*
-        version: 0.1.2
+        version: link:../wasm-loader
     devDependencies:
       '@types/node':
         specifier: latest
@@ -44,7 +44,7 @@ importers:
         version: 0.1.0
       '@vizij/wasm-loader':
         specifier: workspace:*
-        version: 0.1.2
+        version: link:../wasm-loader
     devDependencies:
       '@types/node':
         specifier: ^20.12.7
@@ -60,7 +60,7 @@ importers:
         version: 0.1.0
       '@vizij/wasm-loader':
         specifier: workspace:*
-        version: 0.1.2
+        version: link:../wasm-loader
     devDependencies:
       '@types/node':
         specifier: ^20.12.7
@@ -216,9 +216,6 @@ packages:
 
   '@vizij/value-json@0.1.0':
     resolution: {integrity: sha512-NzSX14YLnA1ZPaxib0qhgHn5+cVxPZpiTINhqfQwD07FBtkLHPNh/FdQTUmyNAdhZB/RVvdobbEnFCEVLRQJqw==}
-
-  '@vizij/wasm-loader@0.1.2':
-    resolution: {integrity: sha512-3q+e1gt/C7S55HdwTLLHjMzIC664pSkfMMhSDoSSwZoG2ZysnsMeiOtudRred0OcHQIfwpFIRWL+E0MBMLGHlw==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -787,8 +784,6 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@vizij/value-json@0.1.0': {}
-
-  '@vizij/wasm-loader@0.1.2': {}
 
   ansi-colors@4.1.3: {}
 


### PR DESCRIPTION
## Summary
- normalize module_or_path init inputs in the wasm wrappers and shared loader so already-wrapped inputs are not double wrapped
- update the wrapper smoke tests to exercise the object-shaped init path that downstream apps use
- realign main with the already-published @vizij/orchestrator-wasm 0.3.1 state and fix the lockfile so workspace wrappers resolve @vizij/wasm-loader through the workspace link instead of a stale 0.1.2 snapshot

## Validation
- unset NODE_ENV && pnpm run build:shared && pnpm run build:wasm:animation && pnpm run build:wasm:graph && pnpm run build:wasm:orchestrator && pnpm --filter @vizij/animation-wasm run test && pnpm --filter @vizij/node-graph-wasm run test && pnpm --filter @vizij/orchestrator-wasm run test
- git pre-commit hook: cargo fmt, cargo clippy --workspace --all-features --bins --examples --tests -- -D warnings
- git pre-push hook: cargo fmt --check, cargo clippy --workspace --all-features --bins --examples --tests -- -D warnings, cargo test --workspace --all-features, node scripts/verify-node-registry.mjs

## Release impact
Changesets now plan these patch releases from main:
- @vizij/wasm-loader 0.1.5
- @vizij/animation-wasm 0.3.8
- @vizij/node-graph-wasm 0.6.1
- @vizij/orchestrator-wasm 0.3.2
