### PR TITLE
chore(deps): freshen workspace dependencies to current majors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,7 +298,7 @@ dependencies = [
  "arora-behavior",
  "arora-behavior-tree",
  "arora-bridge",
- "arora-engine 2.0.0",
+ "arora-engine",
  "arora-hal",
  "arora-simple-data-store",
  "arora-types",
@@ -318,7 +327,7 @@ dependencies = [
  "anyhow",
  "arora-behavior",
  "arora-behavior-tree-types",
- "arora-buffers 1.0.0",
+ "arora-buffers",
  "arora-module-rust",
  "arora-registry",
  "arora-types",
@@ -359,20 +368,6 @@ dependencies = [
 
 [[package]]
 name = "arora-buffers"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504b36a67807b9615f68a4664fbae63df87e5d15ae2e2b616bf4202b3fd46858"
-dependencies = [
- "arora-types",
- "bytes",
- "cbindgen 0.20.0",
- "serde",
- "serde_yaml",
- "uuid",
-]
-
-[[package]]
-name = "arora-buffers"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b4b702d632a2364765041f3ee4694d87acef920e5b1294bb3a0485978dc4e6"
@@ -387,12 +382,12 @@ dependencies = [
 
 [[package]]
 name = "arora-engine"
-version = "0.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e1b4060b86bad406567749556b38c31292577d6fc5e9c5898ce0c1b4a7b4ef"
+checksum = "ad4c47d380640ff156d4a9d4938e621d0b34c4e69bfe480325e2a60e5fa11611"
 dependencies = [
  "anyhow",
- "arora-buffers 0.1.1",
+ "arora-buffers",
  "arora-types",
  "async-trait",
  "bytes",
@@ -405,7 +400,7 @@ dependencies = [
  "libloading 0.9.0",
  "rand 0.10.2",
  "serde",
- "serde-wasm-bindgen 0.6.5",
+ "serde-wasm-bindgen",
  "serde_json",
  "tempfile",
  "uuid",
@@ -413,33 +408,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasmtime",
  "wasmtime-wasi",
- "web-sys",
-]
-
-[[package]]
-name = "arora-engine"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad4c47d380640ff156d4a9d4938e621d0b34c4e69bfe480325e2a60e5fa11611"
-dependencies = [
- "anyhow",
- "arora-buffers 1.0.0",
- "arora-types",
- "async-trait",
- "bytes",
- "cbindgen 0.29.4",
- "console_error_panic_hook",
- "derive_more",
- "getrandom 0.4.3",
- "js-sys",
- "lazy_static",
- "rand 0.10.2",
- "serde",
- "serde-wasm-bindgen 0.6.5",
- "serde_json",
- "uuid",
- "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
 ]
 
@@ -567,7 +535,7 @@ dependencies = [
  "arora",
  "arora-behavior",
  "arora-bridge",
- "arora-engine 2.0.0",
+ "arora-engine",
  "arora-hal",
  "arora-simple-data-store",
  "arora-types",
@@ -575,7 +543,7 @@ dependencies = [
  "getrandom 0.4.3",
  "js-sys",
  "serde",
- "serde-wasm-bindgen 0.6.5",
+ "serde-wasm-bindgen",
  "serde_json",
  "uuid",
  "wasm-bindgen",
@@ -1522,7 +1490,7 @@ name = "bevy_vizij_api"
 version = "1.0.0"
 dependencies = [
  "bevy",
- "hashbrown 0.14.5",
+ "hashbrown 0.17.1",
  "serde",
  "vizij-api-core",
 ]
@@ -1533,7 +1501,7 @@ version = "1.0.0"
 dependencies = [
  "bevy",
  "bevy_vizij_api",
- "hashbrown 0.14.5",
+ "hashbrown 0.17.1",
  "serde",
  "serde_json",
  "vizij-api-core",
@@ -2432,25 +2400,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap 4.5.53",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -2458,12 +2425,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -3318,6 +3285,8 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -3626,30 +3595,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi 0.5.2",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -4572,6 +4521,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5214,17 +5173,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -5948,8 +5896,8 @@ name = "vizij-animation-module"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "arora-buffers 1.0.0",
- "arora-engine 0.1.0",
+ "arora-buffers",
+ "arora-engine",
  "arora-module-core",
  "arora-module-rust",
  "arora-registry",
@@ -5971,7 +5919,7 @@ dependencies = [
  "console_error_panic_hook",
  "js-sys",
  "serde",
- "serde-wasm-bindgen 0.6.5",
+ "serde-wasm-bindgen",
  "serde_json",
  "vizij-animation-core",
  "vizij-api-core",
@@ -5985,10 +5933,10 @@ name = "vizij-api-core"
 version = "1.0.0"
 dependencies = [
  "arora-types",
- "hashbrown 0.14.5",
+ "hashbrown 0.17.1",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -5997,7 +5945,7 @@ name = "vizij-api-wasm"
 version = "1.0.0"
 dependencies = [
  "serde",
- "serde-wasm-bindgen 0.6.5",
+ "serde-wasm-bindgen",
  "serde_json",
  "vizij-api-core",
  "wasm-bindgen",
@@ -6055,7 +6003,7 @@ dependencies = [
  "arora-web",
  "console_error_panic_hook",
  "getrandom 0.4.3",
- "serde-wasm-bindgen 0.6.5",
+ "serde-wasm-bindgen",
  "serde_json",
  "vizij-api-core",
  "vizij-arora-behavior",
@@ -6072,7 +6020,7 @@ name = "vizij-glb-migrate"
 version = "0.1.1"
 dependencies = [
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "vizij-api-core",
 ]
 
@@ -6082,11 +6030,11 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "criterion",
- "hashbrown 0.14.5",
+ "hashbrown 0.17.1",
  "k",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "urdf-rs",
  "vizij-api-core",
  "vizij-test-fixtures",
@@ -6105,10 +6053,10 @@ name = "vizij-graph-wasm"
 version = "1.0.0"
 dependencies = [
  "console_error_panic_hook",
- "hashbrown 0.14.5",
+ "hashbrown 0.17.1",
  "js-sys",
  "serde",
- "serde-wasm-bindgen 0.6.5",
+ "serde-wasm-bindgen",
  "serde_json",
  "vizij-api-core",
  "vizij-graph-core",
@@ -6121,11 +6069,11 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "criterion",
- "hashbrown 0.14.5",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "vizij-animation-core",
  "vizij-api-core",
  "vizij-graph-core",
@@ -6140,7 +6088,7 @@ dependencies = [
  "console_error_panic_hook",
  "js-sys",
  "serde",
- "serde-wasm-bindgen 0.5.0",
+ "serde-wasm-bindgen",
  "serde_json",
  "vizij-animation-core",
  "vizij-api-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ edition = "2021"
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-thiserror = "1"
-hashbrown = { version = "0.14", features = ["serde"] }
+thiserror = "2"
+hashbrown = { version = "0.17", features = ["serde"] }
 wasm-bindgen = "0.2.101"
 js-sys = "0.3"
 anyhow = "1"

--- a/crates/animation/bevy_vizij_animation/Cargo.toml
+++ b/crates/animation/bevy_vizij_animation/Cargo.toml
@@ -12,10 +12,10 @@ keywords    = ["vizij", "animation", "bevy", "plugin"]
 categories  = ["game-engines", "rendering", "wasm"]
 
 [dependencies]
-vizij-animation-core = { version = "1.0.0", path = "../vizij-animation-core" }
+vizij-animation-core = { version = "1", path = "../vizij-animation-core" }
 bevy                = { workspace = true }
-vizij-api-core      = { version = "1.0.0", path = "../../api/vizij-api-core" }
-bevy_vizij_api      = { version = "1.0.0", path = "../../api/bevy_vizij_api" }
+vizij-api-core      = { version = "1", path = "../../api/vizij-api-core" }
+bevy_vizij_api      = { version = "1", path = "../../api/bevy_vizij_api" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/animation/vizij-animation-core/Cargo.toml
+++ b/crates/animation/vizij-animation-core/Cargo.toml
@@ -16,11 +16,11 @@ exclude = ["*/scripts/*", ".github/*", "npm/*", "target/*"]
 [dependencies]
 serde       = { workspace = true }
 serde_json  = { workspace = true }
-vizij-api-core = { version = "1.0.0", path = "../../api/vizij-api-core" }
+vizij-api-core = { version = "1", path = "../../api/vizij-api-core" }
 
 [dev-dependencies]
 vizij-test-fixtures = { path = "../../test-fixtures/vizij-test-fixtures" }
-criterion = "0.5"
+criterion = "0.8"
 
 [[bench]]
 name = "animation_step"

--- a/crates/animation/vizij-animation-wasm/Cargo.toml
+++ b/crates/animation/vizij-animation-wasm/Cargo.toml
@@ -21,9 +21,9 @@ serde                = { workspace = true }
 serde-wasm-bindgen   = "0.6"
 serde_json           = "1"
 console_error_panic_hook = "0.1"
-vizij-animation-core = { path = "../vizij-animation-core", version = "1.0.0" }
-vizij-api-core       = { version = "1.0.0", path = "../../api/vizij-api-core" }
-vizij-api-wasm       = { version = "1.0.0", path = "../../api/vizij-api-wasm" }
+vizij-animation-core = { path = "../vizij-animation-core", version = "1" }
+vizij-api-core       = { version = "1", path = "../../api/vizij-api-core" }
+vizij-api-wasm       = { version = "1", path = "../../api/vizij-api-wasm" }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crates/api/bevy_vizij_api/Cargo.toml
+++ b/crates/api/bevy_vizij_api/Cargo.toml
@@ -6,6 +6,6 @@ publish = false
 
 [dependencies]
 bevy = { version = "0.14.2" }
-vizij-api-core = { version = "1.0.0", path = "../vizij-api-core" }
+vizij-api-core = { version = "1", path = "../vizij-api-core" }
 serde = { version = "1", features = ["derive"] }
 hashbrown = { workspace = true }

--- a/crates/api/vizij-api-core/Cargo.toml
+++ b/crates/api/vizij-api-core/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 arora-types = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-thiserror = "1"
-hashbrown = { version = "0.14", features = ["serde"] }
+thiserror = "2"
+hashbrown = { version = "0.17", features = ["serde"] }
 uuid = "1"

--- a/crates/api/vizij-api-wasm/Cargo.toml
+++ b/crates/api/vizij-api-wasm/Cargo.toml
@@ -12,4 +12,4 @@ wasm-bindgen = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-wasm-bindgen = "0.6"
-vizij-api-core = { version = "1.0.0", path = "../vizij-api-core" }
+vizij-api-core = { version = "1", path = "../vizij-api-core" }

--- a/crates/interop/vizij-animation-module/Cargo.toml
+++ b/crates/interop/vizij-animation-module/Cargo.toml
@@ -21,13 +21,13 @@ uuid = { version = "1", features = ["v4"] }
 [build-dependencies]
 anyhow = "1"
 arora-module-core = "0.2"
-arora-module-rust = "0.2.1"
+arora-module-rust = "0.2"
 arora-registry = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]
 anyhow = "1"
-arora-engine = "0.1"
+arora-engine = "2"
 arora-types = "1"
 uuid = { version = "1", features = ["v4"] }
 serde_yaml = "0.9"

--- a/crates/interop/vizij-arora-web/Cargo.toml
+++ b/crates/interop/vizij-arora-web/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # The published browser-runtime primitive: assembles arora's Runtime over an
 # injected HAL/bridge/store and exposes step() + the Value<->JSON store accessors.
 # 5.2.1 is the floor: the store accessors return plain JS objects from there.
-arora-web = "5.2.1"
+arora-web = "5.2"
 # The default Bridge: the in-process fake, all this device needs for now.
 arora-bridge = "3"
 

--- a/crates/node-graph/bevy_vizij_graph/Cargo.toml
+++ b/crates/node-graph/bevy_vizij_graph/Cargo.toml
@@ -16,9 +16,9 @@ bevy           = { workspace = true }
 serde          = { workspace = true }
 serde_json     = { workspace = true }
 hashbrown      = { workspace = true }
-vizij-graph-core = { path = "../vizij-graph-core", version = "1.0.0" }
-vizij-api-core = { version = "1.0.0", path = "../../api/vizij-api-core" }
-bevy_vizij_api = { version = "1.0.0", path = "../../api/bevy_vizij_api" }
+vizij-graph-core = { path = "../vizij-graph-core", version = "1" }
+vizij-api-core = { version = "1", path = "../../api/vizij-api-core" }
+bevy_vizij_api = { version = "1", path = "../../api/bevy_vizij_api" }
 
 [features]
 default = ["urdf_ik"]

--- a/crates/node-graph/vizij-graph-core/Cargo.toml
+++ b/crates/node-graph/vizij-graph-core/Cargo.toml
@@ -17,12 +17,12 @@ serde_json = { workspace = true }
 thiserror  = { workspace = true }
 hashbrown  = { workspace = true }
 anyhow     = { workspace = true }
-vizij-api-core = { version = "1.0.0", path = "../../api/vizij-api-core" }
+vizij-api-core = { version = "1", path = "../../api/vizij-api-core" }
 k = { version = "0.32", optional = true, default-features = false }
 urdf-rs = { version = "0.9", optional = true }
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = "0.8"
 vizij-test-fixtures = { path = "../../test-fixtures/vizij-test-fixtures" }
 
 [[bench]]

--- a/crates/node-graph/vizij-graph-wasm/Cargo.toml
+++ b/crates/node-graph/vizij-graph-wasm/Cargo.toml
@@ -19,8 +19,8 @@ wasm-bindgen = { workspace = true }
 serde        = { workspace = true }
 serde_json   = { workspace = true }
 hashbrown    = { workspace = true }
-vizij-graph-core = { path = "../vizij-graph-core", version = "1.0.0" }
-vizij-api-core = { version = "1.0.0", path = "../../api/vizij-api-core" }
+vizij-graph-core = { path = "../vizij-graph-core", version = "1" }
+vizij-api-core = { version = "1", path = "../../api/vizij-api-core" }
 serde-wasm-bindgen = { workspace = true }
 js-sys = { workspace = true }
 console_error_panic_hook = { version = "0.1", optional = true }

--- a/crates/orchestrator/vizij-orchestrator-core/Cargo.toml
+++ b/crates/orchestrator/vizij-orchestrator-core/Cargo.toml
@@ -11,9 +11,9 @@ path = "src/lib.rs"
 crate-type = ["lib"]
 
 [dependencies]
-vizij-api-core = { version = "1.0.0", path = "../../api/vizij-api-core" }
-vizij-graph-core = { version = "1.0.0", path = "../../node-graph/vizij-graph-core" }
-vizij-animation-core = { version = "1.0.0", path = "../../animation/vizij-animation-core" }
+vizij-api-core = { version = "1", path = "../../api/vizij-api-core" }
+vizij-graph-core = { version = "1", path = "../../node-graph/vizij-graph-core" }
+vizij-animation-core = { version = "1", path = "../../animation/vizij-animation-core" }
 vizij-test-fixtures = { path = "../../test-fixtures/vizij-test-fixtures" }
 
 # Workspace-managed utility crates
@@ -29,7 +29,7 @@ default = []
 
 [dev-dependencies]
 vizij-test-fixtures = { path = "../../test-fixtures/vizij-test-fixtures" }
-criterion = "0.5"
+criterion = "0.8"
 
 [[bench]]
 name = "orchestrator_tick"

--- a/crates/orchestrator/vizij-orchestrator-wasm/Cargo.toml
+++ b/crates/orchestrator/vizij-orchestrator-wasm/Cargo.toml
@@ -12,15 +12,15 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-serde-wasm-bindgen = "0.5"
-anyhow = "1.0"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde-wasm-bindgen = "0.6"
+anyhow = "1"
 
-vizij-orchestrator-core = { version = "1.0.0", path = "../vizij-orchestrator-core" }
-vizij-api-core = { version = "1.0.0", path = "../../api/vizij-api-core" }
-vizij-animation-core = { version = "1.0.0", path = "../../animation/vizij-animation-core" }
-vizij-graph-core = { version = "1.0.0", path = "../../node-graph/vizij-graph-core" }
+vizij-orchestrator-core = { version = "1", path = "../vizij-orchestrator-core" }
+vizij-api-core = { version = "1", path = "../../api/vizij-api-core" }
+vizij-animation-core = { version = "1", path = "../../animation/vizij-animation-core" }
+vizij-graph-core = { version = "1", path = "../../node-graph/vizij-graph-core" }
 
 console_error_panic_hook = { version = "0.1", optional = true }
 

--- a/crates/tools/vizij-glb-migrate/Cargo.toml
+++ b/crates/tools/vizij-glb-migrate/Cargo.toml
@@ -10,4 +10,4 @@ vizij-api-core = { path = "../../api/vizij-api-core" }
 # preserve_order keeps glTF JSON member order stable across the rewrite so
 # migrated files diff cleanly against their sources.
 serde_json = { version = "1", features = ["preserve_order", "float_roundtrip"] }
-thiserror = "1"
+thiserror = "2"


### PR DESCRIPTION
## What

Freshen the workspace's direct dependencies to their current majors and normalise version requirements to their minimal form.

- `thiserror` 1 → **2**
- `hashbrown` 0.14 → **0.17**
- `criterion` 0.5 → **0.8** (dev)
- `serde-wasm-bindgen` 0.5 → **0.6** in `vizij-orchestrator-wasm` (the other wasm crates were already 0.6)
- Loosen over-precise requirements: `1.0.0` path-dep pins → `1`, and drop patch pins (`arora-web` 5.2, `arora-module-rust` 0.2)

## Not changed

- **Bevy stays 0.14.2.** (An earlier spike bumped it to 0.19 for a native binary; that binary is dropped and Bevy is orphaned in this workspace — tracked for removal in **VIZ-63**.)
- **`wasm-bindgen` stays 0.2.101.** Its crate version is coupled to the wasm-pack CLI and the generated init glue; the Node wasm test harness only loads the 0.2.101 output. Updating the whole wasm-bindgen family *and* the harness is tracked in **VIZ-64**.

## Testing

- `cargo test --workspace`: **244 passed, 0 failed**
- `cargo fmt` + `cargo clippy --workspace --all-features --bins --examples --tests -D warnings`: clean (enforced by the pre-commit/pre-push hooks)
- `pnpm test:wasm` has a **pre-existing** failure unrelated to this PR: the Node harness initialises the wasm module via `fetch()`, which Node can't service (`TypeError: fetch failed / not implemented`). The wasm build scripts, loader, and harness are byte-identical to `main` and wasm-bindgen is unchanged, so this behaves exactly as on `main`. Fixing the harness is **VIZ-64**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
