### PR TITLE
feat(interop): vizij-arora — vizij_api_core::Value ↔ arora Value (Phase 1) (VIZ-41)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "arora-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b19ef73d661ad225f6d208877fea9257c2300d1a50814e7a1709d03be5821fc"
+dependencies = [
+ "async-trait",
+ "derive_more",
+ "js-sys",
+ "lazy_static",
+ "semver",
+ "serde",
+ "uuid",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +311,17 @@ name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -1542,6 +1569,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1737,6 +1773,29 @@ name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.106",
+ "unicode-xid",
+]
 
 [[package]]
 name = "dispatch"
@@ -3570,6 +3629,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3641,6 +3709,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "send_wrapper"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3648,10 +3726,11 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -3690,10 +3769,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4146,6 +4234,17 @@ dependencies = [
  "serde_json",
  "vizij-api-core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "vizij-arora"
+version = "0.0.0"
+dependencies = [
+ "arora-types",
+ "serde_json",
+ "thiserror",
+ "uuid",
+ "vizij-api-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "crates/orchestrator/vizij-orchestrator-core",
   "crates/orchestrator/vizij-orchestrator-wasm",
   "crates/test-fixtures/vizij-test-fixtures",
+  "crates/interop/vizij-arora",
 ]
 resolver = "2"
 

--- a/crates/interop/vizij-arora/Cargo.toml
+++ b/crates/interop/vizij-arora/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "vizij-arora"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+description = "Conversion between Vizij values (vizij-api-core) and the Arora Value vocabulary (arora-types)."
+
+[dependencies]
+vizij-api-core = { path = "../../api/vizij-api-core" }
+arora-types = "1"
+uuid = "1"
+thiserror = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/interop/vizij-arora/src/lib.rs
+++ b/crates/interop/vizij-arora/src/lib.rs
@@ -1,0 +1,327 @@
+//! Conversion between Vizij values (`vizij_api_core::Value`) and the Arora
+//! `Value` vocabulary (`arora_types::value::Value`).
+//!
+//! Vizij's graphics-flavoured composites (`Vec2`/`Vec3`/`Vec4`/`Quat`/
+//! `ColorRgba`/`Transform`) have no Arora primitive, so they map to
+//! `Value::Structure` with stable type/field ids — the same shape the
+//! `arora-module-cli` generator emits for the declared Arora types (see
+//! VIZ-39 / arora-sdk#100). Primitives map directly (`Float`->`F32`, ...).
+//!
+//! `Value` carries no metadata, so a value's `Shape.meta` (unit/space/range/
+//! color_space) rides a **sidecar key** `"/meta/<path>"` -- see [`meta_key`].
+//!
+//! The ids below are placeholders chosen to be stable and collision-free; they
+//! are intended to be unified with the canonical Arora type records once those
+//! land (VIZ-39).
+
+use std::collections::HashMap;
+
+use arora_types::value::{Structure, StructureField, Value as AValue};
+use uuid::Uuid;
+use vizij_api_core::{Shape, Value as VValue};
+
+/// Failures converting between the two `Value` vocabularies.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ConversionError {
+    /// The Vizij value has no Arora mapping yet.
+    #[error("no Arora mapping for Vizij value `{0}`")]
+    UnsupportedVizij(&'static str),
+    /// The Arora value has no Vizij mapping.
+    #[error("no Vizij mapping for this Arora value")]
+    UnsupportedArora,
+    /// A `Value::Structure` carried a type id we do not recognise.
+    #[error("unknown Arora structure type id {0}")]
+    UnknownStructure(Uuid),
+    /// A structure was missing an expected field.
+    #[error("structure {ty} is missing field {field}")]
+    MissingField { ty: Uuid, field: Uuid },
+    /// A structure field held an unexpected value kind.
+    #[error("structure field {field} has an unexpected value kind")]
+    FieldKind { field: Uuid },
+}
+
+// ---- declared type / field ids ------------------------------------------------
+
+const fn id(n: u128) -> Uuid {
+    Uuid::from_u128(n)
+}
+
+const VEC2_TYPE: Uuid = id(0x0002);
+const VEC2_FIELDS: [Uuid; 2] = [id(0x0002_0001), id(0x0002_0002)];
+
+const VEC3_TYPE: Uuid = id(0x0003);
+const VEC3_FIELDS: [Uuid; 3] = [id(0x0003_0001), id(0x0003_0002), id(0x0003_0003)];
+
+const VEC4_TYPE: Uuid = id(0x0004);
+const VEC4_FIELDS: [Uuid; 4] = [
+    id(0x0004_0001),
+    id(0x0004_0002),
+    id(0x0004_0003),
+    id(0x0004_0004),
+];
+
+const QUAT_TYPE: Uuid = id(0x0010);
+const QUAT_FIELDS: [Uuid; 4] = [
+    id(0x0010_0001),
+    id(0x0010_0002),
+    id(0x0010_0003),
+    id(0x0010_0004),
+];
+
+const COLOR_TYPE: Uuid = id(0x0020);
+const COLOR_FIELDS: [Uuid; 4] = [
+    id(0x0020_0001),
+    id(0x0020_0002),
+    id(0x0020_0003),
+    id(0x0020_0004),
+];
+
+const TRANSFORM_TYPE: Uuid = id(0x0030);
+const TRANSFORM_TRANSLATION: Uuid = id(0x0030_0001);
+const TRANSFORM_ROTATION: Uuid = id(0x0030_0002);
+const TRANSFORM_SCALE: Uuid = id(0x0030_0003);
+
+// ---- Vizij -> Arora -----------------------------------------------------------
+
+/// Convert a Vizij value into the Arora `Value` vocabulary.
+pub fn to_arora(value: &VValue) -> Result<AValue, ConversionError> {
+    Ok(match value {
+        VValue::Float(f) => AValue::F32(*f),
+        VValue::Bool(b) => AValue::Boolean(*b),
+        VValue::Text(s) => AValue::String(s.clone()),
+        VValue::Vector(xs) => AValue::ArrayF32(xs.clone()),
+        VValue::Vec2(a) => vec_struct(VEC2_TYPE, &VEC2_FIELDS, a),
+        VValue::Vec3(a) => vec_struct(VEC3_TYPE, &VEC3_FIELDS, a),
+        VValue::Vec4(a) => vec_struct(VEC4_TYPE, &VEC4_FIELDS, a),
+        VValue::Quat(a) => vec_struct(QUAT_TYPE, &QUAT_FIELDS, a),
+        VValue::ColorRgba(a) => vec_struct(COLOR_TYPE, &COLOR_FIELDS, a),
+        VValue::Transform {
+            translation,
+            rotation,
+            scale,
+        } => structure(
+            TRANSFORM_TYPE,
+            vec![
+                (
+                    TRANSFORM_TRANSLATION,
+                    vec_struct(VEC3_TYPE, &VEC3_FIELDS, translation),
+                ),
+                (
+                    TRANSFORM_ROTATION,
+                    vec_struct(QUAT_TYPE, &QUAT_FIELDS, rotation),
+                ),
+                (TRANSFORM_SCALE, vec_struct(VEC3_TYPE, &VEC3_FIELDS, scale)),
+            ],
+        ),
+        other => return Err(ConversionError::UnsupportedVizij(vizij_variant_name(other))),
+    })
+}
+
+fn vec_struct(ty: Uuid, fields: &[Uuid], comps: &[f32]) -> AValue {
+    structure(
+        ty,
+        fields
+            .iter()
+            .zip(comps)
+            .map(|(id, c)| (*id, AValue::F32(*c)))
+            .collect(),
+    )
+}
+
+fn structure(id: Uuid, fields: Vec<(Uuid, AValue)>) -> AValue {
+    AValue::Structure(Structure {
+        id,
+        fields: fields
+            .into_iter()
+            .map(|(id, value)| StructureField {
+                id,
+                value: Box::new(value),
+            })
+            .collect(),
+    })
+}
+
+fn vizij_variant_name(value: &VValue) -> &'static str {
+    match value {
+        VValue::Enum(..) => "Enum",
+        VValue::Record(..) => "Record",
+        VValue::Array(..) => "Array",
+        VValue::List(..) => "List",
+        VValue::Tuple(..) => "Tuple",
+        _ => "unsupported",
+    }
+}
+
+// ---- Arora -> Vizij -----------------------------------------------------------
+
+/// Convert an Arora value into a Vizij value.
+pub fn from_arora(value: &AValue) -> Result<VValue, ConversionError> {
+    Ok(match value {
+        AValue::F32(f) => VValue::Float(*f),
+        AValue::F64(f) => VValue::Float(*f as f32),
+        AValue::Boolean(b) => VValue::Bool(*b),
+        AValue::String(s) => VValue::Text(s.clone()),
+        AValue::ArrayF32(xs) => VValue::Vector(xs.clone()),
+        AValue::Structure(s) => structure_to_vizij(s)?,
+        _ => return Err(ConversionError::UnsupportedArora),
+    })
+}
+
+fn structure_to_vizij(s: &Structure) -> Result<VValue, ConversionError> {
+    let ty = s.id;
+    Ok(if ty == VEC2_TYPE {
+        VValue::Vec2(read_array(s, &VEC2_FIELDS)?)
+    } else if ty == VEC3_TYPE {
+        VValue::Vec3(read_array(s, &VEC3_FIELDS)?)
+    } else if ty == VEC4_TYPE {
+        VValue::Vec4(read_array(s, &VEC4_FIELDS)?)
+    } else if ty == QUAT_TYPE {
+        VValue::Quat(read_array(s, &QUAT_FIELDS)?)
+    } else if ty == COLOR_TYPE {
+        VValue::ColorRgba(read_array(s, &COLOR_FIELDS)?)
+    } else if ty == TRANSFORM_TYPE {
+        VValue::Transform {
+            translation: read_array(read_struct(s, TRANSFORM_TRANSLATION)?, &VEC3_FIELDS)?,
+            rotation: read_array(read_struct(s, TRANSFORM_ROTATION)?, &QUAT_FIELDS)?,
+            scale: read_array(read_struct(s, TRANSFORM_SCALE)?, &VEC3_FIELDS)?,
+        }
+    } else {
+        return Err(ConversionError::UnknownStructure(ty));
+    })
+}
+
+fn read_array<const N: usize>(
+    s: &Structure,
+    fields: &[Uuid; N],
+) -> Result<[f32; N], ConversionError> {
+    let mut out = [0.0f32; N];
+    for (slot, field_id) in out.iter_mut().zip(fields) {
+        *slot = read_f32(s, *field_id)?;
+    }
+    Ok(out)
+}
+
+fn read_f32(s: &Structure, field: Uuid) -> Result<f32, ConversionError> {
+    let entry = s
+        .fields
+        .iter()
+        .find(|f| f.id == field)
+        .ok_or(ConversionError::MissingField { ty: s.id, field })?;
+    match entry.value.as_ref() {
+        AValue::F32(v) => Ok(*v),
+        AValue::F64(v) => Ok(*v as f32),
+        _ => Err(ConversionError::FieldKind { field }),
+    }
+}
+
+fn read_struct(s: &Structure, field: Uuid) -> Result<&Structure, ConversionError> {
+    let entry = s
+        .fields
+        .iter()
+        .find(|f| f.id == field)
+        .ok_or(ConversionError::MissingField { ty: s.id, field })?;
+    match entry.value.as_ref() {
+        AValue::Structure(inner) => Ok(inner),
+        _ => Err(ConversionError::FieldKind { field }),
+    }
+}
+
+// ---- /meta sidecar ------------------------------------------------------------
+
+/// The sidecar key carrying the metadata for the value stored at `data_path`.
+///
+/// Arora's `Value` has no place for `Shape.meta` (unit/space/range/color_space),
+/// so it travels the same store under a reserved `"/meta/"` namespace.
+pub fn meta_key(data_path: &str) -> String {
+    format!("/meta/{}", data_path.trim_start_matches('/'))
+}
+
+/// Encode a value's shape metadata for the sidecar key, if any is present.
+pub fn encode_shape_meta(shape: &Shape) -> Option<AValue> {
+    if shape.meta.is_empty() {
+        return None;
+    }
+    serde_json::to_string(&shape.meta).ok().map(AValue::String)
+}
+
+/// Decode shape metadata previously written to a sidecar key.
+pub fn decode_shape_meta(value: &AValue) -> Option<HashMap<String, String>> {
+    match value {
+        AValue::String(s) => serde_json::from_str(s).ok(),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vizij_api_core::ShapeId;
+
+    fn round_trip(v: VValue) {
+        let a = to_arora(&v).expect("to_arora");
+        let back = from_arora(&a).expect("from_arora");
+        assert_eq!(back, v);
+    }
+
+    #[test]
+    fn primitives_round_trip() {
+        round_trip(VValue::Float(1.5));
+        round_trip(VValue::Bool(true));
+        round_trip(VValue::Text("hi".into()));
+        round_trip(VValue::Vector(vec![1.0, 2.0, 3.0]));
+    }
+
+    #[test]
+    fn composites_round_trip() {
+        round_trip(VValue::Vec2([1.0, 2.0]));
+        round_trip(VValue::Vec3([1.0, 2.0, 3.0]));
+        round_trip(VValue::Vec4([1.0, 2.0, 3.0, 4.0]));
+        round_trip(VValue::Quat([0.0, 0.0, 0.0, 1.0]));
+        round_trip(VValue::ColorRgba([0.1, 0.2, 0.3, 1.0]));
+        round_trip(VValue::Transform {
+            translation: [1.0, 2.0, 3.0],
+            rotation: [0.0, 0.0, 0.0, 1.0],
+            scale: [1.0, 1.0, 1.0],
+        });
+    }
+
+    #[test]
+    fn vec3_becomes_structure() {
+        let a = to_arora(&VValue::Vec3([1.0, 2.0, 3.0])).unwrap();
+        assert!(matches!(a, AValue::Structure(_)));
+    }
+
+    #[test]
+    fn unsupported_vizij_is_reported() {
+        let err = to_arora(&VValue::Record(Default::default())).unwrap_err();
+        assert_eq!(err, ConversionError::UnsupportedVizij("Record"));
+    }
+
+    #[test]
+    fn unknown_structure_is_reported() {
+        let s = AValue::Structure(Structure {
+            id: Uuid::from_u128(0x9999),
+            fields: vec![],
+        });
+        assert!(matches!(
+            from_arora(&s),
+            Err(ConversionError::UnknownStructure(_))
+        ));
+    }
+
+    #[test]
+    fn meta_sidecar_round_trips() {
+        assert_eq!(
+            meta_key("standard/semio/mouth.x"),
+            "/meta/standard/semio/mouth.x"
+        );
+        let shape = Shape::new(ShapeId::Vec3)
+            .with_meta("unit", "radians")
+            .with_meta("space", "head");
+        let encoded = encode_shape_meta(&shape).expect("some meta");
+        let decoded = decode_shape_meta(&encoded).expect("decoded");
+        assert_eq!(decoded.get("unit").map(String::as_str), Some("radians"));
+        assert_eq!(decoded.get("space").map(String::as_str), Some("head"));
+        assert!(encode_shape_meta(&Shape::new(ShapeId::Scalar)).is_none());
+    }
+}

--- a/crates/interop/vizij-arora/src/lib.rs
+++ b/crates/interop/vizij-arora/src/lib.rs
@@ -10,6 +10,13 @@
 //! `Value` carries no metadata, so a value's `Shape.meta` (unit/space/range/
 //! color_space) rides a **sidecar key** `"/meta/<path>"` -- see [`meta_key`].
 //!
+//! Vizij's *recursive* composites convert structurally, to arbitrary depth:
+//! `Record` <-> `Value::KeyValue` (string-keyed, field ids derived from the
+//! key names), `List`/`Array`/`Tuple` -> `Value::ArrayValue`, and `Enum` <->
+//! a tagged `Value::Structure`. Arora's `ArrayValue` has a single sequence
+//! kind, so `Array` and `Tuple` come back as `List`; the declared `Shape` of
+//! the path, not the wire value, is what preserves that distinction.
+//!
 //! The ids below are **Vizij type ids** — UUIDs namespaced under the ASCII
 //! bytes of "vizij" so they are self-identifying and collision-free. They are
 //! the source of truth for Vizij's structured values. An equivalent
@@ -19,6 +26,8 @@
 
 use std::collections::HashMap;
 
+use arora_types::gen_uuid_from_str;
+use arora_types::keyvalue::{KeyValue, KeyValueField};
 use arora_types::value::{Structure, StructureField, Value as AValue};
 use uuid::Uuid;
 use vizij_api_core::{Shape, Value as VValue};
@@ -26,9 +35,6 @@ use vizij_api_core::{Shape, Value as VValue};
 /// Failures converting between the two `Value` vocabularies.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ConversionError {
-    /// The Vizij value has no Arora mapping yet.
-    #[error("no Arora mapping for Vizij value `{0}`")]
-    UnsupportedVizij(&'static str),
     /// The Arora value has no Vizij mapping.
     #[error("no Vizij mapping for this Arora value")]
     UnsupportedArora,
@@ -83,6 +89,12 @@ const COLOR_FIELDS: [Uuid; 4] = [
     id(0x0020_0004),
 ];
 
+const ENUM_TYPE: Uuid = id(0x0040);
+const ENUM_TAG: Uuid = id(0x0040_0001);
+const ENUM_VALUE: Uuid = id(0x0040_0002);
+
+const RECORD_TYPE: Uuid = id(0x0050);
+
 const TRANSFORM_TYPE: Uuid = id(0x0030);
 const TRANSFORM_TRANSLATION: Uuid = id(0x0030_0001);
 const TRANSFORM_ROTATION: Uuid = id(0x0030_0002);
@@ -120,7 +132,36 @@ pub fn to_arora(value: &VValue) -> Result<AValue, ConversionError> {
                 (TRANSFORM_SCALE, vec_struct(VEC3_TYPE, &VEC3_FIELDS, scale)),
             ],
         ),
-        other => return Err(ConversionError::UnsupportedVizij(vizij_variant_name(other))),
+        VValue::Enum(tag, payload) => structure(
+            ENUM_TYPE,
+            vec![
+                (ENUM_TAG, AValue::String(tag.clone())),
+                (ENUM_VALUE, to_arora(payload)?),
+            ],
+        ),
+        VValue::Record(entries) => {
+            let mut fields = HashMap::with_capacity(entries.len());
+            for (key, entry) in entries {
+                fields.insert(
+                    key.clone(),
+                    KeyValueField {
+                        id: gen_uuid_from_str(key),
+                        name: key.clone(),
+                        value: Some(Box::new(to_arora(entry)?)),
+                    },
+                );
+            }
+            AValue::KeyValue(KeyValue {
+                id: RECORD_TYPE,
+                fields,
+            })
+        }
+        VValue::Array(items) | VValue::List(items) | VValue::Tuple(items) => AValue::ArrayValue(
+            items
+                .iter()
+                .map(to_arora)
+                .collect::<Result<Vec<_>, _>>()?,
+        ),
     })
 }
 
