### PR TITLE
feat(interop): vizij-arora-behavior — a Vizij node graph as an Arora Behavior (VIZ-34)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,10 +206,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "arora-types"
-version = "1.5.0"
+name = "arora-hal"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b19ef73d661ad225f6d208877fea9257c2300d1a50814e7a1709d03be5821fc"
+checksum = "24a305d611741ac3ba50a5939a2ec977d2290d86bf30928f2d0477ddac5590df"
+dependencies = [
+ "arora-types",
+ "async-trait",
+]
+
+[[package]]
+name = "arora-types"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0d81688eddd55f4174ed29ff96a2fdd1264d8bb0452d9ffa1c8405ea415aa2"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -3998,6 +4008,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4245,6 +4276,18 @@ dependencies = [
  "thiserror",
  "uuid",
  "vizij-api-core",
+]
+
+[[package]]
+name = "vizij-arora-hal"
+version = "0.0.0"
+dependencies = [
+ "arora-hal",
+ "arora-types",
+ "async-trait",
+ "tokio",
+ "vizij-api-core",
+ "vizij-arora",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arora-behavior"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fea09635fab78d2bb5381483a3f1487cff7be07e6000dae5f8b5cd892d66253"
+dependencies = [
+ "arora-types",
+]
+
+[[package]]
 name = "arora-hal"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +222,15 @@ checksum = "24a305d611741ac3ba50a5939a2ec977d2290d86bf30928f2d0477ddac5590df"
 dependencies = [
  "arora-types",
  "async-trait",
+]
+
+[[package]]
+name = "arora-simple-data-store"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d061192b2a7fba820ad189d411d85640d1a2fa159e30d7ebad6f4e388946849"
+dependencies = [
+ "arora-types",
 ]
 
 [[package]]
@@ -4279,6 +4297,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "vizij-arora-behavior"
+version = "0.0.0"
+dependencies = [
+ "arora-behavior",
+ "arora-simple-data-store",
+ "arora-types",
+ "serde_json",
+ "vizij-api-core",
+ "vizij-arora",
+ "vizij-graph-core",
+]
+
+[[package]]
 name = "vizij-arora-hal"
 version = "0.0.0"
 dependencies = [
@@ -4288,6 +4319,16 @@ dependencies = [
  "tokio",
  "vizij-api-core",
  "vizij-arora",
+]
+
+[[package]]
+name = "vizij-arora-store"
+version = "0.0.0"
+dependencies = [
+ "arora-types",
+ "vizij-api-core",
+ "vizij-arora",
+ "vizij-orchestrator-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "arora-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b19ef73d661ad225f6d208877fea9257c2300d1a50814e7a1709d03be5821fc"
+dependencies = [
+ "async-trait",
+ "derive_more",
+ "js-sys",
+ "lazy_static",
+ "semver",
+ "serde",
+ "uuid",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +311,17 @@ name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -1542,6 +1569,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1737,6 +1773,29 @@ name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.106",
+ "unicode-xid",
+]
 
 [[package]]
 name = "dispatch"
@@ -3570,6 +3629,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3641,6 +3709,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "send_wrapper"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3648,10 +3726,11 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -3690,10 +3769,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4146,6 +4234,17 @@ dependencies = [
  "serde_json",
  "vizij-api-core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "vizij-arora"
+version = "0.0.0"
+dependencies = [
+ "arora-types",
+ "serde_json",
+ "thiserror",
+ "uuid",
+ "vizij-api-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "crates/orchestrator/vizij-orchestrator-wasm",
   "crates/test-fixtures/vizij-test-fixtures",
   "crates/interop/vizij-arora",
+  "crates/interop/vizij-arora-store",
 ]
 resolver = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "crates/test-fixtures/vizij-test-fixtures",
   "crates/interop/vizij-arora",
   "crates/interop/vizij-arora-store",
+  "crates/interop/vizij-arora-hal",
 ]
 resolver = "2"
 
@@ -36,3 +37,4 @@ serde-wasm-bindgen = "0.6"
 opt-level = "s"
 lto = true
 codegen-units = 1
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "crates/interop/vizij-arora",
   "crates/interop/vizij-arora-store",
   "crates/interop/vizij-arora-hal",
+  "crates/interop/vizij-arora-behavior",
 ]
 resolver = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "crates/orchestrator/vizij-orchestrator-core",
   "crates/orchestrator/vizij-orchestrator-wasm",
   "crates/test-fixtures/vizij-test-fixtures",
+  "crates/interop/vizij-arora",
 ]
 resolver = "2"
 

--- a/crates/interop/vizij-arora-behavior/Cargo.toml
+++ b/crates/interop/vizij-arora-behavior/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "vizij-arora-behavior"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+description = "A Vizij node graph as an Arora Behavior (ProcessingGraph)."
+
+[dependencies]
+arora-behavior = "0.1"
+arora-types = "1"
+vizij-arora = { path = "../vizij-arora" }
+vizij-api-core = { path = "../../api/vizij-api-core" }
+vizij-graph-core = { path = "../../node-graph/vizij-graph-core" }
+
+[dev-dependencies]
+arora-simple-data-store = "0.1"
+serde_json = { workspace = true }

--- a/crates/interop/vizij-arora-behavior/src/lib.rs
+++ b/crates/interop/vizij-arora-behavior/src/lib.rs
@@ -1,0 +1,144 @@
+//! [`ProcessingGraph`]: a Vizij node graph driven as an Arora
+//! [`Behavior`](arora_behavior::Behavior) (VIZ-34).
+//!
+//! Each tick it reads its subscribed input paths from the shared store (Arora
+//! values → Vizij via [`vizij_arora`]), evaluates the graph for `dt`, and writes
+//! the graph's outputs back (Vizij → Arora). It always reports
+//! [`BehaviorStatus::Running`] — a node graph runs every frame, unlike a tree
+//! that runs to a terminal status.
+//!
+//! Queue one into an Arora runtime with `Runtime::queue_behavior(Box::new(pg))`;
+//! it then reads/writes the same blackboard the behavior tree and the bridge do.
+//!
+
+use arora_behavior::{Behavior, BehaviorContext, BehaviorError, BehaviorStatus};
+use arora_types::data::{DataStore, Key, StateChange};
+use vizij_api_core::TypedPath;
+use vizij_graph_core::eval::{evaluate_all, GraphRuntime};
+use vizij_graph_core::types::GraphSpec;
+
+/// A Vizij node graph as an Arora behavior.
+pub struct ProcessingGraph {
+    spec: GraphSpec,
+    rt: GraphRuntime,
+    /// Store paths staged into the graph before each evaluation.
+    inputs: Vec<TypedPath>,
+}
+
+impl ProcessingGraph {
+    /// Wrap a graph spec plus the store paths it consumes as inputs.
+    pub fn from_spec(spec: GraphSpec, inputs: Vec<TypedPath>) -> Self {
+        Self {
+            spec: spec.with_cache(),
+            rt: GraphRuntime::default(),
+            inputs,
+        }
+    }
+
+    /// Tick the graph against `store` for `dt`: read subscribed inputs, evaluate,
+    /// write outputs. This is the inherent method behind the [`Behavior`] impl —
+    /// handy for driving a graph directly and for tests.
+    pub fn tick_store(&mut self, store: &dyn DataStore, dt: f32) -> Result<(), BehaviorError> {
+        let delta = if dt.is_finite() { dt.max(0.0) } else { 0.0 };
+        self.rt.dt = delta;
+        self.rt.t += delta;
+
+        // Read subscribed inputs from the store and stage them into the graph.
+        for tp in &self.inputs {
+            let key = Key::new(tp.to_string());
+            if let Some(value) = store
+                .read(std::slice::from_ref(&key))
+                .into_iter()
+                .next()
+                .flatten()
+            {
+                let vizij = vizij_arora::from_arora(&value).map_err(conv)?;
+                self.rt.set_input(tp.clone(), vizij, None);
+            }
+        }
+
+        evaluate_all(&mut self.rt, &self.spec).map_err(|message| BehaviorError { message })?;
+
+        // Write the graph's outputs back to the store.
+        let writes = std::mem::take(&mut self.rt.writes);
+        let mut change = StateChange::new();
+        for op in writes.iter() {
+            let value = vizij_arora::to_arora(&op.value).map_err(conv)?;
+            change
+                .set
+                .insert(Key::new(op.path.to_string()), Some(value));
+        }
+        store.write(change).map_err(|e| BehaviorError {
+            message: e.to_string(),
+        })?;
+        Ok(())
+    }
+}
+
+impl Behavior for ProcessingGraph {
+    fn tick(&mut self, ctx: &mut BehaviorContext) -> Result<BehaviorStatus, BehaviorError> {
+        self.tick_store(ctx.store, ctx.dt)?;
+        // A node graph is continuous: tick it again next step.
+        Ok(BehaviorStatus::Running)
+    }
+}
+
+fn conv(e: vizij_arora::ConversionError) -> BehaviorError {
+    BehaviorError {
+        message: e.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arora_simple_data_store::SimpleDataStore;
+    use arora_types::value::Value as AValue;
+    use serde_json::json;
+    use vizij_api_core::Value as VValue;
+
+    fn passthrough(input: &str, output: &str) -> GraphSpec {
+        let mut spec = json!({
+            "nodes": [
+                { "id": "in",  "type": "input",  "params": { "path": input } },
+                { "id": "out", "type": "output", "params": { "path": output } }
+            ],
+            "edges": [
+                { "from": { "node_id": "in" }, "to": { "node_id": "out", "input": "in" } }
+            ]
+        });
+        vizij_api_core::json::normalize_graph_spec_value(&mut spec).expect("normalize");
+        serde_json::from_value(spec).expect("graph spec")
+    }
+
+    fn read(store: &SimpleDataStore, path: &str) -> Option<AValue> {
+        store.read(&[Key::from(path)]).into_iter().next().flatten()
+    }
+
+    #[test]
+    fn graph_reads_and_writes_the_arora_store() {
+        let store = SimpleDataStore::new();
+        let mut graph = ProcessingGraph::from_spec(
+            passthrough("sensor/x", "actuator/y"),
+            vec![TypedPath::parse("sensor/x").unwrap()],
+        );
+
+        // A scalar flows store -> graph -> store.
+        store
+            .write(StateChange::set(
+                "sensor/x",
+                vizij_arora::to_arora(&VValue::Float(0.75)).unwrap(),
+            ))
+            .unwrap();
+        graph.tick_store(&store, 0.016).expect("tick");
+        assert_eq!(read(&store, "actuator/y"), Some(AValue::F32(0.75)));
+
+        // A Vizij composite flows through as a Value::Structure too.
+        let vec3 = vizij_arora::to_arora(&VValue::Vec3([1.0, 2.0, 3.0])).unwrap();
+        store
+            .write(StateChange::set("sensor/x", vec3.clone()))
+            .unwrap();
+        graph.tick_store(&store, 0.016).expect("tick");
+        assert_eq!(read(&store, "actuator/y"), Some(vec3));
+    }
+}

--- a/crates/interop/vizij-arora-hal/Cargo.toml
+++ b/crates/interop/vizij-arora-hal/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "vizij-arora-hal"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+description = "Vizij rig presented as an Arora HAL (arora-hal)."
+
+[dependencies]
+arora-hal = "0.1"
+arora-types = "1"
+async-trait = "0.1"
+vizij-arora = { path = "../vizij-arora" }
+vizij-api-core = { path = "../../api/vizij-api-core" }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/interop/vizij-arora-hal/src/lib.rs
+++ b/crates/interop/vizij-arora-hal/src/lib.rs
@@ -1,0 +1,201 @@
+//! [`RigHal`]: a Vizij rig presented as an Arora
+//! [`Hal`](arora_hal::Hal) (+ [`HalAssets`](arora_hal::HalAssets)).
+//!
+//! In Vizij-on-Arora terms the "device" is a GLB rig: the runtime's behavior
+//! writes actuator targets (bone transforms, morph weights), the HAL applies
+//! them, and a renderer reads what to draw. This HAL is that boundary on the
+//! Rust side — it holds the GLB, accumulates the latest actuation `State`
+//! (Arora values), and feeds [`updates`](arora_hal::Hal::updates) so a renderer
+//! knows what changed. [`RigHal::pose`] exposes that state as native Vizij
+//! values (via [`vizij_arora`]) for a Vizij renderer; the actual bone/morph
+//! application stays in the renderer.
+//!
+//! Modelled on `arora-hal`'s `FakeHal`: cheaply cloneable, clones share state,
+//! std-channel update feed.
+
+use std::sync::mpsc::{channel, Sender};
+use std::sync::{Arc, Mutex};
+
+use arora_hal::{Hal, HalAssets, HalDescription, HalResult};
+use arora_types::data::{Key, State, StateChange, Subscription};
+use arora_types::value::Value as AValue;
+use async_trait::async_trait;
+use vizij_api_core::{TypedPath, Value as VValue};
+
+#[derive(Default)]
+struct Inner {
+    description: HalDescription,
+    model_glb: Option<Vec<u8>>,
+    /// Latest actuation targets the rig has been driven to (Arora values).
+    state: State,
+    subscribers: Vec<Sender<StateChange>>,
+}
+
+impl Inner {
+    fn notify(&mut self, change: &StateChange) {
+        if change.is_empty() {
+            return;
+        }
+        self.subscribers
+            .retain(|tx| tx.send(change.clone()).is_ok());
+    }
+}
+
+/// A Vizij rig as an Arora HAL. Clone to share the same rig.
+#[derive(Clone, Default)]
+pub struct RigHal {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl RigHal {
+    /// An empty rig HAL with no model and no description.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A rig HAL with device metadata (model family / versions).
+    pub fn with_description(description: HalDescription) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Inner {
+                description,
+                ..Default::default()
+            })),
+        }
+    }
+
+    /// Attach (or replace) the GLB model served by [`HalAssets::model_glb`].
+    pub fn set_model_glb(&self, glb: Vec<u8>) {
+        self.inner.lock().unwrap().model_glb = Some(glb);
+    }
+
+    /// The current rig pose as native Vizij values, for a Vizij renderer.
+    /// Entries whose path or value cannot be converted are skipped.
+    pub fn pose(&self) -> Vec<(TypedPath, VValue)> {
+        let inner = self.inner.lock().unwrap();
+        inner
+            .state
+            .iter()
+            .filter_map(|(key, value)| {
+                let arora = value.as_ref()?;
+                let tp = TypedPath::parse(&key.path).ok()?;
+                let vizij = vizij_arora::from_arora(arora).ok()?;
+                Some((tp, vizij))
+            })
+            .collect()
+    }
+}
+
+#[async_trait]
+impl Hal for RigHal {
+    async fn describe(&self) -> HalDescription {
+        self.inner.lock().unwrap().description.clone()
+    }
+
+    async fn read(&self, keys: &[Key]) -> HalResult<Vec<Option<AValue>>> {
+        let inner = self.inner.lock().unwrap();
+        Ok(keys
+            .iter()
+            .map(|k| inner.state.get(k).cloned().flatten())
+            .collect())
+    }
+
+    async fn read_all(&self) -> HalResult<State> {
+        Ok(self.inner.lock().unwrap().state.clone())
+    }
+
+    async fn write(&self, changes: StateChange) -> HalResult<()> {
+        if changes.is_empty() {
+            return Ok(());
+        }
+        let mut inner = self.inner.lock().unwrap();
+        inner.state.apply(changes.clone());
+        inner.notify(&changes);
+        Ok(())
+    }
+
+    fn updates(&self) -> Subscription {
+        let (tx, rx) = channel();
+        self.inner.lock().unwrap().subscribers.push(tx);
+        Subscription::new(rx)
+    }
+}
+
+#[async_trait]
+impl HalAssets for RigHal {
+    async fn model_glb(&self) -> HalResult<Option<Vec<u8>>> {
+        Ok(self.inner.lock().unwrap().model_glb.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn av(v: VValue) -> AValue {
+        vizij_arora::to_arora(&v).unwrap()
+    }
+
+    #[tokio::test]
+    async fn write_target_then_read_and_pose() {
+        let hal = RigHal::new();
+        // Drive a scalar morph and a Vec3 bone translation.
+        hal.write(StateChange::set("mouth/jaw.open", av(VValue::Float(0.8))))
+            .await
+            .unwrap();
+        hal.write(StateChange::set(
+            "head/root.translation",
+            av(VValue::Vec3([0.0, 1.0, 0.0])),
+        ))
+        .await
+        .unwrap();
+
+        // Read back through the Arora value view.
+        assert_eq!(
+            hal.read(&[Key::from("mouth/jaw.open")]).await.unwrap(),
+            vec![Some(AValue::F32(0.8))]
+        );
+
+        // The Vizij renderer sees native Vizij values.
+        let pose = hal.pose();
+        assert!(pose
+            .iter()
+            .any(|(_, v)| matches!(v, VValue::Vec3(a) if *a == [0.0, 1.0, 0.0])));
+        assert!(pose
+            .iter()
+            .any(|(_, v)| matches!(v, VValue::Float(f) if *f == 0.8)));
+    }
+
+    #[tokio::test]
+    async fn updates_feed_sees_writes() {
+        let hal = RigHal::new();
+        let sub = hal.updates();
+        hal.write(StateChange::set("k", av(VValue::Bool(true))))
+            .await
+            .unwrap();
+        assert!(sub.try_iter().any(|c| c.contains(&Key::from("k"))));
+    }
+
+    #[tokio::test]
+    async fn describe_and_model_glb() {
+        let hal = RigHal::with_description(HalDescription {
+            model_family: Some("vizij".into()),
+            ..Default::default()
+        });
+        hal.set_model_glb(b"glTF".to_vec());
+        assert_eq!(hal.describe().await.model_family.as_deref(), Some("vizij"));
+        assert_eq!(hal.model_glb().await.unwrap(), Some(b"glTF".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn clones_share_the_rig() {
+        let hal = RigHal::new();
+        let other = hal.clone();
+        hal.write(StateChange::set("shared", av(VValue::Float(1.0))))
+            .await
+            .unwrap();
+        assert_eq!(
+            other.read(&[Key::from("shared")]).await.unwrap(),
+            vec![Some(AValue::F32(1.0))]
+        );
+    }
+}

--- a/crates/interop/vizij-arora-store/Cargo.toml
+++ b/crates/interop/vizij-arora-store/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "vizij-arora-store"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+description = "Vizij's Blackboard exposed as an Arora DataStore (arora-types)."
+
+[dependencies]
+vizij-arora = { path = "../vizij-arora" }
+vizij-api-core = { path = "../../api/vizij-api-core" }
+vizij-orchestrator-core = { path = "../../orchestrator/vizij-orchestrator-core" }
+arora-types = "1"

--- a/crates/interop/vizij-arora-store/src/lib.rs
+++ b/crates/interop/vizij-arora-store/src/lib.rs
@@ -1,0 +1,285 @@
+//! [`BlackboardStore`]: Vizij's `Blackboard` exposed as an Arora
+//! [`DataStore`](arora_types::data::DataStore).
+//!
+//! Arora's runtime can be spawned with a custom memory (`Arc<dyn DataStore>`),
+//! so this lets a Vizij `Blackboard` *be* that memory. The `DataStore` interface
+//! speaks the Arora `Value` vocabulary and string [`Key`]s; internally we store
+//! Vizij values keyed by `TypedPath`, bridging each way through
+//! [`vizij_arora`]. The Blackboard's richer provenance (epoch/source/shape) is
+//! kept Vizij-side; the `DataStore` view exposes just the values.
+//!
+//! Like `SimpleDataStore`, this is cheaply cloneable — clones share one store —
+//! and change subscriptions are plain std channels.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{channel, Sender};
+use std::sync::{Arc, Mutex, RwLock};
+
+use arora_types::data::{DataError, DataStore, Key, Slot, State, StateChange, Subscription};
+use arora_types::value::Value as AValue;
+use vizij_api_core::TypedPath;
+use vizij_arora::{from_arora, to_arora};
+use vizij_orchestrator::blackboard::{Blackboard, BlackboardEntry};
+
+/// Source label recorded on entries written through the Arora `DataStore` view.
+const SOURCE: &str = "arora";
+
+struct Inner {
+    blackboard: RwLock<Blackboard>,
+    epoch: AtomicU64,
+    subscribers: Mutex<Vec<Sender<StateChange>>>,
+}
+
+impl Inner {
+    fn next_epoch(&self) -> u64 {
+        self.epoch.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    fn notify(&self, change: StateChange) {
+        if change.is_empty() {
+            return;
+        }
+        let mut subs = self.subscribers.lock().unwrap();
+        subs.retain(|tx| tx.send(change.clone()).is_ok());
+    }
+}
+
+/// A Vizij `Blackboard` presented as an Arora [`DataStore`]. Clone to share.
+#[derive(Clone)]
+pub struct BlackboardStore {
+    inner: Arc<Inner>,
+}
+
+impl Default for BlackboardStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BlackboardStore {
+    /// An empty store backed by a fresh `Blackboard`.
+    pub fn new() -> Self {
+        Self::from_blackboard(Blackboard::new())
+    }
+
+    /// Wrap an existing `Blackboard` (e.g. one an orchestrator already populated).
+    pub fn from_blackboard(blackboard: Blackboard) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                blackboard: RwLock::new(blackboard),
+                epoch: AtomicU64::new(0),
+                subscribers: Mutex::new(Vec::new()),
+            }),
+        }
+    }
+
+    /// Read-only access to the underlying Vizij `Blackboard` (for Vizij-side
+    /// consumers that want the richer entries, not just the Arora value view).
+    pub fn with_blackboard<R>(&self, f: impl FnOnce(&Blackboard) -> R) -> R {
+        f(&self.inner.blackboard.read().unwrap())
+    }
+}
+
+/// Read one Vizij entry as an Arora value (`None` if absent, unparsable, or
+/// not convertible).
+fn read_one(blackboard: &Blackboard, key: &Key) -> Option<AValue> {
+    let tp = TypedPath::parse(&key.path).ok()?;
+    let entry = blackboard.get_tp(&tp)?;
+    to_arora(&entry.value).ok()
+}
+
+/// Apply one `(key, value)` to the blackboard at `epoch`. `None` clears the key.
+fn apply_one(
+    blackboard: &mut Blackboard,
+    key: &Key,
+    value: &Option<AValue>,
+    epoch: u64,
+) -> Result<(), DataError> {
+    match value {
+        Some(av) => {
+            let tp = TypedPath::parse(&key.path)
+                .map_err(|e| DataError::Other(format!("{}: {e}", key.path)))?;
+            let vv = from_arora(av).map_err(|e| DataError::Other(format!("{}: {e}", key.path)))?;
+            blackboard.set_entry(
+                tp,
+                BlackboardEntry::new(vv, None, epoch, SOURCE.to_string(), 0),
+            );
+        }
+        None => {
+            blackboard.remove(&key.path);
+        }
+    }
+    Ok(())
+}
+
+impl DataStore for BlackboardStore {
+    fn read(&self, keys: &[Key]) -> Vec<Option<AValue>> {
+        let blackboard = self.inner.blackboard.read().unwrap();
+        keys.iter().map(|k| read_one(&blackboard, k)).collect()
+    }
+
+    fn write(&self, changes: StateChange) -> Result<(), DataError> {
+        let epoch = self.inner.next_epoch();
+        {
+            let mut blackboard = self.inner.blackboard.write().unwrap();
+            for (key, value) in &changes.set {
+                apply_one(&mut blackboard, key, value, epoch)?;
+            }
+            for key in &changes.unset {
+                blackboard.remove(&key.path);
+            }
+        }
+        self.inner.notify(changes);
+        Ok(())
+    }
+
+    fn snapshot(&self) -> State {
+        let blackboard = self.inner.blackboard.read().unwrap();
+        let storage = blackboard
+            .iter()
+            .filter_map(|(tp, entry)| {
+                let value = to_arora(&entry.value).ok()?;
+                Some((Key::new(tp.to_string()), Some(value)))
+            })
+            .collect();
+        State { storage }
+    }
+
+    fn slot(&self, key: &Key) -> Box<dyn Slot> {
+        Box::new(BlackboardSlot {
+            key: key.clone(),
+            inner: self.inner.clone(),
+        })
+    }
+
+    fn subscribe(&self) -> Subscription {
+        let (tx, rx) = channel();
+        self.inner.subscribers.lock().unwrap().push(tx);
+        Subscription::new(rx)
+    }
+}
+
+/// A handle to one key. The Blackboard does not expose per-cell references, so
+/// the slot re-resolves the path on each access (still hits the same storage).
+struct BlackboardSlot {
+    key: Key,
+    inner: Arc<Inner>,
+}
+
+impl Slot for BlackboardSlot {
+    fn get(&self) -> Option<AValue> {
+        let blackboard = self.inner.blackboard.read().unwrap();
+        read_one(&blackboard, &self.key)
+    }
+
+    fn set(&self, value: Option<AValue>) -> Result<(), DataError> {
+        let epoch = self.inner.next_epoch();
+        {
+            let mut blackboard = self.inner.blackboard.write().unwrap();
+            apply_one(&mut blackboard, &self.key, &value, epoch)?;
+        }
+        self.inner.notify(StateChange {
+            set: HashMap::from([(self.key.clone(), value)]),
+            unset: Default::default(),
+        });
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vizij_api_core::Value as VValue;
+
+    fn av(v: VValue) -> AValue {
+        to_arora(&v).unwrap()
+    }
+
+    #[test]
+    fn write_then_read_primitive_and_composite() {
+        let store = BlackboardStore::new();
+        store
+            .write(StateChange::set("rig/joint.angle", av(VValue::Float(1.5))))
+            .unwrap();
+        assert_eq!(
+            store.read(&[Key::from("rig/joint.angle")]),
+            vec![Some(AValue::F32(1.5))]
+        );
+
+        // A Vizij composite stored as a Value::Structure, round-tripped.
+        let vec3 = av(VValue::Vec3([1.0, 2.0, 3.0]));
+        store
+            .write(StateChange::set("rig/pos", vec3.clone()))
+            .unwrap();
+        assert_eq!(store.read(&[Key::from("rig/pos")]), vec![Some(vec3)]);
+
+        // Internally it is a Vizij Vec3 (not an opaque blob).
+        store.with_blackboard(|bb| {
+            let entry = bb.get("rig/pos").expect("entry");
+            assert!(matches!(entry.value, VValue::Vec3(_)));
+            assert_eq!(entry.source, "arora");
+        });
+
+        assert_eq!(store.read(&[Key::from("absent")]), vec![None]);
+    }
+
+    #[test]
+    fn unset_clears_the_key() {
+        let store = BlackboardStore::new();
+        store
+            .write(StateChange::set("g", av(VValue::Bool(true))))
+            .unwrap();
+        let mut change = StateChange::new();
+        change.unset.insert(Key::from("g"));
+        store.write(change).unwrap();
+        assert_eq!(store.read(&[Key::from("g")]), vec![None]);
+    }
+
+    #[test]
+    fn slot_and_store_coincide() {
+        let store = BlackboardStore::new();
+        let slot = store.slot(&Key::from("x"));
+        slot.set(Some(av(VValue::Float(2.0)))).unwrap();
+        assert_eq!(store.read(&[Key::from("x")]), vec![Some(AValue::F32(2.0))]);
+        store
+            .write(StateChange::set("x", av(VValue::Float(3.0))))
+            .unwrap();
+        assert_eq!(slot.get(), Some(AValue::F32(3.0)));
+    }
+
+    #[test]
+    fn subscribe_delivers_changes() {
+        let store = BlackboardStore::new();
+        let sub = store.subscribe();
+        store
+            .write(StateChange::set("k", av(VValue::Bool(true))))
+            .unwrap();
+        assert!(sub.try_recv().expect("change").contains(&Key::from("k")));
+    }
+
+    #[test]
+    fn snapshot_returns_all() {
+        let store = BlackboardStore::new();
+        store
+            .write(StateChange::set("a", av(VValue::Float(1.0))))
+            .unwrap();
+        store
+            .write(StateChange::set("b", av(VValue::Float(2.0))))
+            .unwrap();
+        assert_eq!(store.snapshot().storage.len(), 2);
+    }
+
+    #[test]
+    fn clones_share_storage() {
+        let store = BlackboardStore::new();
+        let other = store.clone();
+        store
+            .write(StateChange::set("shared", av(VValue::Bool(true))))
+            .unwrap();
+        assert_eq!(
+            other.read(&[Key::from("shared")]),
+            vec![Some(AValue::Boolean(true))]
+        );
+    }
+}

--- a/crates/interop/vizij-arora/Cargo.toml
+++ b/crates/interop/vizij-arora/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "vizij-arora"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+description = "Conversion between Vizij values (vizij-api-core) and the Arora Value vocabulary (arora-types)."
+
+[dependencies]
+vizij-api-core = { path = "../../api/vizij-api-core" }
+arora-types = "1"
+uuid = "1"
+thiserror = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/interop/vizij-arora/src/lib.rs
+++ b/crates/interop/vizij-arora/src/lib.rs
@@ -1,0 +1,327 @@
+//! Conversion between Vizij values (`vizij_api_core::Value`) and the Arora
+//! `Value` vocabulary (`arora_types::value::Value`).
+//!
+//! Vizij's graphics-flavoured composites (`Vec2`/`Vec3`/`Vec4`/`Quat`/
+//! `ColorRgba`/`Transform`) have no Arora primitive, so they map to
+//! `Value::Structure` with stable type/field ids — the same shape the
+//! `arora-module-cli` generator emits for the declared Arora types (see
+//! VIZ-39 / arora-sdk#100). Primitives map directly (`Float`->`F32`, ...).
+//!
+//! `Value` carries no metadata, so a value's `Shape.meta` (unit/space/range/
+//! color_space) rides a **sidecar key** `"/meta/<path>"` -- see [`meta_key`].
+//!
+//! The ids below are placeholders chosen to be stable and collision-free; they
+//! are intended to be unified with the canonical Arora type records once those
+//! land (VIZ-39).
+
+use std::collections::HashMap;
+
+use arora_types::value::{Structure, StructureField, Value as AValue};
+use uuid::Uuid;
+use vizij_api_core::{Shape, Value as VValue};
+
+/// Failures converting between the two `Value` vocabularies.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ConversionError {
+    /// The Vizij value has no Arora mapping yet.
+    #[error("no Arora mapping for Vizij value `{0}`")]
+    UnsupportedVizij(&'static str),
+    /// The Arora value has no Vizij mapping.
+    #[error("no Vizij mapping for this Arora value")]
+    UnsupportedArora,
+    /// A `Value::Structure` carried a type id we do not recognise.
+    #[error("unknown Arora structure type id {0}")]
+    UnknownStructure(Uuid),
+    /// A structure was missing an expected field.
+    #[error("structure {ty} is missing field {field}")]
+    MissingField { ty: Uuid, field: Uuid },
+    /// A structure field held an unexpected value kind.
+    #[error("structure field {field} has an unexpected value kind")]
+    FieldKind { field: Uuid },
+}
+
+// ---- declared type / field ids ------------------------------------------------
+
+const fn id(n: u128) -> Uuid {
+    Uuid::from_u128(n)
+}
+
+const VEC2_TYPE: Uuid = id(0x0002);
+const VEC2_FIELDS: [Uuid; 2] = [id(0x0002_0001), id(0x0002_0002)];
+
+const VEC3_TYPE: Uuid = id(0x0003);
+const VEC3_FIELDS: [Uuid; 3] = [id(0x0003_0001), id(0x0003_0002), id(0x0003_0003)];
+
+const VEC4_TYPE: Uuid = id(0x0004);
+const VEC4_FIELDS: [Uuid; 4] = [
+    id(0x0004_0001),
+    id(0x0004_0002),
+    id(0x0004_0003),
+    id(0x0004_0004),
+];
+
+const QUAT_TYPE: Uuid = id(0x0010);
+const QUAT_FIELDS: [Uuid; 4] = [
+    id(0x0010_0001),
+    id(0x0010_0002),
+    id(0x0010_0003),
+    id(0x0010_0004),
+];
+
+const COLOR_TYPE: Uuid = id(0x0020);
+const COLOR_FIELDS: [Uuid; 4] = [
+    id(0x0020_0001),
+    id(0x0020_0002),
+    id(0x0020_0003),
+    id(0x0020_0004),
+];
+
+const TRANSFORM_TYPE: Uuid = id(0x0030);
+const TRANSFORM_TRANSLATION: Uuid = id(0x0030_0001);
+const TRANSFORM_ROTATION: Uuid = id(0x0030_0002);
+const TRANSFORM_SCALE: Uuid = id(0x0030_0003);
+
+// ---- Vizij -> Arora -----------------------------------------------------------
+
+/// Convert a Vizij value into the Arora `Value` vocabulary.
+pub fn to_arora(value: &VValue) -> Result<AValue, ConversionError> {
+    Ok(match value {
+        VValue::Float(f) => AValue::F32(*f),
+        VValue::Bool(b) => AValue::Boolean(*b),
+        VValue::Text(s) => AValue::String(s.clone()),
+        VValue::Vector(xs) => AValue::ArrayF32(xs.clone()),
+        VValue::Vec2(a) => vec_struct(VEC2_TYPE, &VEC2_FIELDS, a),
+        VValue::Vec3(a) => vec_struct(VEC3_TYPE, &VEC3_FIELDS, a),
+        VValue::Vec4(a) => vec_struct(VEC4_TYPE, &VEC4_FIELDS, a),
+        VValue::Quat(a) => vec_struct(QUAT_TYPE, &QUAT_FIELDS, a),
+        VValue::ColorRgba(a) => vec_struct(COLOR_TYPE, &COLOR_FIELDS, a),
+        VValue::Transform {
+            translation,
+            rotation,
+            scale,
+        } => structure(
+            TRANSFORM_TYPE,
+            vec![
+                (
+                    TRANSFORM_TRANSLATION,
+                    vec_struct(VEC3_TYPE, &VEC3_FIELDS, translation),
+                ),
+                (
+                    TRANSFORM_ROTATION,
+                    vec_struct(QUAT_TYPE, &QUAT_FIELDS, rotation),
+                ),
+                (TRANSFORM_SCALE, vec_struct(VEC3_TYPE, &VEC3_FIELDS, scale)),
+            ],
+        ),
+        other => return Err(ConversionError::UnsupportedVizij(vizij_variant_name(other))),
+    })
+}
+
+fn vec_struct(ty: Uuid, fields: &[Uuid], comps: &[f32]) -> AValue {
+    structure(
+        ty,
+        fields
+            .iter()
+            .zip(comps)
+            .map(|(id, c)| (*id, AValue::F32(*c)))
+            .collect(),
+    )
+}
+
+fn structure(id: Uuid, fields: Vec<(Uuid, AValue)>) -> AValue {
+    AValue::Structure(Structure {
+        id,
+        fields: fields
+            .into_iter()
+            .map(|(id, value)| StructureField {
+                id,
+                value: Box::new(value),
+            })
+            .collect(),
+    })
+}
+
+fn vizij_variant_name(value: &VValue) -> &'static str {
+    match value {
+        VValue::Enum(..) => "Enum",
+        VValue::Record(..) => "Record",
+        VValue::Array(..) => "Array",
+        VValue::List(..) => "List",
+        VValue::Tuple(..) => "Tuple",
+        _ => "unsupported",
+    }
+}
+
+// ---- Arora -> Vizij -----------------------------------------------------------
+
+/// Convert an Arora value into a Vizij value.
+pub fn from_arora(value: &AValue) -> Result<VValue, ConversionError> {
+    Ok(match value {
+        AValue::F32(f) => VValue::Float(*f),
+        AValue::F64(f) => VValue::Float(*f as f32),
+        AValue::Boolean(b) => VValue::Bool(*b),
+        AValue::String(s) => VValue::Text(s.clone()),
+        AValue::ArrayF32(xs) => VValue::Vector(xs.clone()),
+        AValue::Structure(s) => structure_to_vizij(s)?,
+        _ => return Err(ConversionError::UnsupportedArora),
+    })
+}
+
+fn structure_to_vizij(s: &Structure) -> Result<VValue, ConversionError> {
+    let ty = s.id;
+    Ok(if ty == VEC2_TYPE {
+        VValue::Vec2(read_array(s, &VEC2_FIELDS)?)
+    } else if ty == VEC3_TYPE {
+        VValue::Vec3(read_array(s, &VEC3_FIELDS)?)
+    } else if ty == VEC4_TYPE {
+        VValue::Vec4(read_array(s, &VEC4_FIELDS)?)
+    } else if ty == QUAT_TYPE {
+        VValue::Quat(read_array(s, &QUAT_FIELDS)?)
+    } else if ty == COLOR_TYPE {
+        VValue::ColorRgba(read_array(s, &COLOR_FIELDS)?)
+    } else if ty == TRANSFORM_TYPE {
+        VValue::Transform {
+            translation: read_array(read_struct(s, TRANSFORM_TRANSLATION)?, &VEC3_FIELDS)?,
+            rotation: read_array(read_struct(s, TRANSFORM_ROTATION)?, &QUAT_FIELDS)?,
+            scale: read_array(read_struct(s, TRANSFORM_SCALE)?, &VEC3_FIELDS)?,
+        }
+    } else {
+        return Err(ConversionError::UnknownStructure(ty));
+    })
+}
+
+fn read_array<const N: usize>(
+    s: &Structure,
+    fields: &[Uuid; N],
+) -> Result<[f32; N], ConversionError> {
+    let mut out = [0.0f32; N];
+    for (slot, field_id) in out.iter_mut().zip(fields) {
+        *slot = read_f32(s, *field_id)?;
+    }
+    Ok(out)
+}
+
+fn read_f32(s: &Structure, field: Uuid) -> Result<f32, ConversionError> {
+    let entry = s
+        .fields
+        .iter()
+        .find(|f| f.id == field)
+        .ok_or(ConversionError::MissingField { ty: s.id, field })?;
+    match entry.value.as_ref() {
+        AValue::F32(v) => Ok(*v),
+        AValue::F64(v) => Ok(*v as f32),
+        _ => Err(ConversionError::FieldKind { field }),
+    }
+}
+
+fn read_struct(s: &Structure, field: Uuid) -> Result<&Structure, ConversionError> {
+    let entry = s
+        .fields
+        .iter()
+        .find(|f| f.id == field)
+        .ok_or(ConversionError::MissingField { ty: s.id, field })?;
+    match entry.value.as_ref() {
+        AValue::Structure(inner) => Ok(inner),
+        _ => Err(ConversionError::FieldKind { field }),
+    }
+}
+
+// ---- /meta sidecar ------------------------------------------------------------
+
+/// The sidecar key carrying the metadata for the value stored at `data_path`.
+///
+/// Arora's `Value` has no place for `Shape.meta` (unit/space/range/color_space),
+/// so it travels the same store under a reserved `"/meta/"` namespace.
+pub fn meta_key(data_path: &str) -> String {
+    format!("/meta/{}", data_path.trim_start_matches('/'))
+}
+
+/// Encode a value's shape metadata for the sidecar key, if any is present.
+pub fn encode_shape_meta(shape: &Shape) -> Option<AValue> {
+    if shape.meta.is_empty() {
+        return None;
+    }
+    serde_json::to_string(&shape.meta).ok().map(AValue::String)
+}
+
+/// Decode shape metadata previously written to a sidecar key.
+pub fn decode_shape_meta(value: &AValue) -> Option<HashMap<String, String>> {
+    match value {
+        AValue::String(s) => serde_json::from_str(s).ok(),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vizij_api_core::ShapeId;
+
+    fn round_trip(v: VValue) {
+        let a = to_arora(&v).expect("to_arora");
+        let back = from_arora(&a).expect("from_arora");
+        assert_eq!(back, v);
+    }
+
+    #[test]
+    fn primitives_round_trip() {
+        round_trip(VValue::Float(1.5));
+        round_trip(VValue::Bool(true));
+        round_trip(VValue::Text("hi".into()));
+        round_trip(VValue::Vector(vec![1.0, 2.0, 3.0]));
+    }
+
+    #[test]
+    fn composites_round_trip() {
+        round_trip(VValue::Vec2([1.0, 2.0]));
+        round_trip(VValue::Vec3([1.0, 2.0, 3.0]));
+        round_trip(VValue::Vec4([1.0, 2.0, 3.0, 4.0]));
+        round_trip(VValue::Quat([0.0, 0.0, 0.0, 1.0]));
+        round_trip(VValue::ColorRgba([0.1, 0.2, 0.3, 1.0]));
+        round_trip(VValue::Transform {
+            translation: [1.0, 2.0, 3.0],
+            rotation: [0.0, 0.0, 0.0, 1.0],
+            scale: [1.0, 1.0, 1.0],
+        });
+    }
+
+    #[test]
+    fn vec3_becomes_structure() {
+        let a = to_arora(&VValue::Vec3([1.0, 2.0, 3.0])).unwrap();
+        assert!(matches!(a, AValue::Structure(_)));
+    }
+
+    #[test]
+    fn unsupported_vizij_is_reported() {
+        let err = to_arora(&VValue::Record(Default::default())).unwrap_err();
+        assert_eq!(err, ConversionError::UnsupportedVizij("Record"));
+    }
+
+    #[test]
+    fn unknown_structure_is_reported() {
+        let s = AValue::Structure(Structure {
+            id: Uuid::from_u128(0x9999),
+            fields: vec![],
+        });
+        assert!(matches!(
+            from_arora(&s),
+            Err(ConversionError::UnknownStructure(_))
+        ));
+    }
+
+    #[test]
+    fn meta_sidecar_round_trips() {
+        assert_eq!(
+            meta_key("standard/semio/mouth.x"),
+            "/meta/standard/semio/mouth.x"
+        );
+        let shape = Shape::new(ShapeId::Vec3)
+            .with_meta("unit", "radians")
+            .with_meta("space", "head");
+        let encoded = encode_shape_meta(&shape).expect("some meta");
+        let decoded = decode_shape_meta(&encoded).expect("decoded");
+        assert_eq!(decoded.get("unit").map(String::as_str), Some("radians"));
+        assert_eq!(decoded.get("space").map(String::as_str), Some("head"));
+        assert!(encode_shape_meta(&Shape::new(ShapeId::Scalar)).is_none());
+    }
+}

--- a/crates/interop/vizij-arora/src/lib.rs
+++ b/crates/interop/vizij-arora/src/lib.rs
@@ -10,6 +10,13 @@
 //! `Value` carries no metadata, so a value's `Shape.meta` (unit/space/range/
 //! color_space) rides a **sidecar key** `"/meta/<path>"` -- see [`meta_key`].
 //!
+//! Vizij's *recursive* composites convert structurally, to arbitrary depth:
+//! `Record` <-> `Value::KeyValue` (string-keyed, field ids derived from the
+//! key names), `List`/`Array`/`Tuple` -> `Value::ArrayValue`, and `Enum` <->
+//! a tagged `Value::Structure`. Arora's `ArrayValue` has a single sequence
+//! kind, so `Array` and `Tuple` come back as `List`; the declared `Shape` of
+//! the path, not the wire value, is what preserves that distinction.
+//!
 //! The ids below are **Vizij type ids** — UUIDs namespaced under the ASCII
 //! bytes of "vizij" so they are self-identifying and collision-free. They are
 //! the source of truth for Vizij's structured values. An equivalent
@@ -19,6 +26,8 @@
 
 use std::collections::HashMap;
 
+use arora_types::gen_uuid_from_str;
+use arora_types::keyvalue::{KeyValue, KeyValueField};
 use arora_types::value::{Structure, StructureField, Value as AValue};
 use uuid::Uuid;
 use vizij_api_core::{Shape, Value as VValue};
@@ -26,9 +35,6 @@ use vizij_api_core::{Shape, Value as VValue};
 /// Failures converting between the two `Value` vocabularies.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ConversionError {
-    /// The Vizij value has no Arora mapping yet.
-    #[error("no Arora mapping for Vizij value `{0}`")]
-    UnsupportedVizij(&'static str),
     /// The Arora value has no Vizij mapping.
     #[error("no Vizij mapping for this Arora value")]
     UnsupportedArora,
@@ -83,6 +89,12 @@ const COLOR_FIELDS: [Uuid; 4] = [
     id(0x0020_0004),
 ];
 
+const ENUM_TYPE: Uuid = id(0x0040);
+const ENUM_TAG: Uuid = id(0x0040_0001);
+const ENUM_VALUE: Uuid = id(0x0040_0002);
+
+const RECORD_TYPE: Uuid = id(0x0050);
+
 const TRANSFORM_TYPE: Uuid = id(0x0030);
 const TRANSFORM_TRANSLATION: Uuid = id(0x0030_0001);
 const TRANSFORM_ROTATION: Uuid = id(0x0030_0002);
@@ -120,7 +132,36 @@ pub fn to_arora(value: &VValue) -> Result<AValue, ConversionError> {
                 (TRANSFORM_SCALE, vec_struct(VEC3_TYPE, &VEC3_FIELDS, scale)),
             ],
         ),
-        other => return Err(ConversionError::UnsupportedVizij(vizij_variant_name(other))),
+        VValue::Enum(tag, payload) => structure(
+            ENUM_TYPE,
+            vec![
+                (ENUM_TAG, AValue::String(tag.clone())),
+                (ENUM_VALUE, to_arora(payload)?),
+            ],
+        ),
+        VValue::Record(entries) => {
+            let mut fields = HashMap::with_capacity(entries.len());
+            for (key, entry) in entries {
+                fields.insert(
+                    key.clone(),
+                    KeyValueField {
+                        id: gen_uuid_from_str(key),
+                        name: key.clone(),
+                        value: Some(Box::new(to_arora(entry)?)),
+                    },
+                );
+            }
+            AValue::KeyValue(KeyValue {
+                id: RECORD_TYPE,
+                fields,
+            })
+        }
+        VValue::Array(items) | VValue::List(items) | VValue::Tuple(items) => AValue::ArrayValue(
+            items
+                .iter()
+                .map(to_arora)
+                .collect::<Result<Vec<_>, _>>()?,
+        ),
     })
 }
 
