### PR TITLE
vizij-arora-web: the browser device on arora-web 5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -255,7 +255,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -280,6 +280,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arora"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "706bdbb11748cfdba2ded0136a2046207d7a4c01f98985193f42382856b205dd"
+dependencies = [
+ "anyhow",
+ "arora-behavior",
+ "arora-behavior-tree",
+ "arora-bridge",
+ "arora-engine 2.0.0",
+ "arora-hal",
+ "arora-simple-data-store",
+ "arora-types",
+ "futures",
+ "log",
+ "uuid",
+]
+
+[[package]]
 name = "arora-behavior"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +307,54 @@ dependencies = [
  "arora-types",
  "serde",
  "uuid",
+]
+
+[[package]]
+name = "arora-behavior-tree"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf4b586610596f3c8e35bb434c876c328eef25400d43034ea791b95e15c0c4d"
+dependencies = [
+ "anyhow",
+ "arora-behavior",
+ "arora-behavior-tree-types",
+ "arora-buffers 1.0.0",
+ "arora-module-rust",
+ "arora-registry",
+ "arora-types",
+ "derive_more",
+ "lazy_static",
+ "quick-xml 0.40.1",
+ "semver",
+ "serde",
+ "serde_yaml",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "arora-behavior-tree-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f136a84a870d32ec032e4c4ed62d2dfd513b632e378741fb87a31f16104a2b29"
+dependencies = [
+ "arora-types",
+ "lazy_static",
+ "semver",
+ "uuid",
+]
+
+[[package]]
+name = "arora-bridge"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb09ffc7782bf4031d53d2282687d1c77881ed67e41e5fad459273945f6d564f"
+dependencies = [
+ "arora-types",
+ "async-trait",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
 ]
 
 [[package]]
@@ -346,6 +413,33 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasmtime",
  "wasmtime-wasi",
+ "web-sys",
+]
+
+[[package]]
+name = "arora-engine"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad4c47d380640ff156d4a9d4938e621d0b34c4e69bfe480325e2a60e5fa11611"
+dependencies = [
+ "anyhow",
+ "arora-buffers 1.0.0",
+ "arora-types",
+ "async-trait",
+ "bytes",
+ "cbindgen 0.29.4",
+ "console_error_panic_hook",
+ "derive_more",
+ "getrandom 0.4.3",
+ "js-sys",
+ "lazy_static",
+ "rand 0.10.2",
+ "serde",
+ "serde-wasm-bindgen 0.6.5",
+ "serde_json",
+ "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
 ]
 