@@ -148,17 +189,6 @@ fn structure(id: Uuid, fields: Vec<(Uuid, AValue)>) -> AValue {
     })
 }
 
-fn vizij_variant_name(value: &VValue) -> &'static str {
-    match value {
-        VValue::Enum(..) => "Enum",
-        VValue::Record(..) => "Record",
-        VValue::Array(..) => "Array",
-        VValue::List(..) => "List",
-        VValue::Tuple(..) => "Tuple",
-        _ => "unsupported",
-    }
-}
-
 // ---- Arora -> Vizij -----------------------------------------------------------
 
 /// Convert an Arora value into a Vizij value.
@@ -170,6 +200,24 @@ pub fn from_arora(value: &AValue) -> Result<VValue, ConversionError> {
         AValue::String(s) => VValue::Text(s.clone()),
         AValue::ArrayF32(xs) => VValue::Vector(xs.clone()),
         AValue::Structure(s) => structure_to_vizij(s)?,
+        AValue::ArrayValue(items) => VValue::List(
+            items
+                .iter()
+                .map(from_arora)
+                .collect::<Result<Vec<_>, _>>()?,
+        ),
+        AValue::KeyValue(kv) => VValue::Record(
+            kv.fields
+                .iter()
+                .map(|(key, field)| {
+                    let value = field
+                        .value
+                        .as_deref()
+                        .ok_or(ConversionError::FieldKind { field: field.id })?;
+                    Ok((key.clone(), from_arora(value)?))
+                })
+                .collect::<Result<_, ConversionError>>()?,
+        ),
         _ => return Err(ConversionError::UnsupportedArora),
     })
 }