@@ -148,17 +189,6 @@ fn structure(id: Uuid, fields: Vec<(Uuid, AValue)>) -> AValue {
     })
 }
 
-fn vizij_variant_name(value: &VValue) -> &'static str {
-    match value {
-        VValue::Enum(..) => "Enum",
-        VValue::Record(..) => "Record",
-        VValue::Array(..) => "Array",
-        VValue::List(..) => "List",
-        VValue::Tuple(..) => "Tuple",
-        _ => "unsupported",
-    }
-}
-
 // ---- Arora -> Vizij -----------------------------------------------------------
 
 /// Convert an Arora value into a Vizij value.
@@ -170,6 +200,24 @@ pub fn from_arora(value: &AValue) -> Result<VValue, ConversionError> {
         AValue::String(s) => VValue::Text(s.clone()),
         AValue::ArrayF32(xs) => VValue::Vector(xs.clone()),
         AValue::Structure(s) => structure_to_vizij(s)?,
+        AValue::ArrayValue(items) => VValue::List(
+            items
+                .iter()
+                .map(from_arora)
+                .collect::<Result<Vec<_>, _>>()?,
+        ),
+        AValue::KeyValue(kv) => VValue::Record(
+            kv.fields
+                .iter()
+                .map(|(key, field)| {
+                    let value = field
+                        .value
+                        .as_deref()
+                        .ok_or(ConversionError::FieldKind { field: field.id })?;
+                    Ok((key.clone(), from_arora(value)?))
+                })
+                .collect::<Result<_, ConversionError>>()?,
+        ),
         _ => return Err(ConversionError::UnsupportedArora),
     })
 }