@@ -462,6 +556,30 @@ dependencies = [
  "derive_more",
  "serde",
  "sha2",
+]
+
+[[package]]
+name = "arora-web"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bdb27546c8a1ddf653e8210823e8890cc2ece8a6ad5c3e47cccafb4d8dadc1c"
+dependencies = [
+ "arora",
+ "arora-behavior",
+ "arora-bridge",
+ "arora-engine 2.0.0",
+ "arora-hal",
+ "arora-simple-data-store",
+ "arora-types",
+ "console_error_panic_hook",
+ "getrandom 0.4.3",
+ "js-sys",
+ "serde",
+ "serde-wasm-bindgen 0.6.5",
+ "serde_json",
+ "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -3515,7 +3633,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4737,6 +4855,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5005,7 +5132,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5269,7 +5396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5390,10 +5517,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5744,7 +5871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "074515a3e6dc230bbbdcf35830fd71b67b55ae2ac22bc4ff69d89412fc84b830"
 dependencies = [
  "RustyXML",
- "quick-xml",
+ "quick-xml 0.36.2",
  "regex",
  "serde",
  "serde-xml-rs",
@@ -5822,7 +5949,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "arora-buffers 1.0.0",
- "arora-engine",
+ "arora-engine 0.1.0",
  "arora-module-core",
  "arora-module-rust",
  "arora-registry",
@@ -5906,6 +6033,7 @@ dependencies = [
  "async-trait",
  "futures",
  "futures-channel",
+ "futures-core",
  "tokio",
  "vizij-api-core",
 ]
@@ -5917,6 +6045,26 @@ dependencies = [
  "arora-types",
  "vizij-api-core",
  "vizij-orchestrator-core",
+]
+
+[[package]]
+name = "vizij-arora-web"
+version = "0.0.0"
+dependencies = [
+ "arora-bridge",
+ "arora-web",
+ "console_error_panic_hook",
+ "getrandom 0.4.3",
+ "serde-wasm-bindgen 0.6.5",
+ "serde_json",
+ "vizij-api-core",
+ "vizij-arora-behavior",
+ "vizij-arora-hal",
+ "vizij-arora-store",
+ "vizij-graph-core",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "crates/test-fixtures/vizij-test-fixtures",
   "crates/interop/vizij-arora",
   "crates/interop/vizij-animation-module",
+  "crates/interop/vizij-arora-web",
   "crates/interop/vizij-arora-store",
   "crates/interop/vizij-arora-hal",
   "crates/interop/vizij-arora-behavior",

--- a/crates/interop/vizij-arora-hal/Cargo.toml
+++ b/crates/interop/vizij-arora-hal/Cargo.toml
@@ -10,6 +10,7 @@ arora-hal = "2"
 arora-types = "1"
 async-trait = "0.1"
 futures-channel = "0.3"
+futures-core = "0.3"
 vizij-api-core = { path = "../../api/vizij-api-core" }
 
 [dev-dependencies]

--- a/crates/interop/vizij-arora-hal/src/lib.rs
+++ b/crates/interop/vizij-arora-hal/src/lib.rs
@@ -5,16 +5,23 @@
 //! writes actuator targets (bone transforms, morph weights), the HAL applies
 //! them, and a renderer reads what to draw. This HAL is that boundary on the
 //! Rust side — it holds the GLB, accumulates the latest actuation `State`,
-//! and feeds [`updates`](arora_hal::Hal::updates) so a renderer knows what
+//! and feeds [`pose_updates`](RigHal::pose_updates) so a renderer knows what
 //! changed. Vizij and Arora share one runtime value type
 //! ([`vizij_api_core::Value`] is `arora_types::value::Value`), so
 //! [`RigHal::pose`] exposes that state to a Vizij renderer directly — the
 //! only translation is string [`Key`]s to [`TypedPath`]s; the actual
 //! bone/morph application stays in the renderer.
 //!
+//! The rig has **no sensors**: it applies targets instantly and measures
+//! nothing of its own, so [`Hal::updates`] — the runtime's *reading* feed —
+//! never yields. (Echoing applied targets back through it would make the
+//! runtime re-apply them as readings a frame later, overwriting anything
+//! fresher written to the store in between.) The echo of applied actuations
+//! lives on [`pose_updates`](RigHal::pose_updates), the renderer-side feed.
+//!
 //! Modelled on `arora-hal`'s `FakeHal`: cheaply cloneable, clones share state,
 //! writes apply synchronously (so [`try_send`](arora_hal::Hal::try_send) needs
-//! no internal task), and the update feed is an owned stream per subscriber.
+//! no internal task), and the pose feed is an owned stream per subscriber.
 
 use std::sync::{Arc, Mutex};
 
@@ -68,6 +75,17 @@ impl RigHal {
     /// Attach (or replace) the GLB model served by [`HalAssets::model_glb`].
     pub fn set_model_glb(&self, glb: Vec<u8>) {
         self.inner.lock().unwrap().model_glb = Some(glb);
+    }
+
+    /// A feed of applied actuation changes, for a Vizij renderer that wants
+    /// deltas instead of polling [`pose`](RigHal::pose). Each call yields an
+    /// independent, owned stream. This is deliberately **not**
+    /// [`Hal::updates`]: that seam is the runtime's sensor-reading feed, and
+    /// the rig has no sensors.
+    pub fn pose_updates(&self) -> UpdatesStream {
+        let (tx, rx) = futures_channel::mpsc::unbounded();
+        self.inner.lock().unwrap().subscribers.push(tx);
+        Box::pin(rx)
     }
 
     /// The current rig pose for a Vizij renderer: the accumulated actuation
@@ -126,10 +144,25 @@ impl Hal for RigHal {
         self.apply_write(changes);
     }
 
+    /// The rig reports no readings — see the module docs. Renderers wanting
+    /// the actuation echo subscribe to [`pose_updates`](RigHal::pose_updates).
     fn updates(&self) -> UpdatesStream {
-        let (tx, rx) = futures_channel::mpsc::unbounded();
-        self.inner.lock().unwrap().subscribers.push(tx);
-        Box::pin(rx)
+        Box::pin(NeverStream)
+    }
+}
+
+/// A stream that stays pending forever: the rig's (empty) sensor feed. Never
+/// ending matters — a finished [`UpdatesStream`] means the hardware is gone.
+struct NeverStream;
+
+impl futures_core::Stream for NeverStream {
+    type Item = StateChange;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<StateChange>> {
+        std::task::Poll::Pending
     }
 }
 
@@ -194,11 +227,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn updates_feed_sees_writes() {
+    async fn pose_feed_sees_writes_and_reading_feed_stays_silent() {
         let hal = RigHal::new();
-        let mut sub = hal.updates();
+        let mut pose_feed = hal.pose_updates();
+        let mut reading_feed = hal.updates();
         hal.write(StateChange::set("k", bool_(true))).await.unwrap();
-        assert!(drain(&mut sub).iter().any(|c| c.contains(&Key::from("k"))));
+        // The renderer's pose feed carries the applied actuation…
+        assert!(drain(&mut pose_feed)
+            .iter()
+            .any(|c| c.contains(&Key::from("k"))));
+        // …but the runtime's reading feed never echoes it back: the rig has no
+        // sensors, and an echo would clobber fresher store writes a frame later.
+        assert!(drain(&mut reading_feed).is_empty());
     }
 
     #[tokio::test]

--- a/crates/interop/vizij-arora-web/Cargo.toml
+++ b/crates/interop/vizij-arora-web/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "vizij-arora-web"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+description = "Run a Vizij runtime in the browser as an Arora device: a thin wasm-bindgen cdylib over arora-web's BrowserRuntime, injected with a BlackboardStore + RigHal + a Vizij Behavior (VIZ-14)."
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+# The whole crate is `wasm32`-only (arora-web's browser runtime is), so every
+# dependency is gated to that target. On the host the crate is an empty shim with
+# no dependencies, so it still participates in a native `cargo build`/`cargo test`
+# without pulling the browser runtime into a host link.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# The published browser-runtime primitive: assembles arora's Runtime over an
+# injected HAL/bridge/store and exposes step() + the Value<->JSON store accessors.
+arora-web = "5"
+# The default Bridge: the in-process fake, all this device needs for now.
+arora-bridge = "3"
+
+# The interop crates that already implement the Arora traits over Vizij.
+vizij-arora-store = { path = "../vizij-arora-store" }
+vizij-arora-hal = { path = "../vizij-arora-hal" }
+vizij-arora-behavior = { path = "../vizij-arora-behavior" }
+
+# Vizij pieces the browser wrapper builds the injected behavior from.
+vizij-api-core = { path = "../../api/vizij-api-core" }
+vizij-graph-core = { path = "../../node-graph/vizij-graph-core" }
+
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = "0.4"
+serde_json = { workspace = true }
+console_error_panic_hook = "0.1"
+# uuid v4 on wasm needs a browser RNG (selects getrandom's wasm_js backend).
+getrandom = { version = "0.4", features = ["wasm_js"] }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
+serde-wasm-bindgen = { workspace = true }

--- a/crates/interop/vizij-arora-web/src/lib.rs
+++ b/crates/interop/vizij-arora-web/src/lib.rs
@@ -1,0 +1,159 @@
+//! Run a Vizij runtime *as* an Arora device in the browser.
+//!
+//! This is a thin wasm-bindgen wrapper: it assembles the Vizij interop pieces
+//! and hands them to [`arora_web::BrowserRuntime`], the reusable browser-device
+//! primitive, then forwards the JS-facing methods. All the runtime scaffolding
+//! (the arora step loop, the golden clock, the Value↔JSON store accessors)
+//! lives in `arora-web`; here we only choose the backends:
+//!
+//! - the store is a [`BlackboardStore`] (a Vizij `Blackboard` as an Arora
+//!   `DataStore`);
+//! - the HAL is a [`RigHal`] (a Vizij rig as an Arora HAL);
+//! - the bridge is the in-process [`FakeBridge`];
+//! - the behavior is a [`ProcessingGraph`] (a Vizij node graph driven as the
+//!   device's `BehaviorInterpreter`), built from the caller's graph spec.
+//!
+//! JavaScript constructs it with [`VizijArora::start`] (passing a Vizij graph
+//! spec as JSON, in any accepted form — the spec normalizer runs here), drives
+//! it one tick at a time with [`VizijArora::step`] from `requestAnimationFrame`
+//! timestamps, and reads or writes keys on the injected store through the
+//! forwarded accessors. Values cross the JS boundary as JSON in the Arora
+//! `Value` vocabulary (e.g. `{"f32": 0.75}`).
+//!
+//! This crate only carries content when built for `wasm32`; on the host it is
+//! an empty shim so it can participate in `cargo build`/`cargo test` on the
+//! host.
+
+#![cfg(target_arch = "wasm32")]
+
+use std::time::Duration;
+
+use arora_bridge::FakeBridge;
+use arora_web::BrowserRuntime;
+use vizij_api_core::TypedPath;
+use vizij_arora_behavior::ProcessingGraph;
+use vizij_arora_hal::RigHal;
+use vizij_arora_store::BlackboardStore;
+use vizij_graph_core::types::{GraphSpec, NodeType};
+use wasm_bindgen::prelude::*;
+
+/// The store path the default proof graph reads from.
+const GRAPH_INPUT: &str = "sensor/x";
+/// The store path the default proof graph writes to.
+const GRAPH_OUTPUT: &str = "actuator/y";
+
+/// A running Vizij-on-Arora device, JS-callable.
+///
+/// Holds an [`arora_web::BrowserRuntime`] assembled over the Vizij interop
+/// pieces; every method forwards to it.
+#[wasm_bindgen]
+pub struct VizijArora {
+    inner: BrowserRuntime,
+}
+
+#[wasm_bindgen]
+impl VizijArora {
+    /// Start the device in the browser: inject a [`BlackboardStore`] +
+    /// [`RigHal`] + [`FakeBridge`] into a [`BrowserRuntime`] with a
+    /// [`ProcessingGraph`] as its behavior.
+    ///
+    /// `graph_json` is a Vizij graph spec (any form the spec normalizer
+    /// accepts); its `input` nodes' paths become the store keys the graph
+    /// reads each tick. Pass nothing to get the passthrough proof graph
+    /// (`sensor/x` → `actuator/y`). Drive with [`step`](Self::step).
+    pub async fn start(graph_json: Option<String>) -> Result<VizijArora, JsValue> {
+        let spec = match graph_json {
+            Some(json) => parse_graph(&json)?,
+            None => parse_graph(&passthrough_json(GRAPH_INPUT, GRAPH_OUTPUT))?,
+        };
+        let inputs = input_paths(&spec);
+        let graph = ProcessingGraph::from_spec(spec, inputs);
+
+        let inner = BrowserRuntime::start(
+            Box::new(RigHal::new()),
+            Box::new(FakeBridge::new()),
+            Box::new(BlackboardStore::new()),
+            Box::new(graph),
+        )
+        .await?;
+
+        Ok(VizijArora { inner })
+    }
+
+    /// Advance the device one tick. `dt_ms` is the wall time elapsed since the
+    /// previous step, in milliseconds — the difference of two
+    /// `requestAnimationFrame` timestamps. Returns `true` while live, `false`
+    /// once the device is unregistered (stop stepping then).
+    pub fn step(&mut self, dt_ms: f64) -> Result<bool, JsValue> {
+        self.inner
+            .step(Duration::from_secs_f64((dt_ms / 1000.0).max(0.0)))
+    }
+
+    /// Write one key into the store. `value_json` is an Arora `Value` as JSON,
+    /// e.g. `{"f32": 0.75}`.
+    #[wasm_bindgen(js_name = setValue)]
+    pub fn set_value(&self, path: &str, value_json: &str) -> Result<(), JsValue> {
+        self.inner.set_value(path, value_json)
+    }
+
+    /// Write several keys at once, as one store change. `values_json` is a JSON
+    /// object mapping each key path to an Arora `Value`.
+    #[wasm_bindgen(js_name = writeValues)]
+    pub fn write_values(&self, values_json: &str) -> Result<(), JsValue> {
+        self.inner.write_values(values_json)
+    }
+
+    /// Read keys from the store. `paths` is a JS `string[]`; the result maps
+    /// each path to its Arora `Value` (or `null` if absent).
+    #[wasm_bindgen(js_name = readValues)]
+    pub fn read_values(&self, paths: JsValue) -> Result<JsValue, JsValue> {
+        self.inner.read_values(paths)
+    }
+
+    /// A snapshot of every key currently in the store, as a path → `Value`
+    /// object.
+    pub fn snapshot(&self) -> Result<JsValue, JsValue> {
+        self.inner.snapshot()
+    }
+
+    /// Drain the keys that changed since the last call, as a path → `Value`
+    /// object (or `null` for a cleared key). Call it right after
+    /// [`step`](Self::step).
+    #[wasm_bindgen(js_name = drainChanges)]
+    pub fn drain_changes(&self) -> Result<JsValue, JsValue> {
+        self.inner.drain_changes()
+    }
+}
+
+/// Normalize and deserialize a Vizij graph spec from JSON.
+fn parse_graph(json: &str) -> Result<GraphSpec, JsValue> {
+    let mut spec: serde_json::Value = serde_json::from_str(json)
+        .map_err(|e| JsValue::from_str(&format!("graph spec is not JSON: {e}")))?;
+    vizij_api_core::json::normalize_graph_spec_value(&mut spec)
+        .map_err(|e| JsValue::from_str(&format!("normalize graph spec failed: {e}")))?;
+    serde_json::from_value(spec).map_err(|e| JsValue::from_str(&format!("invalid graph spec: {e}")))
+}
+
+/// The store paths the spec's `input` nodes read — what the graph subscribes
+/// to on the device's store.
+fn input_paths(spec: &GraphSpec) -> Vec<TypedPath> {
+    spec.nodes
+        .iter()
+        .filter(|node| matches!(node.kind, NodeType::Input))
+        .filter_map(|node| node.params.path.clone())
+        .collect()
+}
+
+/// The passthrough proof graph (`input` path → `output` path), as spec JSON.
+fn passthrough_json(input: &str, output: &str) -> String {
+    serde_json::json!({
+        "nodes": [
+            { "id": "in",  "type": "input",  "params": { "path": input } },
+            { "id": "out", "type": "output", "params": { "path": output } }
+        ],
+        "edges": [
+            { "from": { "node_id": "in" }, "to": { "node_id": "out", "input": "in" } }
+        ]
+    })
+    .to_string()
+}

--- a/crates/interop/vizij-arora-web/tests/proof.rs
+++ b/crates/interop/vizij-arora-web/tests/proof.rs
@@ -1,0 +1,61 @@
+//! Values flow JS → store → arora tick → store → JS, through arora-web.
+//!
+//! Boots the thin Vizij-on-Arora device (which builds an `arora_web::BrowserRuntime`
+//! over a `BlackboardStore` + `RigHal` + a passthrough Vizij graph), writes an
+//! input key from "JS", steps the arora tick, and reads the graph's output key
+//! back out — proving the whole seam end to end in wasm through the published
+//! browser-runtime primitive.
+
+#![cfg(target_arch = "wasm32")]
+
+use serde_json::{json, Value as Json};
+use vizij_arora_web::VizijArora;
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::*;
+
+/// Build a JS `string[]` from string slices.
+fn paths(ps: &[&str]) -> JsValue {
+    serde_wasm_bindgen::to_value(&ps.iter().map(|p| p.to_string()).collect::<Vec<_>>()).unwrap()
+}
+
+/// Read the JS object returned by `read_values`/`drain_changes` back into JSON.
+fn as_json(v: JsValue) -> Json {
+    serde_wasm_bindgen::from_value(v).unwrap()
+}
+
+#[wasm_bindgen_test]
+async fn values_flow_js_store_tick_store_js() {
+    let mut rt = VizijArora::start(None).await.expect("runtime starts");
+
+    // The graph's output key is absent before any tick runs.
+    let before = as_json(rt.read_values(paths(&["actuator/y"])).unwrap());
+    assert_eq!(before["actuator/y"], Json::Null);
+
+    // "JS" writes the input key into the store (Arora Value JSON).
+    rt.set_value("sensor/x", &json!({ "f32": 0.75 }).to_string())
+        .unwrap();
+
+    // One tick: the arora runtime ticks the installed Vizij graph, which reads
+    // sensor/x from the store and writes actuator/y back.
+    assert!(rt.step(16.0).unwrap(), "runtime stays live");
+
+    // "JS" reads the transformed output back out of the same store.
+    let after = as_json(rt.read_values(paths(&["sensor/x", "actuator/y"])).unwrap());
+    assert_eq!(after["sensor/x"], json!({ "f32": 0.75 }));
+    assert_eq!(
+        after["actuator/y"],
+        json!({ "f32": 0.75 }),
+        "the value flowed through the arora tick into the graph's output key"
+    );
+
+    // A second value proves it keeps flowing tick to tick.
+    rt.write_values(&json!({ "sensor/x": { "f32": 0.25 } }).to_string())
+        .unwrap();
+    assert!(rt.step(16.0).unwrap());
+    let after2 = as_json(rt.read_values(paths(&["actuator/y"])).unwrap());
+    assert_eq!(after2["actuator/y"], json!({ "f32": 0.25 }));
+
+    // The change feed saw the graph's write this step.
+    let changes = as_json(rt.drain_changes().unwrap());
+    assert_eq!(changes["actuator/y"], json!({ "f32": 0.25 }));
+}


### PR DESCRIPTION
Rebuilds the Phase-1 proof crate (#27) on the published arora line: **vizij-arora-web** is the thin wasm cdylib that runs Vizij *as* an Arora device in the browser.

## What it is

A `#[wasm_bindgen]` wrapper that assembles the interop seams into an `arora_web::BrowserRuntime` (arora-web 5.2) and forwards the JS-facing methods:

- **store** = `BlackboardStore`, **HAL** = `RigHal`, **bridge** = `FakeBridge`, **behavior** = `ProcessingGraph` built from the caller's graph spec (any form the spec normalizer accepts; `input` nodes' paths become the store keys the graph reads).
- JS drives it with `start(graphJson?)` → `step(dtMs)` from `requestAnimationFrame`, and talks to the store through `setValue` / `writeValues` / `readValues` / `snapshot` / `drainChanges` (values as Arora `Value` JSON).

The proof test runs **in wasm** (`wasm-pack test --node`) and drives two ticks end to end: JS write → store → arora tick → graph → store → JS read, plus the change feed.

## Bug fix the proof caught: RigHal echoed writings back as readings

`Hal::updates` is the runtime's *sensor-reading* feed. RigHal echoed every applied write through it, so each frame's writings came back one frame later as readings and overwrote anything fresher — the proof's second tick read the first tick's input (`0.75` instead of `0.25`). `FakeHal`, the stated model, mirrors targets to *distinct* measured keys; same-key echo is not a reading.

The rig has no sensors: `Hal::updates` now never yields, and the actuation echo moved to a new inherent `RigHal::pose_updates()` for renderer-side consumers.

## Next

The vizij-web side of the swap: point `@vizij/runtime-react` at this device instead of the three per-kernel wasm wrappers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)