### PR TITLE
ci: a manual publish-npm dispatch publishes whatever the registry is missing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -84,7 +84,10 @@ jobs:
           git commit -m "$RELEASE_COMMIT_MESSAGE"
 
       - name: Publish npm packages
-        if: steps.version.outputs.has_changes == 'true'
+        # A manual dispatch means "publish whatever the registry is missing":
+        # `changeset publish` keys on package.json versions, so it works even
+        # when the versions were bumped without changeset files.
+        if: steps.version.outputs.has_changes == 'true' || github.event_name == 'workflow_dispatch'
         run: pnpm ci:publish
 
       - name: Push release commit and tags
@@ -95,6 +98,10 @@ jobs:
           git push origin HEAD:"$RELEASE_BRANCH"
           git push origin --follow-tags
 
+      - name: Push release tags
+        if: steps.version.outputs.has_changes != 'true' && github.event_name == 'workflow_dispatch'
+        run: git push origin --tags
+
       - name: No release needed
-        if: steps.version.outputs.has_changes != 'true'
+        if: steps.version.outputs.has_changes != 'true' && github.event_name != 'workflow_dispatch'
         run: echo "No unpublished packages detected; skipping publish."


### PR DESCRIPTION
Your dispatch this morning ran green but published nothing: the publish step was gated on changesets producing a version commit, and the value-unification majors were bumped directly in package.json (no changeset files), so `ci:version` saw nothing pending and the job took the "No release needed" branch.

`changeset publish` (inside `ci:publish`) keys on package.json versions vs the registry, so on **workflow_dispatch** it now runs regardless of the changesets gate, and pushes the tags it creates. The tag-triggered flow is unchanged.

After merge, re-run: `gh workflow run publish-npm.yml --repo vizij-ai/vizij-rs --ref main` → publishes value-json 0.2.0, animation-wasm 0.4.0, node-graph-wasm 0.7.0, orchestrator-wasm 0.4.0 → my registry monitor finishes vizij-web #37 (lockfile regen, undraft, merge on green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)