### PR TITLE
chore: ignore nested Rust target dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Rust build
-/target
+# Rust build (root workspace + any nested crate, e.g. devices/vizij-device)
+**/target/
 /node_modules
 # wasm-pack output (generated)
 npm/@vizij/animation-wasm/pkg/


### PR DESCRIPTION
Generalize the root `/target` ignore to `**/target/` so per-crate build output (e.g. `devices/vizij-device/target`) is ignored too — not just the workspace-root `target`. Keeps `git status` honest as nested crates are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)