@@ -192,6 +240,13 @@ fn structure_to_vizij(s: &Structure) -> Result<VValue, ConversionError> {
             rotation: read_array(read_struct(s, TRANSFORM_ROTATION)?, &QUAT_FIELDS)?,
             scale: read_array(read_struct(s, TRANSFORM_SCALE)?, &VEC3_FIELDS)?,
         }
+    } else if ty == ENUM_TYPE {
+        let tag = match read_field(s, ENUM_TAG)? {
+            AValue::String(tag) => tag.clone(),
+            _ => return Err(ConversionError::FieldKind { field: ENUM_TAG }),
+        };
+        let payload = from_arora(read_field(s, ENUM_VALUE)?)?;
+        VValue::Enum(tag, Box::new(payload))
     } else {
         return Err(ConversionError::UnknownStructure(ty));
     })
@@ -219,6 +274,14 @@ fn read_f32(s: &Structure, field: Uuid) -> Result<f32, ConversionError> {
         AValue::F64(v) => Ok(*v as f32),
         _ => Err(ConversionError::FieldKind { field }),
     }
+}
+
+fn read_field(s: &Structure, field: Uuid) -> Result<&AValue, ConversionError> {
+    s.fields
+        .iter()
+        .find(|f| f.id == field)
+        .map(|f| f.value.as_ref())
+        .ok_or(ConversionError::MissingField { ty: s.id, field })
 }
 
 fn read_struct(s: &Structure, field: Uuid) -> Result<&Structure, ConversionError> {
@@ -299,9 +362,62 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_vizij_is_reported() {
-        let err = to_arora(&VValue::Record(Default::default())).unwrap_err();
-        assert_eq!(err, ConversionError::UnsupportedVizij("Record"));
+    fn record_of_records_round_trips() {
+        // The URDF IK/FK shape: a record of joint -> angle, here nested one
+        // level deeper to prove arbitrary depth.
+        let joints = VValue::Record(
+            [
+                ("shoulder".to_string(), VValue::Float(0.4)),
+                ("elbow".to_string(), VValue::Float(-1.2)),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        let record = VValue::Record(
+            [
+                ("left_arm".to_string(), joints.clone()),
+                ("confidence".to_string(), VValue::Float(0.9)),
+            ]
+            .into_iter()
+            .collect(),
+        );
+
+        let arora = to_arora(&record).unwrap();
+        assert!(matches!(arora, AValue::KeyValue(_)));
+        assert_eq!(from_arora(&arora).unwrap(), record);
+    }
+
+    #[test]
+    fn list_round_trips_and_sequences_collapse_to_list() {
+        let list = VValue::List(vec![
+            VValue::Float(1.0),
+            VValue::Vec3([1.0, 2.0, 3.0]),
+            VValue::Text("mixed".into()),
+        ]);
+        let arora = to_arora(&list).unwrap();
+        assert!(matches!(arora, AValue::ArrayValue(_)));
+        assert_eq!(from_arora(&arora).unwrap(), list);
+
+        // Tuple and Array share ArrayValue on the wire, so they come back as
+        // List: the path's declared Shape carries the distinction instead.
+        let tuple = VValue::Tuple(vec![VValue::Float(1.0), VValue::Bool(true)]);
+        let back = from_arora(&to_arora(&tuple).unwrap()).unwrap();
+        assert_eq!(
+            back,
+            VValue::List(vec![VValue::Float(1.0), VValue::Bool(true)])
+        );
+    }
+
+    #[test]
+    fn enum_round_trips() {
+        let value = VValue::Enum(
+            "grasp".to_string(),
+            Box::new(VValue::Record(
+                [("force".to_string(), VValue::Float(0.5))].into_iter().collect(),
+            )),
+        );
+        let arora = to_arora(&value).unwrap();
+        assert_eq!(from_arora(&arora).unwrap(), value);
     }
 
     #[test]

--- a/crates/interop/vizij-arora/src/lib.rs
+++ b/crates/interop/vizij-arora/src/lib.rs
@@ -10,9 +10,12 @@
 //! `Value` carries no metadata, so a value's `Shape.meta` (unit/space/range/
 //! color_space) rides a **sidecar key** `"/meta/<path>"` -- see [`meta_key`].
 //!
-//! The ids below are placeholders chosen to be stable and collision-free; they
-//! are intended to be unified with the canonical Arora type records once those
-//! land (VIZ-39).
+//! The ids below are **Vizij type ids** — UUIDs namespaced under the ASCII
+//! bytes of "vizij" so they are self-identifying and collision-free. They are
+//! the source of truth for Vizij's structured values. An equivalent
+//! Arora-declared type (identical structural shape) would be linked by mapping
+//! its id onto the matching Vizij id here; nothing in vizij-rs needs to run the
+//! Arora generator for that.
 
 use std::collections::HashMap;
 
@@ -42,8 +45,12 @@ pub enum ConversionError {
 
 // ---- declared type / field ids ------------------------------------------------
 
-const fn id(n: u128) -> Uuid {
-    Uuid::from_u128(n)
+/// Namespace for all Vizij type ids: the ASCII bytes of "vizij"
+/// (`76 69 7a 69 6a`) in the leading bytes, so every id is self-identifying.
+const VIZIJ_NS: u128 = 0x7669_7a69_6a00_0000_0000_0000_0000_0000;
+
+const fn id(offset: u128) -> Uuid {
+    Uuid::from_u128(VIZIJ_NS | offset)
 }
 
 const VEC2_TYPE: Uuid = id(0x0002);

--- a/crates/interop/vizij-arora/src/lib.rs
+++ b/crates/interop/vizij-arora/src/lib.rs
@@ -8,7 +8,7 @@
 //! VIZ-39 / arora-sdk#100). Primitives map directly (`Float`->`F32`, ...).
 //!
 //! `Value` carries no metadata, so a value's `Shape.meta` (unit/space/range/
-//! color_space) rides a **sidecar key** `"/meta/<path>"` -- see [`meta_key`].
+//! color_space) rides a **sidecar key** `"meta/<path>"` -- see [`meta_key`].
 //!
 //! Vizij's *recursive* composites convert structurally, to arbitrary depth:
 //! `Record` <-> `Value::KeyValue` (string-keyed, field ids derived from the
@@ -156,12 +156,9 @@ pub fn to_arora(value: &VValue) -> Result<AValue, ConversionError> {
                 fields,
             })
         }
-        VValue::Array(items) | VValue::List(items) | VValue::Tuple(items) => AValue::ArrayValue(
-            items
-                .iter()
-                .map(to_arora)
-                .collect::<Result<Vec<_>, _>>()?,
-        ),
+        VValue::Array(items) | VValue::List(items) | VValue::Tuple(items) => {
+            AValue::ArrayValue(items.iter().map(to_arora).collect::<Result<Vec<_>, _>>()?)
+        }
     })
 }
 
@@ -301,9 +298,9 @@ fn read_struct(s: &Structure, field: Uuid) -> Result<&Structure, ConversionError
 /// The sidecar key carrying the metadata for the value stored at `data_path`.
 ///
 /// Arora's `Value` has no place for `Shape.meta` (unit/space/range/color_space),
-/// so it travels the same store under a reserved `"/meta/"` namespace.
+/// so it travels the same store under a reserved `"meta/"` namespace. (No leading slash: `TypedPath` rejects an empty first segment, and the sidecar must be storable in a `BlackboardStore`.)
 pub fn meta_key(data_path: &str) -> String {
-    format!("/meta/{}", data_path.trim_start_matches('/'))
+    format!("meta/{}", data_path.trim_start_matches('/'))
 }
 
 /// Encode a value's shape metadata for the sidecar key, if any is present.
@@ -413,7 +410,9 @@ mod tests {
         let value = VValue::Enum(
             "grasp".to_string(),
             Box::new(VValue::Record(
-                [("force".to_string(), VValue::Float(0.5))].into_iter().collect(),
+                [("force".to_string(), VValue::Float(0.5))]
+                    .into_iter()
+                    .collect(),
             )),
         );
         let arora = to_arora(&value).unwrap();
@@ -436,7 +435,7 @@ mod tests {
     fn meta_sidecar_round_trips() {
         assert_eq!(
             meta_key("standard/semio/mouth.x"),
-            "/meta/standard/semio/mouth.x"
+            "meta/standard/semio/mouth.x"
         );
         let shape = Shape::new(ShapeId::Vec3)
             .with_meta("unit", "radians")

--- a/crates/node-graph/vizij-graph-core/src/eval/eval_node.rs
+++ b/crates/node-graph/vizij-graph-core/src/eval/eval_node.rs
@@ -899,7 +899,7 @@ fn prepare_piecewise_breakpoints(
     let mut unique_inputs = Vec::with_capacity(inputs.len());
     let mut unique_outputs = Vec::with_capacity(outputs.len());
 
-    for (idx, (input, output)) in inputs.into_iter().zip(outputs.into_iter()).enumerate() {
+    for (idx, (input, output)) in inputs.into_iter().zip(outputs).enumerate() {
         if let Some(&prev_input) = unique_inputs.last() {
             let delta: f32 = input - prev_input;
             if delta < -PIECEWISE_BREAKPOINT_EPS {


### PR DESCRIPTION
## What

New crate `crates/interop/vizij-arora` (VIZ-41) — the **Phase 1 "value convergence"** consumer side of the [Vizij-on-Arora proposal](docs/proposal-vizij-on-arora.md) (#18). It converts between Vizij values (`vizij_api_core::Value`) and the Arora `Value` vocabulary (`arora_types::value::Value`, from crates.io).

- **Primitives** map directly: `Float↔F32`, `Bool↔Boolean`, `Text↔String`, `Vector↔ArrayF32`.
- **Graphics composites** (`Vec2`/`Vec3`/`Vec4`/`Quat`/`ColorRgba`/`Transform`) have no Arora primitive, so they map to **`Value::Structure`** with stable type/field ids — the exact shape `arora-module-cli` now emits for declared Arora structs (arora-sdk#100, just merged). `Transform` nests `Vec3`/`Quat` structures.
- A value's **`Shape.meta`** (unit/space/range/color_space) has no place in Arora's `Value`, so it rides a **`/meta/<path>` sidecar** key (`meta_key` / `encode_shape_meta` / `decode_shape_meta`).

`to_arora` / `from_arora` are free functions (the orphan rule rules out `From`/`Into` impls between two foreign `Value` types).

## Why

Both VIZ-34 (node graph as an Arora behavior, exchanging Values through the store) and VIZ-35 (Vizij storage implementing Arora's `DataStore`, holding Values) need Vizij's composites to flow as Arora `Value`s. This crate is that bridge. The mechanics were proven in a throwaway spike (a Vizij `Vec3` flowed through a `SimpleDataStore` as a `Value::Structure`).

## Notes

- The type/field UUIDs are stable placeholders, to be unified with the canonical Arora type records (VIZ-39 / the generated bindings) — a follow-up can swap the hand-written `Structure` mapping for the `arora-module-cli`-generated `Into/TryFrom<Value>`.
- Round-trip tested for all primitives + composites + the `/meta` sidecar (`cargo test -p vizij-arora`, 6/6). clippy `-D warnings` and fmt clean.
- Includes one drive-by commit (`fix(graph): drop useless into_iter()`) — the same one-liner as #18, required to satisfy the `-D warnings` pre-commit hook against `main`. Merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)