### PR TITLE
fix(glb-migrate): correctly-rounded float parsing makes migration a fixed point

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4418,7 +4418,7 @@ dependencies = [
 
 [[package]]
 name = "vizij-glb-migrate"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde_json",
  "thiserror",

--- a/crates/tools/vizij-glb-migrate/Cargo.toml
+++ b/crates/tools/vizij-glb-migrate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vizij-glb-migrate"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 description = "Rewrites the Value-bearing JSON embedded in Vizij face-bundle .glb files to canonical arora Value serde"
@@ -9,5 +9,5 @@ description = "Rewrites the Value-bearing JSON embedded in Vizij face-bundle .gl
 vizij-api-core = { path = "../../api/vizij-api-core" }
 # preserve_order keeps glTF JSON member order stable across the rewrite so
 # migrated files diff cleanly against their sources.
-serde_json = { version = "1", features = ["preserve_order"] }
+serde_json = { version = "1", features = ["preserve_order", "float_roundtrip"] }
 thiserror = "1"

--- a/crates/tools/vizij-glb-migrate/src/migrate.rs
+++ b/crates/tools/vizij-glb-migrate/src/migrate.rs
@@ -474,12 +474,19 @@ mod tests {
         });
 
         let first = migrate_gltf_json(&mut root).expect("first pass");
-        assert_eq!(first.robot_defaults_changed, 1, "the web raw value migrates");
+        assert_eq!(
+            first.robot_defaults_changed, 1,
+            "the web raw value migrates"
+        );
 
         let bytes_after_first = serde_json::to_vec(&root).expect("serializes");
         let mut reparsed: Json = serde_json::from_slice(&bytes_after_first).expect("parses");
         let second = migrate_gltf_json(&mut reparsed).expect("second pass");
-        assert!(!second.changed(), "second pass must be a no-op: {}", second.summary());
+        assert!(
+            !second.changed(),
+            "second pass must be a no-op: {}",
+            second.summary()
+        );
 
         let bytes_after_second = serde_json::to_vec(&reparsed).expect("serializes");
         assert_eq!(

--- a/crates/tools/vizij-glb-migrate/src/migrate.rs
+++ b/crates/tools/vizij-glb-migrate/src/migrate.rs
@@ -453,4 +453,38 @@ mod tests {
         assert!(message.contains("scenes[0]"), "{message}");
         assert!(message.contains("links"), "{message}");
     }
+
+    /// Migration is a fixed point: a second pass over already-canonical output
+    /// reports nothing to change, and re-serialization keeps every float —
+    /// including untouched ones — byte-stable. This is what the serde_json
+    /// `float_roundtrip` feature guarantees; without it the fast float parser
+    /// drifts by an ulp per parse/print cycle, so canonical `f32`-widened
+    /// payloads flipped forever and untouched glTF floats eroded on every run.
+    #[test]
+    fn migration_is_idempotent_including_float_round_trips() {
+        // Real offenders lifted from a face bundle: an f64-widened f32 payload
+        // and an untouched accessor bound with a wicked mantissa.
+        let mut root = json!({
+            "accessors": [{ "min": [-8.398046702495775e-10] }],
+            "nodes": [{
+                "extensions": { "RobotData": { "features": { "rot": { "value": {
+                    "default": { "x": 1.5106206774362366e-7, "y": -3.258413698858931e-7, "z": 18.08459091186523 }
+                }}}}}
+            }]
+        });
+
+        let first = migrate_gltf_json(&mut root).expect("first pass");
+        assert_eq!(first.robot_defaults_changed, 1, "the web raw value migrates");
+
+        let bytes_after_first = serde_json::to_vec(&root).expect("serializes");
+        let mut reparsed: Json = serde_json::from_slice(&bytes_after_first).expect("parses");
+        let second = migrate_gltf_json(&mut reparsed).expect("second pass");
+        assert!(!second.changed(), "second pass must be a no-op: {}", second.summary());
+
+        let bytes_after_second = serde_json::to_vec(&reparsed).expect("serializes");
+        assert_eq!(
+            bytes_after_first, bytes_after_second,
+            "parse + print must be byte-stable, untouched floats included"
+        );
+    }
 }


### PR DESCRIPTION
Found while migrating vizij-web's 16 face bundles: `--check` after migration kept reporting 11/113 RobotData defaults + 2/2 graph docs to change, forever, and untouched glTF floats (accessor min/max, node rotations) eroded by one trailing digit per pass.

**Root cause:** without serde_json's `float_roundtrip` feature, its fast float parser can land 1 ulp off the value a printed float denotes. Each parse→print cycle then drifts: canonical `f32`-widened payloads never re-parse to themselves (so the change detector re-fires every pass) and untouched floats decay on every rewrite.

**Fix:** enable `float_roundtrip` for the tool. A regression test pins both properties on real offenders lifted from a face bundle: second pass is a no-op, and re-serialization is byte-stable including untouched floats. Verified on `example.glb`: migrate → `--check` exit 0 → re-run byte-identical. 0.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)