### PR TITLE
Selective single-package npm publish + arora-web-wasm changelog

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -2,6 +2,13 @@ name: publish-npm
 
 on:
   workflow_dispatch:
+    inputs:
+      package:
+        description: >-
+          Publish only this package (name under @vizij/, e.g. arora-web-wasm).
+          Leave empty to publish everything the registry is missing.
+        required: false
+        type: string
   push:
     tags:
       - 'npm-pub-*'
@@ -86,8 +93,12 @@ jobs:
       - name: Publish npm packages
         # A manual dispatch means "publish whatever the registry is missing":
         # `changeset publish` keys on package.json versions, so it works even
-        # when the versions were bumped without changeset files.
+        # when the versions were bumped without changeset files. The optional
+        # `package` input narrows the run to one package (scoped build +
+        # pnpm publish of just that package).
         if: steps.version.outputs.has_changes == 'true' || github.event_name == 'workflow_dispatch'
+        env:
+          PUBLISH_PACKAGE: ${{ inputs.package }}
         run: pnpm ci:publish
 
       - name: Push release commit and tags

--- a/npm/@vizij/arora-web-wasm/CHANGELOG.md
+++ b/npm/@vizij/arora-web-wasm/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to `@vizij/arora-web-wasm`. The format follows
+[Keep a Changelog](https://keepachangelog.com/); versions follow
+[Semantic Versioning](https://semver.org/).
+
+## [0.1.1] - 2026-07-10
+
+### Changed
+
+- arora-web 5.2.1 floor: the store accessors return plain JS objects, so the
+  wrapper forwards them as-is (the deep Map→object conversion is gone).
+
+## [0.1.0] - 2026-07-10
+
+### Added
+
+- Initial release: run a Vizij runtime in the browser as an Arora device.
+  `init()` loads the wasm once; `startDevice(graphSpec?)` boots the device
+  with the graph as its behavior; `AroraDevice` exposes `step(dtMs)`,
+  `setValue`/`writeValues` (ValueInput in), `readValues`/`snapshot`/
+  `drainChanges` (ValueJSON out).

--- a/scripts/ci-publish.mjs
+++ b/scripts/ci-publish.mjs
@@ -17,12 +17,45 @@ function run(command, args) {
   });
 }
 
+/**
+ * Wasm build target for each wasm wrapper package, for selective publishes.
+ * Non-wasm packages (value-json, wasm-loader, …) need no wasm build step.
+ */
+const WASM_TARGETS = {
+  "animation-wasm": "animation",
+  "node-graph-wasm": "graph",
+  "orchestrator-wasm": "orchestrator",
+  "arora-web-wasm": "arora-web",
+};
+
 async function main() {
+  // PUBLISH_PACKAGE (a name under @vizij/, e.g. "arora-web-wasm") publishes
+  // that one package: build only what it needs, then `pnpm publish` it.
+  // Without it, the full pipeline runs and `changeset publish` releases every
+  // package whose version is not on the registry yet.
+  const only = process.env.PUBLISH_PACKAGE?.trim();
   await applyWorkspaceManifestUpdates();
   try {
-    await run("pnpm", ["run", "build:wasm"]);
-    await run("pnpm", ["run", "build:shared"]);
-    await run("pnpm", ["changeset", "publish"]);
+    if (only) {
+      const target = WASM_TARGETS[only];
+      if (target) {
+        await run("pnpm", ["run", "build:wasm", "--", target]);
+      }
+      await run("pnpm", ["run", "build:shared"]);
+      await run("pnpm", ["--filter", `@vizij/${only}`, "run", "build"]);
+      await run("pnpm", [
+        "--filter",
+        `@vizij/${only}`,
+        "publish",
+        "--access",
+        "public",
+        "--no-git-checks",
+      ]);
+    } else {
+      await run("pnpm", ["run", "build:wasm"]);
+      await run("pnpm", ["run", "build:shared"]);
+      await run("pnpm", ["changeset", "publish"]);
+    }
   } finally {
     await restoreWorkspaceManifests();
   }


### PR DESCRIPTION
The publish workflow gains an optional `package` dispatch input (a name under `@vizij/`, e.g. `arora-web-wasm`): `ci-publish` then builds only that package's wasm target and `pnpm publish`es just that package. Without the input, the existing full pipeline runs unchanged (`changeset publish` over everything the registry is missing).

Also adds the `CHANGELOG.md` that `@vizij/arora-web-wasm` was missing (0.1.0, 0.1.1) — every other package already carries one.

Once merged, publishing 0.1.1 alone is: Actions → publish-npm → Run workflow → `package: arora-web-wasm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)