### PR TITLE
chore(hooks): build module-generated sources before cargo fmt

### DIFF
--- a/scripts/hook-tasks.sh
+++ b/scripts/hook-tasks.sh
@@ -22,11 +22,22 @@ run_cmd() {
   "$@"
 }
 
+# The arora wasm modules emit their `src/arora_generated/` sources from a
+# build.rs. Until those exist, `cargo fmt --all` can't resolve `mod
+# arora_generated` and dies — which in a fresh checkout forces a manual build
+# before fmt/hooks work. Build them first so fmt and the hooks just work.
+# Extend the list if more generated-source modules are added.
+rust_codegen() {
+  run_cmd "generate module sources (build.rs)" cargo build -p vizij-animation-module
+}
+
 rust_fmt() {
+  rust_codegen
   run_cmd "cargo fmt --all" cargo fmt --all
 }
 
 rust_fmt_check() {
+  rust_codegen
   run_cmd "cargo fmt --all -- --check" cargo fmt --all -- --check
 }
 


### PR DESCRIPTION
## Problem
The arora wasm modules (`vizij-animation-module`) emit `src/arora_generated/` from a `build.rs`. In a **fresh checkout** those sources don't exist yet, so `cargo fmt --all` can't resolve `mod arora_generated` and dies — which makes the fmt / pre-commit / pre-push hooks fail until you manually `cargo build` the module first. (Hit while landing the ModuleCall node, #42.)

## Fix
Add `rust_codegen()` (builds `vizij-animation-module`, running its `build.rs`) and call it at the top of `rust_fmt` / `rust_fmt_check` in `scripts/hook-tasks.sh`. Now fmt and the hooks generate what they need before running, so a clean worktree just works.

**Verified:** on a fresh worktree with no `arora_generated`, `bash scripts/hook-tasks.sh fmt-rust-check` now builds then fmt-checks clean (exit 0), where before it errored on the unresolved module.

Extend the `rust_codegen` build list if more generated-source modules are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)