### PR TITLE
ci: guard the animation module's arora_call boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,3 +133,29 @@ jobs:
           node-version: 24
       - name: Verify node registry artifacts are updated
         run: node scripts/verify-node-registry.mjs
+
+  # Proves the animation module's arora_call boundary end-to-end: the typed
+  # AnimationClip (Vec<Struct> -> Value::ArrayStructure) marshals through
+  # `arora_call` into the wasm module and the sampled TrackOutput marshals back.
+  # host_ramp is #[ignore]d because building the wasm artifact from inside the
+  # test deadlocks the cargo build lock, so we pre-build the artifact here and
+  # then run the test with --ignored (the workspace `cargo test` never runs it).
+  animation-module-boundary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-animmod-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build the animation wasm module artifact
+        run: cargo build -p vizij-animation-module --target wasm32-wasip1
+      - name: Prove the arora_call boundary (host_ramp)
+        run: cargo test -p vizij-animation-module --test host_ramp -- --ignored


### PR DESCRIPTION
## What

Adds a dedicated CI job (`animation-module-boundary`) that pre-builds the `vizij-animation-module` wasm artifact and runs the `host_ramp` test with `--ignored`.

## Why

`host_ramp` is the one test that proves the animation module's `arora_call` boundary end-to-end — the typed `AnimationClip` (`Vec<Struct>`) crossing into the wasm module as `Value::ArrayStructure`, and the sampled `TrackOutput` crossing back. It is `#[ignore]`d because building the wasm artifact from inside the test deadlocks the cargo build lock, so the workspace `cargo test --workspace` never runs it. That left the boundary integrated (the ARORA-55 codegen fix in `arora-module-rust 0.2.1` is in the lockfile) but **unverified in CI** — free to silently rot.

The new job pre-builds the artifact, then runs the test with `--ignored`. Verified locally: builds clean and `test result: ok. 1 passed`.

## Scope

One new independent job; no existing job or crate touched. Groundwork for VIZ-61 (animation ticked through the graph).

🤖 Generated with [Claude Code](https://claude.com/claude-code)