### PR TITLE
arora-web 5.2.1 floor: the wrapper forwards plain objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "arora-web"
-version = "5.2.0"
+version = "5.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bdb27546c8a1ddf653e8210823e8890cc2ece8a6ad5c3e47cccafb4d8dadc1c"
+checksum = "e8ed94f5621090679343a16f8c25738e65d522219394d41b9c24bf881b3646c2"
 dependencies = [
  "arora",
  "arora-behavior",

--- a/crates/interop/vizij-arora-web/Cargo.toml
+++ b/crates/interop/vizij-arora-web/Cargo.toml
@@ -15,7 +15,8 @@ crate-type = ["cdylib", "rlib"]
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # The published browser-runtime primitive: assembles arora's Runtime over an
 # injected HAL/bridge/store and exposes step() + the Value<->JSON store accessors.
-arora-web = "5"
+# 5.2.1 is the floor: the store accessors return plain JS objects from there.
+arora-web = "5.2.1"
 # The default Bridge: the in-process fake, all this device needs for now.
 arora-bridge = "3"
 

--- a/npm/@vizij/arora-web-wasm/package.json
+++ b/npm/@vizij/arora-web-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizij/arora-web-wasm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Run a Vizij runtime in the browser as an Arora device: wasm bindings over arora-web's BrowserRuntime.",
   "license": "MIT",
   "repository": {

--- a/npm/@vizij/arora-web-wasm/src/index.ts
+++ b/npm/@vizij/arora-web-wasm/src/index.ts
@@ -34,30 +34,10 @@ interface WasmVizijArora {
   step(dt_ms: number): boolean;
   setValue(path: string, value_json: string): void;
   writeValues(values_json: string): void;
-  readValues(paths: string[]): unknown;
-  snapshot(): unknown;
-  drainChanges(): unknown;
+  readValues(paths: string[]): Record<string, ValueJSON | null>;
+  snapshot(): Record<string, ValueJSON>;
+  drainChanges(): Record<string, ValueJSON | null>;
   free(): void;
-}
-
-/**
- * The wasm side serializes its path→Value objects with serde-wasm-bindgen's
- * default map representation: JS `Map`s, nested. Convert them (deeply) to the
- * plain objects the `ValueJSON` vocabulary uses; plain objects pass through,
- * so a wasm module that already emits objects is a no-op.
- */
-function toPlain(value: unknown): unknown {
-  if (value instanceof Map) {
-    const out: Record<string, unknown> = {};
-    for (const [k, v] of value.entries()) {
-      out[String(k)] = toPlain(v);
-    }
-    return out;
-  }
-  if (Array.isArray(value)) {
-    return value.map(toPlain);
-  }
-  return value;
 }
 
 interface WasmBindings {
@@ -190,12 +170,12 @@ export class AroraDevice {
 
   /** Read store keys; absent keys map to `null`. */
   readValues(paths: string[]): Record<string, ValueJSON | null> {
-    return toPlain(this.inner.readValues(paths)) as Record<string, ValueJSON | null>;
+    return this.inner.readValues(paths);
   }
 
   /** Every key currently in the store. */
   snapshot(): Record<string, ValueJSON> {
-    return toPlain(this.inner.snapshot()) as Record<string, ValueJSON>;
+    return this.inner.snapshot();
   }
 
   /**
@@ -203,7 +183,7 @@ export class AroraDevice {
    * after `step` to feed a renderer.
    */
   drainChanges(): Record<string, ValueJSON | null> {
-    return toPlain(this.inner.drainChanges()) as Record<string, ValueJSON | null>;
+    return this.inner.drainChanges();
   }
 
   /** Release the wasm-side device. The instance is unusable afterwards. */


### PR DESCRIPTION
arora-web 5.2.1's store accessors return plain path-keyed JS objects, so `@vizij/arora-web-wasm` forwards them as-is — the wrapper's deep Map→object conversion is gone and its internal types state the record shapes. Crate floor raised to `arora-web = "5.2.1"`; package version 0.1.1.

Verified: the crate's wasm proof (`wasm-pack test --node`) and the package's Node smoke test both pass against the rebuilt 5.2.1 artifacts. Closes the `toPlain` item of [VIZ-62](https://linear.app/semio-ai/issue/VIZ-62).

🤖 Generated with [Claude Code](https://claude.com/claude-code)