### PR TITLE
feat(viz-53): GraphHost seam + ModuleCall node (Step C)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5857,6 +5857,7 @@ dependencies = [
  "arora-simple-data-store",
  "arora-types",
  "serde_json",
+ "uuid",
  "vizij-api-core",
  "vizij-arora",
  "vizij-graph-core",

--- a/crates/interop/vizij-arora-behavior/Cargo.toml
+++ b/crates/interop/vizij-arora-behavior/Cargo.toml
@@ -13,6 +13,7 @@ vizij-api-core = { path = "../../api/vizij-api-core" }
 vizij-graph-core = { path = "../../node-graph/vizij-graph-core" }
 vizij-orchestrator-core = { path = "../../orchestrator/vizij-orchestrator-core" }
 serde_json = { workspace = true }
+uuid = "1"
 
 [dev-dependencies]
 arora-simple-data-store = "0.1"

--- a/crates/interop/vizij-arora-behavior/src/host.rs
+++ b/crates/interop/vizij-arora-behavior/src/host.rs
@@ -1,0 +1,261 @@
+//! [`AroraGraphHost`]: bind a Vizij node-graph's [`GraphHost`] callout seam to
+//! an Arora [`CallBridge`] (VIZ-53 Step C).
+//!
+//! This is the *only* place arora call-types meet the graph's host seam. The
+//! graph speaks in graph-core's own [`CallTarget`] and Vizij [`VValue`]s;
+//! `AroraGraphHost` translates a [`CallTarget::ModuleFn`] into an arora
+//! [`Call`] (function id + args), marshals args/results with [`vizij_arora`]'s
+//! [`to_arora`](vizij_arora::to_arora)/[`from_arora`](vizij_arora::from_arora),
+//! and dispatches through the bridge — exactly the shape a behavior-tree action
+//! node uses (`caller.arora_call(module, Call { id, args })` -> `CallResult`).
+//!
+//! Args convention: a [`ModuleCall`](vizij_graph_core::types::NodeType::ModuleCall)
+//! node's `args` value is a Vizij [`Record`](VValue::Record) mapping each
+//! parameter's id to its value. A key that parses as a UUID is used directly;
+//! otherwise it is derived with [`gen_uuid_from_str`](arora_types::gen_uuid_from_str)
+//! (the same derivation `vizij-arora` uses for record field ids). The call's
+//! return [`Value`](AValue) becomes the node's output.
+
+use arora_types::call::{Call, CallBridge};
+use arora_types::value::StructureField;
+use uuid::Uuid;
+use vizij_api_core::Value as VValue;
+use vizij_graph_core::host::{CallTarget, GraphHost};
+
+/// Adapts an Arora [`CallBridge`] into a Vizij [`GraphHost`], so a node graph
+/// evaluated with [`evaluate_all_with_host`] can call arora module functions.
+///
+/// [`evaluate_all_with_host`]: vizij_graph_core::eval::evaluate_all_with_host
+pub struct AroraGraphHost<'a> {
+    bridge: &'a mut dyn CallBridge,
+}
+
+impl<'a> AroraGraphHost<'a> {
+    /// Wrap a call bridge (the engine, or a mock) as a graph host.
+    pub fn new(bridge: &'a mut dyn CallBridge) -> Self {
+        Self { bridge }
+    }
+}
+
+impl GraphHost for AroraGraphHost<'_> {
+    fn call(&mut self, target: &CallTarget, args: VValue) -> Result<VValue, String> {
+        match target {
+            CallTarget::ModuleFn { module, function } => {
+                let module = Uuid::parse_str(module)
+                    .map_err(|e| format!("invalid module id '{module}': {e}"))?;
+                let function = Uuid::parse_str(function)
+                    .map_err(|e| format!("invalid function id '{function}': {e}"))?;
+                let args = args_to_fields(&args)?;
+                let result = self
+                    .bridge
+                    .arora_call(
+                        &module,
+                        Call {
+                            module_id: None,
+                            id: function,
+                            args,
+                        },
+                    )
+                    .map_err(|e| e.to_string())?;
+                vizij_arora::from_arora(&result.ret).map_err(|e| e.to_string())
+            }
+            // `CallTarget` is `#[non_exhaustive]`: a future `Behavior` target
+            // (design note §2) would be dispatched here to a named interpreter.
+            other => Err(format!(
+                "unsupported call target for AroraGraphHost: {other:?}"
+            )),
+        }
+    }
+}
+
+/// Convert a `ModuleCall` args value (a Vizij `Record` of param-id -> value)
+/// into the arora `Call`'s `Vec<StructureField>`.
+fn args_to_fields(args: &VValue) -> Result<Vec<StructureField>, String> {
+    match args {
+        VValue::Record(entries) => entries
+            .iter()
+            .map(|(key, value)| {
+                let id =
+                    Uuid::parse_str(key).unwrap_or_else(|_| arora_types::gen_uuid_from_str(key));
+                let value = vizij_arora::to_arora(value).map_err(|e| e.to_string())?;
+                Ok(StructureField {
+                    id,
+                    value: Box::new(value),
+                })
+            })
+            .collect(),
+        other => Err(format!(
+            "ModuleCall args must be a Record of param-id -> value, got {other:?}"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arora_types::call::{CallError, CallResult, Callable, CallableId};
+    use arora_types::value::Value as AValue;
+    use std::rc::Rc;
+    use vizij_graph_core::eval::{evaluate_all_with_host, GraphRuntime};
+    use vizij_graph_core::types::{
+        EdgeInputEndpoint, EdgeOutputEndpoint, EdgeSpec, GraphSpec, NodeParams, NodeSpec, NodeType,
+    };
+
+    // A trivial "echo" module: `arora_call` returns the value of the first arg
+    // unchanged. Enough to prove the seam end to end at the graph level.
+    #[derive(Default)]
+    struct EchoBridge {
+        last_module: Option<Uuid>,
+        last_function: Option<Uuid>,
+    }
+
+    impl CallBridge for EchoBridge {
+        fn arora_call(&mut self, module: &Uuid, call: Call) -> Result<CallResult, CallError> {
+            self.last_module = Some(*module);
+            self.last_function = Some(call.id);
+            let ret = call
+                .args
+                .first()
+                .map(|field| (*field.value).clone())
+                .ok_or(CallError::Generic {
+                    message: "echo module expects at least one arg".into(),
+                })?;
+            Ok(CallResult {
+                ret,
+                mutated: vec![],
+            })
+        }
+        fn arora_register_callable(&mut self, _callable: Rc<dyn Callable>) -> CallableId {
+            unimplemented!("echo bridge registers no callables")
+        }
+        fn arora_unregister_callable(&mut self, _callable_id: &CallableId) {}
+        fn arora_call_indirect(&mut self, _callable_id: &CallableId) -> Result<AValue, CallError> {
+            unimplemented!("echo bridge dispatches no indirect callables")
+        }
+    }
+
+    const MODULE: &str = "76697a69-6a00-0000-0d00-000000000000";
+    const FUNCTION: &str = "76697a69-6a00-0000-0f00-000000000001";
+    const PARAM: &str = "76697a69-6a00-0000-0f01-000000000001";
+
+    /// A graph: Constant(record{PARAM: 0.75}) -> ModuleCall -> Output("result/x").
+    /// The echo module hands the arg value back, so 0.75 must reach both the
+    /// node's `out` port and the `Output` sink's write.
+    fn graph() -> GraphSpec {
+        let args = VValue::Record(
+            [(PARAM.to_string(), VValue::Float(0.75))]
+                .into_iter()
+                .collect(),
+        );
+        GraphSpec {
+            nodes: vec![
+                NodeSpec {
+                    id: "args".into(),
+                    kind: NodeType::Constant,
+                    params: NodeParams {
+                        value: Some(args),
+                        ..Default::default()
+                    },
+                    output_shapes: Default::default(),
+                    input_defaults: Default::default(),
+                },
+                NodeSpec {
+                    id: "call".into(),
+                    kind: NodeType::ModuleCall,
+                    params: NodeParams {
+                        module: Some(MODULE.into()),
+                        function: Some(FUNCTION.into()),
+                        ..Default::default()
+                    },
+                    output_shapes: Default::default(),
+                    input_defaults: Default::default(),
+                },
+                NodeSpec {
+                    id: "out".into(),
+                    kind: NodeType::Output,
+                    params: NodeParams {
+                        path: Some(vizij_api_core::TypedPath::parse("result/x").unwrap()),
+                        ..Default::default()
+                    },
+                    output_shapes: Default::default(),
+                    input_defaults: Default::default(),
+                },
+            ],
+            edges: vec![
+                EdgeSpec {
+                    from: EdgeOutputEndpoint {
+                        node_id: "args".into(),
+                        output: "out".into(),
+                    },
+                    to: EdgeInputEndpoint {
+                        node_id: "call".into(),
+                        input: "args".into(),
+                    },
+                    selector: None,
+                },
+                EdgeSpec {
+                    from: EdgeOutputEndpoint {
+                        node_id: "call".into(),
+                        output: "out".into(),
+                    },
+                    to: EdgeInputEndpoint {
+                        node_id: "out".into(),
+                        input: "in".into(),
+                    },
+                    selector: None,
+                },
+            ],
+            version: 0,
+            fingerprint: 0,
+        }
+    }
+
+    #[test]
+    fn module_call_flows_through_the_call_bridge() {
+        let spec = graph().with_cache();
+        let mut rt = GraphRuntime::default();
+        let mut bridge = EchoBridge::default();
+        let mut host = AroraGraphHost::new(&mut bridge);
+
+        evaluate_all_with_host(&mut rt, &spec, &mut host).expect("evaluation succeeds");
+
+        // The ModuleCall node's output carries the echoed value.
+        let out = rt
+            .outputs
+            .get("call")
+            .and_then(|ports| ports.get("out"))
+            .expect("call node produced an output");
+        assert_eq!(out.value, VValue::Float(0.75));
+
+        // ...and it flows through the Output sink into the write batch.
+        let write = rt
+            .writes
+            .iter()
+            .find(|op| op.path.to_string() == "result/x")
+            .expect("output write emitted");
+        assert_eq!(write.value, VValue::Float(0.75));
+
+        // The host addressed the intended module/function.
+        assert_eq!(bridge.last_module, Some(Uuid::parse_str(MODULE).unwrap()));
+        assert_eq!(
+            bridge.last_function,
+            Some(Uuid::parse_str(FUNCTION).unwrap())
+        );
+    }
+
+    #[test]
+    fn missing_target_params_error_clearly() {
+        // A ModuleCall with no `module` param errors when reached, and the
+        // message names the offending node.
+        let mut spec = graph();
+        spec.nodes[1].params.module = None;
+        let spec = spec.with_cache();
+
+        let mut rt = GraphRuntime::default();
+        let mut bridge = EchoBridge::default();
+        let mut host = AroraGraphHost::new(&mut bridge);
+        let err = evaluate_all_with_host(&mut rt, &spec, &mut host)
+            .expect_err("missing module param should error");
+        assert!(err.contains("missing required 'module'"), "got: {err}");
+    }
+}

--- a/crates/interop/vizij-arora-behavior/src/lib.rs
+++ b/crates/interop/vizij-arora-behavior/src/lib.rs
@@ -17,7 +17,10 @@
 //! [`orchestrator::OrchestratorBehavior`] wraps a whole Vizij orchestrator (many
 //! controllers + their merge) as one `BehaviorInterpreter` (VIZ-38).
 
+pub mod host;
 pub mod orchestrator;
+
+pub use host::AroraGraphHost;
 
 use arora_behavior::{BehaviorContext, BehaviorError, BehaviorInterpreter, BehaviorStatus};
 use arora_types::data::{DataStore, Key, StateChange};

--- a/crates/node-graph/vizij-graph-core/src/eval/eval_node.rs
+++ b/crates/node-graph/vizij-graph-core/src/eval/eval_node.rs
@@ -3,6 +3,7 @@
 use crate::eval::graph_runtime::{GraphRuntime, StagedInput};
 use crate::eval::plan::{PlanCache, PortLayout};
 use crate::eval::variadic::collect_operand_ports;
+use crate::host::{CallTarget, GraphHost};
 use crate::types::{NodeParams, NodeSpec, NodeType, RoundMode};
 use hashbrown::HashMap;
 use vizij_api_core::{coercion, Shape, Value, WriteOp};
@@ -176,13 +177,18 @@ fn single_output(outputs: &mut OutputSlots, value: Value) -> Result<(), String> 
 }
 
 /// Evaluate a single node, updating `rt` with new outputs and queued writes.
+///
+/// `host` is the callout seam used by [`NodeType::ModuleCall`] nodes; nodes that
+/// do not call out ignore it entirely, so a [`NoHost`](crate::host::NoHost) is
+/// perfectly fine for host-less graphs.
 pub fn eval_node(
     rt: &mut GraphRuntime,
     spec: &NodeSpec,
     inputs: &InputSlots,
     outputs: &mut OutputSlots,
+    host: &mut dyn GraphHost,
 ) -> Result<(), String> {
-    evaluate_kind(rt, spec, inputs, outputs)?;
+    evaluate_kind(rt, spec, inputs, outputs, host)?;
     enforce_output_shapes_slots(spec, outputs.layout, outputs.as_mut_slice())?;
 
     // Only explicit sink nodes (Output) publish external writes.
@@ -207,6 +213,7 @@ fn evaluate_kind(
     spec: &NodeSpec,
     inputs: &InputSlots,
     outputs: &mut OutputSlots,
+    host: &mut dyn GraphHost,
 ) -> Result<(), String> {
     let params = &spec.params;
     match &spec.kind {
@@ -304,7 +311,42 @@ fn evaluate_kind(
         NodeType::MathSubRecord => eval_math_record(inputs, outputs, |a, b| a - b),
         NodeType::Input => eval_input_node(rt, spec, outputs),
         NodeType::Output => eval_output(inputs, outputs),
+        NodeType::ModuleCall => eval_module_call(spec, inputs, outputs, host),
     }
+}
+
+/// Build a [`CallTarget`] from the node's params and args from the `args` input,
+/// dispatch through the [`GraphHost`], and expose the returned value on `out`.
+///
+/// Generic by construction: it calls *a module function*, not a specific one.
+/// Missing `args` defaults to an empty record ("no arguments"); the host decides
+/// how to marshal it.
+fn eval_module_call(
+    spec: &NodeSpec,
+    inputs: &InputSlots,
+    outputs: &mut OutputSlots,
+    host: &mut dyn GraphHost,
+) -> Result<(), String> {
+    let params = &spec.params;
+    let module = params.module.clone().ok_or_else(|| {
+        format!(
+            "ModuleCall node '{}' missing required 'module' parameter",
+            spec.id
+        )
+    })?;
+    let function = params.function.clone().ok_or_else(|| {
+        format!(
+            "ModuleCall node '{}' missing required 'function' parameter",
+            spec.id
+        )
+    })?;
+    let target = CallTarget::ModuleFn { module, function };
+    let args = inputs
+        .get("args")
+        .map(|pv| pv.value.clone())
+        .unwrap_or_else(|| Value::Record(Default::default()));
+    let ret = host.call(&target, args)?;
+    single_output(outputs, ret)
 }
 
 fn input_or_default(inputs: &InputSlots, key: &str) -> PortValue {

--- a/crates/node-graph/vizij-graph-core/src/eval/mod.rs
+++ b/crates/node-graph/vizij-graph-core/src/eval/mod.rs
@@ -13,6 +13,7 @@
 //!
 //! Integration code should primarily interact with [`GraphRuntime`] and [`evaluate_all`].
 
+use crate::host::{GraphHost, NoHost};
 use crate::types::GraphSpec;
 use std::mem;
 
@@ -40,7 +41,23 @@ mod tests;
 ///
 /// The runtime is cleared before evaluation and is repopulated as nodes are visited in topological
 /// order. Any error propagated from an individual node halts evaluation.
+///
+/// This is the host-less entry point: it wires a [`NoHost`], so graphs that
+/// contain a [`ModuleCall`](crate::types::NodeType::ModuleCall) node error only
+/// if such a node is actually reached. Use [`evaluate_all_with_host`] to supply
+/// a real host.
 pub fn evaluate_all(rt: &mut GraphRuntime, spec: &GraphSpec) -> Result<(), String> {
+    evaluate_all_with_host(rt, spec, &mut NoHost)
+}
+
+/// Evaluate every node in `spec`, dispatching [`ModuleCall`] nodes through `host`.
+///
+/// [`ModuleCall`]: crate::types::NodeType::ModuleCall
+pub fn evaluate_all_with_host(
+    rt: &mut GraphRuntime,
+    spec: &GraphSpec,
+    host: &mut dyn GraphHost,
+) -> Result<(), String> {
     if spec.version > 0 {
         rt.plan.ensure_versioned(spec)?;
     } else {
@@ -78,7 +95,7 @@ pub fn evaluate_all(rt: &mut GraphRuntime, spec: &GraphSpec) -> Result<(), Strin
                 let mut outputs =
                     eval_node::OutputSlots::new(&mut vec_out, &plan.layouts[idx].outputs);
                 outputs.clear();
-                eval_node::eval_node(rt, node, &inputs, &mut outputs)?;
+                eval_node::eval_node(rt, node, &inputs, &mut outputs, host)?;
             }
 
             let compat = eval_node::materialize_outputs(&plan.layouts[idx].outputs, &vec_out);
@@ -100,7 +117,20 @@ fn resize_and_clear(bucket: &mut Vec<PortValue>) {
 /// `spec` matches the cached plan; it returns an error if the layouts are missing or mis-sized.
 /// Intended for callers that manage plan invalidation themselves (e.g., WASM wrapper with
 /// immutable specs).
+///
+/// Host-less entry point (wires a [`NoHost`]); see [`evaluate_all_cached_with_host`].
 pub fn evaluate_all_cached(rt: &mut GraphRuntime, spec: &GraphSpec) -> Result<(), String> {
+    evaluate_all_cached_with_host(rt, spec, &mut NoHost)
+}
+
+/// Cached-plan evaluation that dispatches [`ModuleCall`] nodes through `host`.
+///
+/// [`ModuleCall`]: crate::types::NodeType::ModuleCall
+pub fn evaluate_all_cached_with_host(
+    rt: &mut GraphRuntime,
+    spec: &GraphSpec,
+    host: &mut dyn GraphHost,
+) -> Result<(), String> {
     if rt.plan.layouts.len() != spec.nodes.len() {
         return Err("plan cache not initialised for this spec".to_string());
     }
@@ -151,7 +181,7 @@ pub fn evaluate_all_cached(rt: &mut GraphRuntime, spec: &GraphSpec) -> Result<()
                 let mut outputs =
                     eval_node::OutputSlots::new(&mut vec_out, &plan.layouts[idx].outputs);
                 outputs.clear();
-                eval_node::eval_node(rt, node, &inputs, &mut outputs)?;
+                eval_node::eval_node(rt, node, &inputs, &mut outputs, host)?;
             }
 
             let compat = eval_node::materialize_outputs(&plan.layouts[idx].outputs, &vec_out);

--- a/crates/node-graph/vizij-graph-core/src/eval/tests.rs
+++ b/crates/node-graph/vizij-graph-core/src/eval/tests.rs
@@ -2269,3 +2269,114 @@ fn noise_nodes_are_deterministic_and_in_range() {
         );
     }
 }
+
+/// The [`GraphHost`](crate::host::GraphHost) seam, proven arora-free: a mock
+/// host that doubles a scalar arg is dispatched by a `ModuleCall` node, and its
+/// result flows to the node output and the `Output` sink's write.
+mod module_call {
+    use super::*;
+    use crate::host::{CallTarget, GraphHost};
+
+    /// A host that returns `2 * args` for a scalar arg, recording the target.
+    #[derive(Default)]
+    struct DoublingHost {
+        seen: Option<(String, String)>,
+    }
+
+    impl GraphHost for DoublingHost {
+        fn call(&mut self, target: &CallTarget, args: Value) -> Result<Value, String> {
+            let CallTarget::ModuleFn { module, function } = target;
+            self.seen = Some((module.clone(), function.clone()));
+            match args {
+                Value::Float(f) => Ok(Value::Float(f * 2.0)),
+                other => Err(format!("expected a scalar arg, got {other:?}")),
+            }
+        }
+    }
+
+    fn module_call_node(id: &str, module: &str, function: &str) -> NodeSpec {
+        NodeSpec {
+            id: id.to_string(),
+            kind: NodeType::ModuleCall,
+            params: NodeParams {
+                module: Some(module.to_string()),
+                function: Some(function.to_string()),
+                ..Default::default()
+            },
+            output_shapes: HashMap::new(),
+            input_defaults: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn module_call_dispatches_through_the_host() {
+        let spec = graph_spec!({
+            nodes: vec![
+                constant_node("a", Value::Float(21.0)),
+                module_call_node("call", "mod-x", "fn-y"),
+                NodeSpec {
+                    id: "out".into(),
+                    kind: NodeType::Output,
+                    params: NodeParams {
+                        path: Some(TypedPath::parse("result/x").unwrap()),
+                        ..Default::default()
+                    },
+                    output_shapes: HashMap::new(),
+                    input_defaults: HashMap::new(),
+                },
+            ],
+            edges: vec![
+                EdgeSpec {
+                    from: EdgeOutputEndpoint { node_id: "a".into(), output: "out".into() },
+                    to: EdgeInputEndpoint { node_id: "call".into(), input: "args".into() },
+                    selector: None,
+                },
+                EdgeSpec {
+                    from: EdgeOutputEndpoint { node_id: "call".into(), output: "out".into() },
+                    to: EdgeInputEndpoint { node_id: "out".into(), input: "in".into() },
+                    selector: None,
+                },
+            ],
+        });
+
+        let mut rt = GraphRuntime::default();
+        let mut host = DoublingHost::default();
+        evaluate_all_with_host(&mut rt, &spec, &mut host).expect("evaluation succeeds");
+
+        let out = rt
+            .outputs
+            .get("call")
+            .and_then(|ports| ports.get("out"))
+            .map(|p| &p.value);
+        assert_eq!(out, Some(&Value::Float(42.0)));
+
+        let write = rt
+            .writes
+            .iter()
+            .find(|op| op.path.to_string() == "result/x")
+            .expect("output write emitted");
+        assert_eq!(write.value, Value::Float(42.0));
+
+        assert_eq!(host.seen, Some(("mod-x".into(), "fn-y".into())));
+    }
+
+    #[test]
+    fn host_less_evaluation_errors_only_when_a_module_call_is_hit() {
+        let spec = graph_spec!({
+            nodes: vec![
+                constant_node("a", Value::Float(1.0)),
+                module_call_node("call", "mod-x", "fn-y"),
+            ],
+            edges: vec![EdgeSpec {
+                from: EdgeOutputEndpoint { node_id: "a".into(), output: "out".into() },
+                to: EdgeInputEndpoint { node_id: "call".into(), input: "args".into() },
+                selector: None,
+            }],
+        });
+
+        // `evaluate_all` wires a `NoHost`, so hitting the ModuleCall node errors.
+        let mut rt = GraphRuntime::default();
+        let err = evaluate_all(&mut rt, &spec).expect_err("NoHost should reject a ModuleCall");
+        assert!(err.contains("without a GraphHost"), "got: {err}");
+    }
+}

--- a/crates/node-graph/vizij-graph-core/src/host.rs
+++ b/crates/node-graph/vizij-graph-core/src/host.rs
@@ -1,0 +1,79 @@
+//! Host-callout seam for graph nodes that must invoke behaviour living outside
+//! the graph.
+//!
+//! Today the only escape from a node handler to the host is the [`Output`] sink
+//! pushing a write into `rt.writes`. A [`ModuleCall`] node needs the *opposite*
+//! direction: to call *out* to the host, hand it arguments, and receive a value
+//! back. [`GraphHost`] is that seam.
+//!
+//! It is deliberately **arora-agnostic** — this keeps `vizij-graph-core` free of
+//! any arora dependency. The host speaks in graph-core's own [`Value`] and an
+//! opaque, extensible [`CallTarget`]; the concrete arora `CallBridge` binding
+//! lives in the interop layer (`vizij-arora-behavior`), which is the only place
+//! arora types appear.
+//!
+//! [`Output`]: crate::types::NodeType::Output
+//! [`ModuleCall`]: crate::types::NodeType::ModuleCall
+
+use vizij_api_core::Value;
+
+/// An extensible descriptor of *what* a graph node is asking the host to invoke.
+///
+/// The single variant today is a module-function target. The enum is
+/// intentionally open-ended and `#[non_exhaustive]`: the design note
+/// (`docs/design-note-behavior-recursion-and-interpreter-composition.md`, §2)
+/// prescribes a future `Behavior { interpreter, behavior }` variant so a graph
+/// node can hand off to *another interpreter* (a behaviour-tree, or a sub-graph)
+/// through this **same** seam, with no change to [`GraphHost`]. Widening the
+/// target — not re-cutting the seam — is how that future stays additive.
+///
+/// The ids here are graph-core's own opaque strings, **not** arora types: the
+/// host maps them onto whatever call vocabulary it speaks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CallTarget {
+    /// Invoke `function` within `module`. Both ids are host-opaque strings.
+    ModuleFn {
+        /// Module identifier (host-opaque).
+        module: String,
+        /// Function identifier within the module (host-opaque).
+        function: String,
+    },
+    // Future (design note §2):
+    //   Behavior { interpreter: String, behavior: String },
+    // Run a named behaviour under a named interpreter — makes interpreters
+    // first-class callables and expresses graph-in-graph recursion as a
+    // `Behavior` target whose interpreter is the graph interpreter itself.
+}
+
+/// The seam by which a graph node calls out to its host.
+///
+/// A [`ModuleCall`](crate::types::NodeType::ModuleCall) node builds a
+/// [`CallTarget`] plus an args [`Value`], calls [`GraphHost::call`], and exposes
+/// the returned [`Value`] as its output. The host performs the dispatch — e.g.
+/// over an arora `CallBridge` — and is free to fail with a message.
+pub trait GraphHost {
+    /// Dispatch `target` with `args`, returning the produced value.
+    fn call(&mut self, target: &CallTarget, args: Value) -> Result<Value, String>;
+}
+
+/// A [`GraphHost`] with nothing wired up: every call fails.
+///
+/// Graphs that contain no [`ModuleCall`](crate::types::NodeType::ModuleCall)
+/// node evaluate perfectly well with this host — only *actually hitting* a
+/// `ModuleCall` node surfaces the error. [`evaluate_all`] uses `NoHost`
+/// internally so existing, host-less callers keep their signature; wire a real
+/// host through [`evaluate_all_with_host`] when a graph needs to call out.
+///
+/// [`evaluate_all`]: crate::eval::evaluate_all
+/// [`evaluate_all_with_host`]: crate::eval::evaluate_all_with_host
+pub struct NoHost;
+
+impl GraphHost for NoHost {
+    fn call(&mut self, target: &CallTarget, _args: Value) -> Result<Value, String> {
+        Err(format!(
+            "graph evaluated without a GraphHost, but a ModuleCall node targeted {target:?}; \
+             evaluate with `evaluate_all_with_host` and supply a host"
+        ))
+    }
+}

--- a/crates/node-graph/vizij-graph-core/src/lib.rs
+++ b/crates/node-graph/vizij-graph-core/src/lib.rs
@@ -4,13 +4,16 @@
 //! and evaluation runtime used by Bevy adapters, wasm bindings, and the orchestrator.
 
 pub mod eval;
+pub mod host;
 pub mod schema;
 pub mod topo;
 pub mod types;
 
 pub use eval::{
-    eval_node, evaluate_all, evaluate_all_cached, GraphRuntime, PortValue, StagedInput,
+    eval_node, evaluate_all, evaluate_all_cached, evaluate_all_cached_with_host,
+    evaluate_all_with_host, GraphRuntime, PortValue, StagedInput,
 };
+pub use host::{CallTarget, GraphHost, NoHost};
 pub use schema::registry;
 pub use topo::topo_order;
 pub use types::*;

--- a/crates/node-graph/vizij-graph-core/src/schema.rs
+++ b/crates/node-graph/vizij-graph-core/src/schema.rs
@@ -2670,6 +2670,52 @@ pub fn registry() -> Registry {
         params: vec![],
     });
 
+    // Host callout
+    nodes.push(NodeSignature {
+        type_id: ModuleCall,
+        name: "Module Call",
+        category: "Host",
+        doc: "Calls a module function through the host GraphHost seam, passing the \
+              args value and exposing the returned value on the out port.",
+        inputs: vec![PortSpec {
+            id: "args",
+            ty: PortType::Any,
+            label: "Args",
+            doc: "Arguments value handed to the host call; the host maps it onto the \
+                  target's call vocabulary.",
+            optional: true,
+        }],
+        variadic_inputs: None,
+        outputs: vec![PortSpec {
+            id: "out",
+            ty: PortType::Any,
+            label: "Out",
+            doc: "Value returned by the host call.",
+            optional: false,
+        }],
+        variadic_outputs: None,
+        params: vec![
+            ParamSpec {
+                id: "module",
+                ty: ParamType::Text,
+                label: "Module",
+                doc: "Host-opaque module identifier to call.",
+                default_json: None,
+                min: None,
+                max: None,
+            },
+            ParamSpec {
+                id: "function",
+                ty: ParamType::Text,
+                label: "Function",
+                doc: "Host-opaque function identifier within the module.",
+                default_json: None,
+                min: None,
+                max: None,
+            },
+        ],
+    });
+
     Registry {
         version: "1.0.0",
         nodes,

--- a/crates/node-graph/vizij-graph-core/src/types.rs
+++ b/crates/node-graph/vizij-graph-core/src/types.rs
@@ -151,6 +151,13 @@ pub enum NodeType {
     Input,
     /// Writes a value to a host-visible typed path sink.
     Output,
+
+    // Host callout
+    /// Calls a module function through the host
+    /// [`GraphHost`](crate::host::GraphHost) seam, exposing the returned value
+    /// on its `out` port.
+    #[serde(rename = "module_call")]
+    ModuleCall,
 }
 
 /// Node-construction parameters consumed selectively by different [`NodeType`] variants.
@@ -272,6 +279,14 @@ pub struct NodeParams {
     /// Example: `"robot1/Arm/Joint3.translation"`.
     #[serde(default)]
     pub path: Option<TypedPath>,
+
+    /// Host-opaque module identifier for [`NodeType::ModuleCall`].
+    #[serde(default)]
+    pub module: Option<String>,
+    /// Host-opaque function identifier within [`Self::module`] for
+    /// [`NodeType::ModuleCall`].
+    #[serde(default)]
+    pub function: Option<String>,
 }
 
 /// Rounding strategy for [`NodeType::Round`].


### PR DESCRIPTION
**VIZ-53 Step C** — the seam a Vizij node-graph uses to call an arora module function through the `CallBridge`. Stacked on #28 (Steps A+B); the animation node + orchestrator-as-graph (Step D) build on this.

Shaped per `docs/design-note-behavior-recursion-and-interpreter-composition.md`: a **general `call(target, args)`** with an **extensible target descriptor**, not a narrow module-only call.

## What's here
- **`GraphHost` trait** (`vizij-graph-core`, arora-agnostic): `fn call(&mut self, target: &CallTarget, args: Value) -> Result<Value, String>`. `CallTarget::ModuleFn { module, function }` uses host-opaque strings (not arora ids); the design note's future `Behavior { interpreter, behavior }` target slots in with no seam change.
- **Host threaded explicitly** (`evaluate_all_with_host`/`_cached_with_host` → `eval_node`), keeping `GraphRuntime` clean. `evaluate_all`/`evaluate_all_cached` keep their signatures as thin wrappers wiring a `NoHost`, so host-less callers are unchanged — only actually hitting a `ModuleCall` node errors.
- **`ModuleCall` node** — new `NodeType` + `schema.rs` entry + handler: reads its `args` input, builds the `CallTarget` from `module`/`function` params, calls `host.call`, exposes the return on `out`. Generic (calls *a module function*, not specifically animation).
- **`AroraGraphHost`** (`vizij-arora-behavior`) — the only place arora types appear: maps `CallTarget::ModuleFn` → arora `Call`, marshals args/results with `vizij-arora`'s `to_arora`/`from_arora` over a `CallBridge`.

## Tests
Graph-core with a mock (arora-free) host proving the seam end to end at the graph level; the interop layer with an echo `CallBridge`.

`vizij-graph-core` stays free of any arora dependency — the whole point of the trait.

Stacked on #28. Part of VIZ-53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)