@@ -192,6 +240,13 @@ fn structure_to_vizij(s: &Structure) -> Result<VValue, ConversionError> {
             rotation: read_array(read_struct(s, TRANSFORM_ROTATION)?, &QUAT_FIELDS)?,
             scale: read_array(read_struct(s, TRANSFORM_SCALE)?, &VEC3_FIELDS)?,
         }
+    } else if ty == ENUM_TYPE {
+        let tag = match read_field(s, ENUM_TAG)? {
+            AValue::String(tag) => tag.clone(),
+            _ => return Err(ConversionError::FieldKind { field: ENUM_TAG }),
+        };
+        let payload = from_arora(read_field(s, ENUM_VALUE)?)?;
+        VValue::Enum(tag, Box::new(payload))
     } else {
         return Err(ConversionError::UnknownStructure(ty));
     })
@@ -219,6 +274,14 @@ fn read_f32(s: &Structure, field: Uuid) -> Result<f32, ConversionError> {
         AValue::F64(v) => Ok(*v as f32),
         _ => Err(ConversionError::FieldKind { field }),
     }
+}
+
+fn read_field(s: &Structure, field: Uuid) -> Result<&AValue, ConversionError> {
+    s.fields
+        .iter()
+        .find(|f| f.id == field)
+        .map(|f| f.value.as_ref())
+        .ok_or(ConversionError::MissingField { ty: s.id, field })
 }
 
 fn read_struct(s: &Structure, field: Uuid) -> Result<&Structure, ConversionError> {
@@ -299,9 +362,62 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_vizij_is_reported() {
-        let err = to_arora(&VValue::Record(Default::default())).unwrap_err();
-        assert_eq!(err, ConversionError::UnsupportedVizij("Record"));
+    fn record_of_records_round_trips() {
+        // The URDF IK/FK shape: a record of joint -> angle, here nested one
+        // level deeper to prove arbitrary depth.
+        let joints = VValue::Record(
+            [
+                ("shoulder".to_string(), VValue::Float(0.4)),
+                ("elbow".to_string(), VValue::Float(-1.2)),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        let record = VValue::Record(
+            [
+                ("left_arm".to_string(), joints.clone()),
+                ("confidence".to_string(), VValue::Float(0.9)),
+            ]
+            .into_iter()
+            .collect(),
+        );
+
+        let arora = to_arora(&record).unwrap();
+        assert!(matches!(arora, AValue::KeyValue(_)));
+        assert_eq!(from_arora(&arora).unwrap(), record);
+    }
+
+    #[test]
+    fn list_round_trips_and_sequences_collapse_to_list() {
+        let list = VValue::List(vec![
+            VValue::Float(1.0),
+            VValue::Vec3([1.0, 2.0, 3.0]),
+            VValue::Text("mixed".into()),
+        ]);
+        let arora = to_arora(&list).unwrap();
+        assert!(matches!(arora, AValue::ArrayValue(_)));
+        assert_eq!(from_arora(&arora).unwrap(), list);
+
+        // Tuple and Array share ArrayValue on the wire, so they come back as
+        // List: the path's declared Shape carries the distinction instead.
+        let tuple = VValue::Tuple(vec![VValue::Float(1.0), VValue::Bool(true)]);
+        let back = from_arora(&to_arora(&tuple).unwrap()).unwrap();
+        assert_eq!(
+            back,
+            VValue::List(vec![VValue::Float(1.0), VValue::Bool(true)])
+        );
+    }
+
+    #[test]
+    fn enum_round_trips() {
+        let value = VValue::Enum(
+            "grasp".to_string(),
+            Box::new(VValue::Record(
+                [("force".to_string(), VValue::Float(0.5))].into_iter().collect(),
+            )),
+        );
+        let arora = to_arora(&value).unwrap();
+        assert_eq!(from_arora(&arora).unwrap(), value);
     }
 
     #[test]

--- a/crates/interop/vizij-arora/src/lib.rs
+++ b/crates/interop/vizij-arora/src/lib.rs
@@ -10,9 +10,12 @@
 //! `Value` carries no metadata, so a value's `Shape.meta` (unit/space/range/
 //! color_space) rides a **sidecar key** `"/meta/<path>"` -- see [`meta_key`].
 //!
-//! The ids below are placeholders chosen to be stable and collision-free; they
-//! are intended to be unified with the canonical Arora type records once those
-//! land (VIZ-39).
+//! The ids below are **Vizij type ids** — UUIDs namespaced under the ASCII
+//! bytes of "vizij" so they are self-identifying and collision-free. They are
+//! the source of truth for Vizij's structured values. An equivalent
+//! Arora-declared type (identical structural shape) would be linked by mapping
+//! its id onto the matching Vizij id here; nothing in vizij-rs needs to run the
+//! Arora generator for that.
 
 use std::collections::HashMap;
 
@@ -42,8 +45,12 @@ pub enum ConversionError {
 
 // ---- declared type / field ids ------------------------------------------------
 
-const fn id(n: u128) -> Uuid {
-    Uuid::from_u128(n)
+/// Namespace for all Vizij type ids: the ASCII bytes of "vizij"
+/// (`76 69 7a 69 6a`) in the leading bytes, so every id is self-identifying.
+const VIZIJ_NS: u128 = 0x7669_7a69_6a00_0000_0000_0000_0000_0000;
+
+const fn id(offset: u128) -> Uuid {
+    Uuid::from_u128(VIZIJ_NS | offset)
 }
 
 const VEC2_TYPE: Uuid = id(0x0002);

--- a/crates/interop/vizij-arora/src/lib.rs
+++ b/crates/interop/vizij-arora/src/lib.rs
@@ -8,7 +8,7 @@
 //! VIZ-39 / arora-sdk#100). Primitives map directly (`Float`->`F32`, ...).
 //!
 //! `Value` carries no metadata, so a value's `Shape.meta` (unit/space/range/
-//! color_space) rides a **sidecar key** `"/meta/<path>"` -- see [`meta_key`].
+//! color_space) rides a **sidecar key** `"meta/<path>"` -- see [`meta_key`].
 //!
 //! Vizij's *recursive* composites convert structurally, to arbitrary depth:
 //! `Record` <-> `Value::KeyValue` (string-keyed, field ids derived from the
@@ -156,12 +156,9 @@ pub fn to_arora(value: &VValue) -> Result<AValue, ConversionError> {
                 fields,
             })
         }
-        VValue::Array(items) | VValue::List(items) | VValue::Tuple(items) => AValue::ArrayValue(
-            items
-                .iter()
-                .map(to_arora)
-                .collect::<Result<Vec<_>, _>>()?,
-        ),
+        VValue::Array(items) | VValue::List(items) | VValue::Tuple(items) => {
+            AValue::ArrayValue(items.iter().map(to_arora).collect::<Result<Vec<_>, _>>()?)
+        }
     })
 }
 
@@ -301,9 +298,9 @@ fn read_struct(s: &Structure, field: Uuid) -> Result<&Structure, ConversionError
 /// The sidecar key carrying the metadata for the value stored at `data_path`.
 ///
 /// Arora's `Value` has no place for `Shape.meta` (unit/space/range/color_space),
-/// so it travels the same store under a reserved `"/meta/"` namespace.
+/// so it travels the same store under a reserved `"meta/"` namespace. (No leading slash: `TypedPath` rejects an empty first segment, and the sidecar must be storable in a `BlackboardStore`.)
 pub fn meta_key(data_path: &str) -> String {
-    format!("/meta/{}", data_path.trim_start_matches('/'))
+    format!("meta/{}", data_path.trim_start_matches('/'))
 }
 
 /// Encode a value's shape metadata for the sidecar key, if any is present.
@@ -413,7 +410,9 @@ mod tests {
         let value = VValue::Enum(
             "grasp".to_string(),
             Box::new(VValue::Record(
-                [("force".to_string(), VValue::Float(0.5))].into_iter().collect(),
+                [("force".to_string(), VValue::Float(0.5))]
+                    .into_iter()
+                    .collect(),
             )),
         );
         let arora = to_arora(&value).unwrap();
@@ -436,7 +435,7 @@ mod tests {
     fn meta_sidecar_round_trips() {
         assert_eq!(
             meta_key("standard/semio/mouth.x"),
-            "/meta/standard/semio/mouth.x"
+            "meta/standard/semio/mouth.x"
         );
         let shape = Shape::new(ShapeId::Vec3)
             .with_meta("unit", "radians")

--- a/crates/node-graph/vizij-graph-core/src/eval/eval_node.rs
+++ b/crates/node-graph/vizij-graph-core/src/eval/eval_node.rs
@@ -899,7 +899,7 @@ fn prepare_piecewise_breakpoints(
     let mut unique_inputs = Vec::with_capacity(inputs.len());
     let mut unique_outputs = Vec::with_capacity(outputs.len());
 
-    for (idx, (input, output)) in inputs.into_iter().zip(outputs.into_iter()).enumerate() {
+    for (idx, (input, output)) in inputs.into_iter().zip(outputs).enumerate() {
         if let Some(&prev_input) = unique_inputs.last() {
             let delta: f32 = input - prev_input;
             if delta < -PIECEWISE_BREAKPOINT_EPS {

--- a/docs/proposal-vizij-on-arora.md
+++ b/docs/proposal-vizij-on-arora.md
@@ -1,0 +1,607 @@
+# Proposal: running Vizij on Arora (HAL, Behavior, Bridge, DataStore)
+
+Status: draft, for review.
+Date: 2026-06-29.
+Author: Victor (with research help from an LLM agent).
+
+This document proposes how the **Vizij** real-time animation runtime
+(`vizij-rs` + `vizij-web`) can run *on top of Arora* instead of
+reimplementing Arora's concepts, and what Arora must generalize to host
+it. It is the concrete continuation of the `arora-web` thread opened in
+arora-engine `docs/proposal-split-arora-repos.md` §2.4: there we named `arora-web` as the
+`wasm-bindgen` surface that "the Vizij Workspace could depend on
+directly". This proposal works out what that dependency actually looks
+like, end to end.
+
+The thesis is simple: **Vizij and Arora are the same shape.** Vizij has
+independently re-grown three of Arora's four pillars (a device/model, a
+remote-control protocol, an in-memory store) and added a fourth kind of
+behavior content (a data-flow node graph instead of a behavior tree).
+The integration is therefore mostly *recognition and convergence*, plus
+**one genuine generalization in Arora**: turning behavior from a concrete
+struct into a trait so a node graph can be a first-class behavior.
+
+A useful side effect: the APIs we expose for Vizij's *live editing* (live
+data writes, live graph patch/reload) are not Vizij-specific. They are
+the archetypal surface any web app would use to drive an Arora at
+runtime. We design them as such.
+
+## Discussions and Agreements
+
+- **Victor (Value strategy, 2026-06-29):** Vizij's `Shape`/`ShapeId`
+  resemble Arora's value-type system — "specific structured types". They
+  may stay as concrete Vizij Rust types **as long as they convert to and
+  from Arora `Value`**. We should *exercise `arora-module-authoring`* to
+  declare those types and generate the bindings, rather than hand-write a
+  parallel conversion layer. The free-form `meta` part of `Shape`
+  (`unit`/`space`/`range`/`color_space`) is metadata, not type — it
+  belongs in a **distinct sidecar key**, not inside `Value`.
+- _Open for review:_ disposition of Vizij's orchestrator merge semantics
+  (§2.5), and the live-edit op vocabulary on the Bridge (§5).
+
+---
+
+## 1. Context and goal
+
+### 1.1 What Vizij is, in Arora terms
+
+Vizij drives a GLB rig (bones, morph targets) from behavior content (a
+node graph, plus animation clips), and can be controlled remotely over a
+WebSocket. Stripped of vocabulary, that is an Arora: a thing being
+actuated, behavior that computes actuation, a remote that observes and
+commands, and an in-memory store everyone reads and writes.
+
+The mapping is nearly one-to-one:
+
+| Vizij today | Arora concept | Fit |
+| --- | --- | --- |
+| GLB rig + Three.js renderer (actuated; outputs applied to bones/morphs) | **HAL** (`Hal` + `HalAssets::model_glb`) | clean — the renderer *is* a HAL |
+| `arora-connection` / `arora-websocket` (already "the Arora protocol") | **Bridge** (`Bridge`, `BridgeOp::{Get,Update,Call}`) | clean — Vizij's is *richer* (has introspection) |
+| Blackboard (`HashMap<TypedPath, BlackboardEntry>`, conflict logs, subscribe) | **DataStore** (`read`/`write`/`snapshot`/`slot`/`subscribe`) | clean — Vizij's is a *better impl* |
+| Node graph (`GraphSpec` + `GraphRuntime`, `evaluate_all`) | **BehaviorTree** | **the one real seam** — needs a trait |
+| Orchestrator (multi-controller, pass schedule, merge) | _(nothing — Arora has no orchestrator)_ | mostly dissolves into `step()`; merge needs a home |
+
+### 1.2 What we want
+
+1. Vizij reuses Arora wherever Arora already covers the concern (store,
+   bridge, runtime loop, type/codegen tooling), deleting Vizij's
+   parallel implementations.
+2. Arora gains the minimum generality to host (a) a node-graph behavior
+   and (b) Vizij's richer store, **without** absorbing graphics-specific
+   concerns into its core types.
+3. The result runs in two places that matter: the Tauri standalone
+   (native Rust) and the browser (`arora-web`, the `wasm-bindgen`
+   surface). Both drive the same `step()`.
+4. The live-edit APIs that fall out are designed as Arora's general
+   runtime-control surface, not a Vizij one-off.
+
+### 1.3 Non-goals
+
+- Not merging the two `Value` enums into one. Vizij keeps its graphics
+  value types as concrete Rust types (§3).
+- Not pushing graphics semantics (units, color spaces, coordinate
+  frames) into Arora's type system. That metadata stays in a sidecar
+  (§3.3).
+- Not preserving Vizij's `vizij-orchestrator-core` as a long-term crate.
+  Its scheduling dissolves; only its *merge semantics* are load-bearing
+  and need a deliberate home (§2.5).
+
+---
+
+## 2. Concept mapping (Vizij ↔ Arora)
+
+### 2.1 HAL ↔ renderer / model
+
+Arora's `Hal` (`arora-hal/src/lib.rs:61`) is async and interior-mutable:
+
+```rust
+pub trait Hal: Send + Sync {
+    async fn describe(&self) -> HalDescription;
+    async fn read(&self, keys: &[Key]) -> HalResult<Vec<Option<Value>>>;
+    async fn read_all(&self) -> HalResult<State>;
+    async fn write(&self, changes: StateChange) -> HalResult<()>;
+    fn updates(&self) -> Subscription;
+}
+pub trait HalAssets: Send + Sync {
+    async fn model_glb(&self) -> HalResult<Option<Vec<u8>>>;
+}
+```
+
+In Arora the HAL is the robot; in Vizij the "robot" is the GLB rig being
+driven. So **Vizij's renderer is a HAL**:
+
+- `model_glb()` → the loaded GLB (Arora already models the world as a
+  GLB — `HalAssets` exists for exactly this).
+- `write(StateChange)` → apply outputs to the rig (set bone transforms /
+  morph weights). This is the actuation path; in Arora the io-pump calls
+  `hal.write` with the store changes a behavior produced.
+- `read` / `read_all` → current rig state (mostly write-only in practice;
+  read returns last-applied).
+- `updates()` → typically empty for a pure renderer; non-empty if the
+  surface feeds anything back (e.g. picking, measured pose).
+
+The current web data path (`frame.merged_writes` → `store.setValues()` →
+renderer, in `@vizij/runtime-react`) *is* this flow, just spelled
+differently: behavior writes the store, the store change is applied to
+the renderer-as-HAL.
+
+### 2.2 Bridge ↔ WebSocket protocol
+
+Arora's `Bridge` (`arora-bridge/src/lib.rs:106`) carries device-info,
+data-requested, and command streams, with operations:
+
+```rust
+pub enum BridgeOp {
+    Get(Vec<Key>),
+    Update(StateChange),
+    Call(Call),
+}
+```
+
+Vizij's `arora-websocket` messages map straight onto these:
+
+| Vizij `Incoming` | Arora `BridgeOp` |
+| --- | --- |
+| `SetSlotValues { values }` | `Update(StateChange)` |
+| `GetSlotValues { slots }` | `Get(Vec<Key>)` |
+| `Invoke { method, args }` | `Call(Call)` |
+| `ListSlots { path }` | *(none — Arora's Bridge lacks introspection)* |
+| `ListMethods { path }` | *(none)* |
+
+Two findings:
+
+1. Vizij already calls this "the Arora protocol" and even ships a
+   bespoke `AroraConnection` trait + an exclusive-single-client WS
+   server. This is a *parallel reimplementation of `arora-bridge`*. It
+   should become a `WsBridge: arora_bridge::Bridge`, and the bespoke
+   `AroraConnection` trait should be retired. One protocol, one place.
+2. Vizij's protocol is **ahead** of Arora's: it has `ListSlots` /
+   `ListMethods` — *introspection*. That is not noise; it is precisely
+   the live-edit surface (§5). Arora's Bridge should grow it.
+
+### 2.3 DataStore ↔ Blackboard
+
+Arora's store is already a trait (`arora-types/src/data/store.rs:94`):
+
+```rust
+pub trait DataStore: Send + Sync {
+    fn read(&self, keys: &[Key]) -> Vec<Option<Value>>;
+    fn write(&self, changes: StateChange) -> Result<(), DataError>;
+    fn snapshot(&self) -> State;
+    fn slot(&self, key: &Key) -> Box<dyn Slot>;
+    fn subscribe(&self) -> Subscription;
+}
+```
+
+`SimpleDataStore` is just the reference impl. Vizij's Blackboard
+(`HashMap<TypedPath, BlackboardEntry>`, with `BlackboardEntry { value,
+shape, epoch, source, priority }` and `apply_writebatch → Vec<ConflictLog>`)
+is a *richer* `DataStore`: it is provenance-tracked (epoch + writer
+source) and records conflict logs. It becomes an Arora `DataStore` impl,
+and the conflict-log/provenance machinery is a capability Arora gains for
+free.
+
+The only blocker is that `Runtime` hard-codes the field type
+`store: SimpleDataStore` (`arora/src/runtime.rs:104`). That becomes
+`Arc<dyn DataStore>` (or a generic) — a small, contained change (§4.4).
+
+Note the addressing match: Arora `Key { path: String }`
+("namespace/entity.attribute") and Vizij `TypedPath`
+("namespace/.../target.field") are the same path grammar with different
+parsers. They converge on one path type.
+
+### 2.4 Behavior ↔ node graph — the one real seam
+
+This is where Arora must change. Arora's runtime hard-codes
+`trees: VecDeque<BehaviorTree>` and ticks them via `tick_tree()`; there
+is **no `Behavior` trait**. `BehaviorTree` is a concrete struct
+(`arora-behavior-tree/src/behavior_tree.rs:31`) ticked through
+`CallBridge` into modules.
+
+Vizij's node graph is a *different kind of behavior*: `GraphSpec` +
+`GraphRuntime`, driven once per frame by `evaluate_all(rt, spec)` with
+`rt.t`/`rt.dt` set by the caller, inputs staged by `TypedPath`, outputs
+read from `outputs: HashMap<NodeId, HashMap<String, PortValue>>`.
+
+To host it, Arora generalizes behavior to a trait that both the tree and
+the graph implement. Full design in §4. This is the central — and
+essentially the *only* structural — change required in Arora.
+
+### 2.5 The orchestrator dissolves (but its merge does not)
+
+Most of `vizij-orchestrator-core` is replaced by Arora's serial `step()`
+loop. But one responsibility has **no Arora equivalent and is genuinely
+valuable**: when multiple controllers (graphs + animations) write the
+same path in a frame, the orchestrator merges their `WriteBatch`es with a
+*conflict strategy* (`error` / `namespace` / `blend` / `add`) under a
+chosen *schedule* (`SinglePass` / `TwoPass`). Arora ticks **one** behavior
+per step; it has nothing that blends N write batches.
+
+Disposition (recommended, migration-friendly): **wrap the whole
+orchestrator as a single Arora `Behavior` first.** It already has
+`step(dt) -> OrchestratorFrame`; satisfying the trait is immediate and
+preserves all merge semantics on day one. Then, incrementally:
+
+- single-graph cases drop the orchestrator and tick a bare
+  `ProcessingGraph`;
+- the multi-writer *merge* becomes either a `Behavior` combinator
+  (a behavior that composes child behaviors and blends their writes) or,
+  later, a first-class Arora runtime feature.
+
+What we must *not* do is lose the merge strategies in the shuffle. They
+are the one piece of orchestrator IP worth carrying forward.
+
+---
+
+## 3. Value strategy (the linchpin)
+
+### 3.1 What Vizij's `Shape` actually is
+
+`Shape` (`vizij-api-core/src/shape.rs:77`) is **two things bundled**:
+
+```rust
+pub struct Shape {
+    pub id: ShapeId,                       // structural TYPE
+    pub meta: HashMap<String, String>,     // free-form METADATA
+}
+```
+
+- **`ShapeId`** is the *structural type*: `Scalar`, `Bool`, `Vec2/3/4`,
+  `Quat`, `ColorRgba`, `Transform`, `Text`, `Vector{len}`,
+  `Record(fields)`, `Array(inner,len)`, `List(inner)`, `Tuple`, `Enum`.
+  It is **functional**: `shape_helpers.rs` uses it to validate node
+  outputs (`value_matches_shape`, `enforce_output_shapes`) and to infer
+  shapes from values. This is the part that resembles Arora's value-type
+  system.
+- **`meta`** is open-ended annotations (`unit`, `space`, `range`,
+  `color_space`). It is **never read during evaluation** — purely carried
+  for hosts/adapters.
+
+### 3.2 Decision: declare Vizij's types via `arora-module-authoring`
+
+Arora already has the type machinery and the codegen to absorb `ShapeId`
+without a parallel system:
+
+- Arora's `Value` carries `Structure(Structure)` / `Enumeration(...)`,
+  each identified by a UUID; primitives have well-known UUIDs
+  (`arora-types/src/ty/`).
+- `arora-module-authoring` takes a declared type (YAML record) and
+  *generates* the Rust bindings — including `impl Into<Value>` and
+  `impl TryFrom<Value>` per type (`arora-module-authoring/rust/src/lib.rs`),
+  plus the YAML structure/enumeration records that persist the schema in
+  the registry.
+
+So the strategy (per Victor's call) is:
+
+> Keep Vizij's `Vec3` / `Quat` / `Transform` / `ColorRgba` / record types
+> as **concrete Rust types** used inside the node graph. **Declare them as
+> Arora types** via `arora-module-authoring`, which generates the
+> `From`/`Into Value` bindings and the type records. `ShapeId` then maps
+> onto Arora's type system rather than living as a second, parallel type
+> language.
+
+Concretely:
+
+- Vizij's fixed-arity numeric types (`Vec3`, `Quat`, `Transform`,
+  `ColorRgba`) become declared Arora **structure** types (e.g. `Transform`
+  = `{ translation: [f32;3], rotation: [f32;4], scale: [f32;3] }`), each
+  with a stable UUID and generated `Into/TryFrom<Value>`.
+- Vizij's `Enum(tag, payload)` maps to Arora `Enumeration`; `Record` maps
+  to `Structure`; `List`/`Array`/`Tuple` map to Arora's array value
+  variants.
+- `Value::Float/Bool/Text` map to Arora primitives directly.
+
+This is "exercise `arora-module-authoring` to declare types and generate
+bindings" — the tooling already does precisely this; Vizij becomes its
+first cross-project consumer. A bonus: the same declarations can emit the
+TypeScript/`wasm-bindgen` side, keeping the web types in lockstep.
+
+### 3.3 Metadata (`meta`) as a sidecar
+
+Arora has **no** metadata/annotation system — confirmed: neither `Value`,
+`Structure`, `Enumeration`, nor the `Type` descriptor has any place for
+units/ranges/spaces. So `Shape.meta` cannot and should not be folded into
+`Value`. It becomes a **sidecar keyed by path**, e.g. a reserved metadata
+namespace in the same `DataStore`:
+
+```
+/standard/semio/mouth/pos.x          -> Value (the live value)
+/meta/standard/semio/mouth/pos.x     -> KeyValue { unit, space, range, color_space }
+```
+
+Properties of this choice:
+
+- Metadata travels the same store, subscribe, and bridge machinery as
+  data — no new transport.
+- It is *optional* and *sparse*: only annotated paths carry a `/meta/`
+  entry; evaluation never depends on it.
+- A web editor reads `/meta/...` to render units/ranges; the runtime
+  ignores it. This matches how Vizij already treats `meta` (host-only).
+
+(Arora's `KeyValue` value variant is a natural carrier for the sidecar
+payload. If a typed metadata record is preferred later, it too can be a
+declared type.)
+
+### 3.4 What this buys us
+
+- One `Value` on the wire and in the store (Arora's), so Bridge, store,
+  and runtime stay value-agnostic.
+- Vizij code keeps ergonomic concrete types (`Vec3`, …) via generated
+  conversions — no stringly-typed access.
+- No graphics concepts leak into Arora's core. Units and spaces live in a
+  sidecar; structural types live in the registry as ordinary declared
+  types.
+
+---
+
+## 4. The Arora generalization: a `Behavior` trait
+
+### 4.1 Today
+
+`arora/src/runtime.rs` owns `trees: VecDeque<BehaviorTree>` and, each
+step, pops one and calls `tick_tree()`. Behavior is a concrete type; the
+runtime cannot tick anything that is not a `BehaviorTree`.
+
+### 4.2 Proposed `Behavior` trait (sketch)
+
+A behavior is "a thing the runtime ticks against the store each frame".
+The minimal trait:
+
+```rust
+/// A unit of behavior the runtime ticks once per step.
+pub trait Behavior: Send {
+    /// Advance by `dt`, reading and writing `store`. Returns running status.
+    fn tick(&mut self, store: &dyn DataStore, dt: f32) -> Result<Status, BehaviorError>;
+}
+```
+
+- `BehaviorTree` implements it by wrapping its existing
+  `BehaviorTreeRuntime::tick` (it already reads/writes the store and
+  calls modules via `CallBridge`).
+- The runtime holds `behaviors: VecDeque<Box<dyn Behavior>>` (or a single
+  `Box<dyn Behavior>` for the common case) and ticks through the trait.
+
+Live editing adds three optional methods (kept separate so simple
+behaviors need not implement them; see §5):
+
+```rust
+pub trait LiveBehavior: Behavior {
+    /// Apply a fine-grained edit; returns whether a structural reset occurred.
+    fn patch(&mut self, edit: BehaviorEdit) -> Result<PatchOutcome, BehaviorError>;
+    /// Replace the spec wholesale, migrating preserved runtime state where possible.
+    fn load(&mut self, spec: BehaviorSpec) -> Result<(), BehaviorError>;
+    /// Read current structure + live values for an editor (bidirectional sync).
+    fn inspect(&self) -> BehaviorSnapshot;
+}
+```
+
+### 4.3 `ProcessingGraph` (Vizij's node graph as a behavior)
+
+A `ProcessingGraph` wraps `GraphSpec + GraphRuntime` and implements
+`Behavior::tick` as the adapter between Arora's "read/write the store"
+model and Vizij's "stage inputs / evaluate / read outputs" model:
+
+```rust
+impl Behavior for ProcessingGraph {
+    fn tick(&mut self, store: &dyn DataStore, dt: f32) -> Result<Status, BehaviorError> {
+        // 1. read this graph's subscribed input paths from the store
+        for key in &self.input_keys {
+            let v = store.read(std::slice::from_ref(key)).pop().flatten();
+            if let Some(v) = v { self.rt.set_input(key.into(), v, None); }
+        }
+        // 2. evaluate one frame
+        self.rt.dt = dt; self.rt.t += dt;
+        evaluate_all(&mut self.rt, &self.spec)?;
+        // 3. write outputs back as a StateChange
+        let change = outputs_to_state_change(&self.rt, &self.spec);
+        store.write(change).map_err(...)?;
+        Ok(Status::Running)
+    }
+}
+```
+
+`LiveBehavior::patch` maps onto Vizij's existing `set_param(node, key,
+value)` (param-only, keeps the plan cache + node states);
+`LiveBehavior::load` maps onto `load_graph(json)`. The genuinely hard
+part — preserving spring/damp/slew runtime state across a topology change
+— is called out as risk R-3 (§7).
+
+The orchestrator-as-`Behavior` from §2.5 is just another `Behavior` impl
+whose `tick` runs the schedule and merge; it can compose child
+`ProcessingGraph`s.
+
+### 4.4 Runtime takes `Arc<dyn DataStore>`
+
+To let Vizij's Blackboard back the runtime, the hard-coded
+`store: SimpleDataStore` field becomes `store: Arc<dyn DataStore>` (or
+`Runtime<S: DataStore>` if we prefer monomorphization). `with_io(...)`
+gains a store parameter (defaulting to `SimpleDataStore` for existing
+callers). The single-owner step-loop discipline is unchanged — only one
+thread touches the store; the trait object does not introduce sharing.
+
+---
+
+## 5. Live-edit API archetype
+
+The runtime-control surface that Vizij needs is the same surface any web
+app would use to drive an Arora live. We design it generically and
+surface it both over the Bridge (remote) and over `arora-web` (in-process
+JS). There are **two planes**.
+
+### 5.1 Data plane — live value updates (≈90% already present)
+
+Writing/reading live values already exists end to end: `DataStore::write`
++ Bridge `Update`/`Get`. What is missing for an *editor* is introspection
+and observation:
+
+- `list_slots(prefix) -> [SlotInfo]` — enumerate what paths exist and
+  their declared type (Vizij's `ListSlots`; Arora's Bridge lacks it).
+- `subscribe(filter) -> stream<StateChange>` — observe changes so an
+  editor reflects runtime state (Arora's store already has `subscribe`;
+  the Bridge needs to expose a filtered feed).
+
+In `arora-web` (JS):
+
+```ts
+runtime.write(path, value)        // or writeBatch([...])
+runtime.read(paths)
+runtime.listSlots(prefix)
+runtime.subscribe(filter, cb)     // editor reflection
+```
+
+### 5.2 Behavior plane — live graph updates (the new archetype)
+
+This is what Arora does *not* have today and what `LiveBehavior` (§4.2)
+introduces. Three operations, at two granularities:
+
+- **`patch(edit)`** — fine-grained: set a node param, add/remove a
+  node/edge. Returns whether a structural reset was forced. Cheap path
+  preserves runtime state.
+- **`load(spec)`** — wholesale swap; the runtime decides patch-vs-reset
+  and migrates preserved state (node-keyed buffers) where it can.
+- **`inspect()`** — read current structure + live param values for the
+  editor; enables bidirectional sync (runtime → editor), which Vizij
+  lacks today.
+
+In `arora-web` (JS):
+
+```ts
+runtime.patchBehavior(edit)       // { setParam: { node, key, value } } etc.
+runtime.loadBehavior(spec)
+runtime.inspectBehavior()         // structure + live values
+runtime.listMethods(prefix)       // callable surface (Vizij's ListMethods)
+```
+
+### 5.3 Surfacing through the Bridge
+
+The same two planes extend `BridgeOp` so a *remote* editor (Studio, a web
+client) can drive live edits, not just in-process JS:
+
+```rust
+pub enum BridgeOp {
+    Get(Vec<Key>),
+    Update(StateChange),
+    Call(Call),
+    // proposed, for live edit + introspection:
+    ListSlots(Option<Path>),
+    ListMethods(Option<Path>),
+    InspectBehavior(BehaviorRef),
+    PatchBehavior(BehaviorRef, BehaviorEdit),
+    LoadBehavior(BehaviorRef, BehaviorSpec),
+}
+```
+
+These are additive; existing bridges ignore the new variants until they
+implement them. Vizij's `WsBridge` implements them by delegating to the
+runtime's `LiveBehavior`.
+
+### 5.4 Who drives `step()`
+
+Unchanged from Arora's model and Vizij's reality: on native, a thread
+calls `step()` on its cadence with the async io-pump spawned alongside;
+on web, `requestAnimationFrame` (or a worker) calls `step(dt)` — exactly
+what `@vizij/runtime-react` does now. `arora-web` owns this loop and
+exposes the data/behavior plane methods above to JS.
+
+---
+
+## 6. Phased migration plan
+
+Ordered by risk-retired-per-step; each phase is independently valuable
+and leaves both projects building.
+
+**Phase 0 — Spike the seam (lowest risk, highest information).**
+Implement the `Behavior` trait + a `ProcessingGraph` that runs *one* Vizij
+graph against a `SimpleDataStore`, natively, with no orchestrator and no
+bridge. Goal: prove the read-inputs / evaluate / write-outputs adapter
+and surface unknowns (path mapping, value conversion gaps). No Arora
+public API committed yet.
+
+**Phase 1 — Value convergence via `arora-module-authoring`.**
+Declare Vizij's structured types (`Vec3`/`Quat`/`Transform`/`ColorRgba`/
+records) as Arora types; generate `Into/TryFrom<Value>` and the type
+records. Land `outputs_to_state_change` / `state_change_to_inputs` on top
+of the generated conversions. Decide and document the `/meta/` sidecar
+convention (§3.3).
+
+**Phase 2 — `Behavior` trait lands in Arora.**
+Promote the spike: `BehaviorTree` implements `Behavior`; runtime ticks
+`Box<dyn Behavior>`; `store` becomes `Arc<dyn DataStore>`. Existing Arora
+behavior keeps working (regression-gated by the engine's current tests).
+
+**Phase 3 — Blackboard as a `DataStore`.**
+Implement `DataStore` for Vizij's Blackboard (provenance + conflict
+logs). Run a Vizij graph against it through the Phase-2 runtime. Arora
+gains conflict-log capability.
+
+**Phase 4 — Orchestrator-as-`Behavior`, then decompose.**
+Wrap `Orchestrator` as one `Behavior` to preserve merge semantics
+immediately. Then split: single-graph paths tick a bare `ProcessingGraph`;
+multi-writer merge becomes a `Behavior` combinator. Retire
+`vizij-orchestrator-core` as a standalone crate when nothing depends on
+it.
+
+**Phase 5 — Bridge convergence.**
+Reimplement `arora-websocket` as `WsBridge: arora_bridge::Bridge`; retire
+the bespoke `AroraConnection` trait. Add the introspection ops
+(`ListSlots`/`ListMethods`) to `arora-bridge`.
+
+**Phase 6 — Live-edit plane + `arora-web`.**
+Add `LiveBehavior` (`patch`/`load`/`inspect`) and the behavior-plane
+`BridgeOp`s. Expose the data + behavior plane through `arora-web`'s
+`wasm-bindgen` surface, driven by rAF/worker. This replaces
+`vizij-orchestrator-wasm` and the bespoke WS client. Tackle R-3
+(state-preserving reload) here.
+
+At the end, `vizij-rs` is: a set of Arora-declared types, a
+`ProcessingGraph`, a `BlackboardStore`, and a thin renderer-HAL — all
+running on `arora` natively and `arora-web` in the browser.
+
+---
+
+## 7. Risks and open questions
+
+- **R-1 — Value fidelity.** Vizij `Vec3`/`Quat`/`Transform` carry
+  graphics semantics that Arora `Value` represents structurally. Generated
+  conversions must round-trip losslessly. *Mitigation:* Phase 1 ships
+  round-trip property tests per type before anything depends on them.
+- **R-2 — Two path grammars.** `Key` and `TypedPath` are the same idea,
+  different parsers. *Mitigation:* converge on one path type in Phase 1;
+  keep a thin `From`/`Into` shim during migration.
+- **R-3 — State-preserving graph reload (hard).** Live topology edits
+  must migrate node-keyed runtime state (spring/damp/slew buffers).
+  Param-only edits are easy (`set_param`); structural edits today reset.
+  *Mitigation:* `patch` returns whether a reset occurred; full
+  state-migration is a Phase-6 deliverable with its own design note.
+- **R-4 — Merge semantics ownership.** If we decompose the orchestrator
+  too eagerly we can lose `blend`/`add`/`namespace` conflict resolution.
+  *Mitigation:* orchestrator-as-`Behavior` first (Phase 4); decompose
+  only behind tests that assert merge outcomes.
+- **R-5 — Async/sync seam on web.** Arora's `Hal`/`Bridge` are async with
+  an io-pump; the graph evaluates synchronously in `step()`. This already
+  matches Vizij's rAF loop, but the wasm single-thread + `spawn_local`
+  pump must be re-validated for `arora-web` (cf. the existing
+  `arora-web` wasm build notes).
+- **Q-1 — Generic vs trait-object store/behavior?** `Arc<dyn DataStore>`
+  and `Box<dyn Behavior>` keep the runtime simple; generics avoid dynamic
+  dispatch in the hot loop. Recommend trait objects first; measure before
+  optimizing.
+- **Q-2 — Where does the merge combinator live** — `arora` core, a new
+  `arora-compose` crate, or Vizij-side? Defer to Phase 4 evidence.
+
+---
+
+## 8. Summary
+
+Vizij is an Arora that grew up separately. Bringing it home is mostly
+convergence — its store, bridge, and renderer become Arora's `DataStore`,
+`Bridge`, and `Hal` impls — plus **one real generalization**: a
+`Behavior` trait so a node graph is a first-class behavior alongside the
+behavior tree. Vizij's structured types stay concrete and convert through
+Arora `Value` via `arora-module-authoring`-generated bindings; their
+metadata rides a `/meta/` sidecar. The orchestrator dissolves into
+`step()`, keeping only its merge semantics. And the live-edit surface we
+build for Vizij — write/subscribe/list on the data plane,
+patch/load/inspect on the behavior plane, over both the Bridge and
+`arora-web` — is the archetypal way any web app will drive an Arora at
+runtime.


### PR DESCRIPTION
## Why

To run a **Vizij node graph on the Arora runtime**, the graph has to look like something the runtime's step loop drives — a `Behavior` (arora-sdk #105, VIZ-33). This crate is that adapter.

## What

`ProcessingGraph` wraps a Vizij `GraphSpec` + `GraphRuntime` and implements `arora_behavior::Behavior`. Each tick:

1. **read** — for each graph input, read its key from the Arora `DataStore` and `from_arora` it into a `vizij_api_core::Value`, then `set_input`;
2. **evaluate** — `evaluate_all` with `dt`;
3. **write** — `to_arora` each output `Value` and `write` it back to the store.

Value conversion is `vizij-arora` (#19, VIZ-41); composites (e.g. `Vec3`) round-trip as `Value::Structure`. A graph and a behavior tree therefore share one blackboard.

## Tests

`graph_reads_and_writes_the_arora_store` — a scalar and a `Vec3` flow store → graph → store through a `SimpleDataStore`.

## Dependencies

`arora-behavior = "0.1"` / `arora-types = "1"` / `arora-simple-data-store = "0.1"`, all from crates.io — one `Value`/`DataStore` across `vizij-arora` and `arora-behavior`; no git/patch (VIZ-42 done).

> Stacks on **#19** (`vizij-arora`). Depends on arora-sdk **#105** (`arora-behavior`), itself on #104 (ARORA-39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

