### PR TITLE
feat(graph): ExternalFunction node + NodeFunctions call bridge (concrete Value, UUID ids)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5967,6 +5967,7 @@ dependencies = [
  "arora-simple-data-store",
  "arora-types",
  "serde_json",
+ "uuid",
  "vizij-api-core",
  "vizij-graph-core",
  "vizij-orchestrator-core",
@@ -6036,6 +6037,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "urdf-rs",
+ "uuid",
  "vizij-api-core",
  "vizij-test-fixtures",
 ]

--- a/crates/interop/vizij-arora-behavior/Cargo.toml
+++ b/crates/interop/vizij-arora-behavior/Cargo.toml
@@ -8,6 +8,7 @@ description = "Vizij node graph / orchestrator driven as Arora behavior interpre
 [dependencies]
 arora-behavior = "4"
 arora-types = "1"
+uuid = "1"
 vizij-api-core = { path = "../../api/vizij-api-core" }
 vizij-graph-core = { path = "../../node-graph/vizij-graph-core" }
 vizij-orchestrator-core = { path = "../../orchestrator/vizij-orchestrator-core" }

--- a/crates/interop/vizij-arora-behavior/src/lib.rs
+++ b/crates/interop/vizij-arora-behavior/src/lib.rs
@@ -19,12 +19,58 @@
 
 pub mod orchestrator;
 
+use std::collections::HashMap;
+
 use arora_behavior::{golden, BehaviorContext, BehaviorError, BehaviorInterpreter, BehaviorStatus};
+use arora_types::call::{Call, CallBridge};
 use arora_types::data::{DataStore, Key, StateChange};
-use arora_types::value::Value;
+use arora_types::value::{StructureField, Value};
+use uuid::Uuid;
 use vizij_api_core::TypedPath;
-use vizij_graph_core::eval::{evaluate_all, GraphRuntime};
+use vizij_graph_core::eval::{evaluate_all_with_functions, GraphRuntime, NodeFunctions};
 use vizij_graph_core::types::GraphSpec;
+
+/// Adapts an Arora [`CallBridge`] to graph-core's [`NodeFunctions`] host interface.
+///
+/// A graph `ExternalFunction` node carries an opaque function [`Uuid`] for the function it invokes.
+/// Arora's [`CallBridge::arora_call`] dispatches by *module* id — and the engine looks the module
+/// up directly (see `arora-engine`'s `Engine::arora_call`). So this adapter must know which module
+/// each function lives in; it holds a `function -> module` map supplied at construction. The map is
+/// built from module-load summaries (arora-engine's `LoadedModule { id, function_ids }`); this
+/// crate does not own that plumbing.
+struct CallBridgeFunctions<'a> {
+    bridge: &'a mut dyn CallBridge,
+    /// function id -> module id, so a bare function handle can be dispatched to `arora_call`.
+    function_modules: &'a HashMap<Uuid, Uuid>,
+}
+
+impl NodeFunctions for CallBridgeFunctions<'_> {
+    fn call(&mut self, function: Uuid, args: &[(Uuid, Value)]) -> Result<Value, String> {
+        let module_id = *self
+            .function_modules
+            .get(&function)
+            .ok_or_else(|| format!("no module registered for external function {function}"))?;
+        let args: Vec<StructureField> = args
+            .iter()
+            .map(|(id, value)| StructureField {
+                id: *id,
+                value: Box::new(value.clone()),
+            })
+            .collect();
+        let result = self
+            .bridge
+            .arora_call(
+                &module_id,
+                Call {
+                    module_id: Some(module_id),
+                    id: function,
+                    args,
+                },
+            )
+            .map_err(|e| format!("module call failed: {e}"))?;
+        Ok(result.ret)
+    }
+}
 
 /// A Vizij node graph as an Arora behavior interpreter.
 pub struct ProcessingGraph {
@@ -32,6 +78,10 @@ pub struct ProcessingGraph {
     rt: GraphRuntime,
     /// Store paths staged into the graph before each evaluation.
     inputs: Vec<TypedPath>,
+    /// function id -> module id, so `ExternalFunction` nodes can be dispatched through the
+    /// [`CallBridge`]. See [`CallBridgeFunctions`] for why this map is needed and where it
+    /// should come from.
+    function_modules: HashMap<Uuid, Uuid>,
 }
 
 impl ProcessingGraph {
@@ -41,14 +91,30 @@ impl ProcessingGraph {
             spec: spec.with_cache(),
             rt: GraphRuntime::default(),
             inputs,
+            function_modules: HashMap::new(),
         }
+    }
+
+    /// Set the `function id -> module id` map used to dispatch `ExternalFunction` nodes.
+    ///
+    /// Until this is populated, an `ExternalFunction` node errors with "no module registered".
+    pub fn set_function_modules(&mut self, function_modules: HashMap<Uuid, Uuid>) {
+        self.function_modules = function_modules;
     }
 
     /// Tick the graph against `store` for `dt`: read subscribed inputs, evaluate,
     /// write outputs. This is the inherent method behind the
     /// [`BehaviorInterpreter`] impl — handy for driving a graph directly and
     /// for tests.
-    pub fn tick_store(&mut self, store: &dyn DataStore, dt: f32) -> Result<(), BehaviorError> {
+    ///
+    /// `call_bridge` is the Arora host call interface; `ExternalFunction` nodes dispatch through
+    /// it, resolving each function to its module via the `function id -> module id` map.
+    pub fn tick_store(
+        &mut self,
+        store: &dyn DataStore,
+        call_bridge: &mut dyn CallBridge,
+        dt: f32,
+    ) -> Result<(), BehaviorError> {
         let delta = if dt.is_finite() { dt.max(0.0) } else { 0.0 };
         self.rt.dt = delta;
         self.rt.t += delta;
@@ -66,7 +132,12 @@ impl ProcessingGraph {
             }
         }
 
-        evaluate_all(&mut self.rt, &self.spec).map_err(|message| BehaviorError { message })?;
+        let mut functions = CallBridgeFunctions {
+            bridge: call_bridge,
+            function_modules: &self.function_modules,
+        };
+        evaluate_all_with_functions(&mut self.rt, &self.spec, &mut functions)
+            .map_err(|message| BehaviorError { message })?;
 
         // Write the graph's outputs back to the store.
         let writes = std::mem::take(&mut self.rt.writes);
@@ -86,7 +157,7 @@ impl ProcessingGraph {
 impl BehaviorInterpreter for ProcessingGraph {
     fn tick(&mut self, ctx: &mut BehaviorContext) -> Result<BehaviorStatus, BehaviorError> {
         let dt = golden_dt_seconds(ctx.store);
-        self.tick_store(ctx.store, dt)?;
+        self.tick_store(ctx.store, &mut *ctx.call_bridge, dt)?;
         // A node graph is continuous: tick it again next step.
         Ok(BehaviorStatus::Running)
     }
@@ -111,8 +182,30 @@ pub(crate) fn golden_dt_seconds(store: &dyn DataStore) -> f32 {
 mod tests {
     use super::*;
     use arora_simple_data_store::SimpleDataStore;
+    use arora_types::call::{Call, CallError, CallResult, Callable, CallableId};
     use serde_json::json;
+    use std::rc::Rc;
+    use uuid::Uuid;
     use vizij_api_core::value::{float, vec3};
+
+    /// A bridge the passthrough graphs never invoke (they contain no ExternalFunction nodes).
+    #[derive(Default)]
+    struct NoopBridge;
+
+    impl CallBridge for NoopBridge {
+        fn arora_call(&mut self, _module: &Uuid, _call: Call) -> Result<CallResult, CallError> {
+            unimplemented!("passthrough graphs make no external function calls")
+        }
+        fn arora_register_callable(&mut self, _callable: Rc<dyn Callable>) -> CallableId {
+            unimplemented!()
+        }
+        fn arora_unregister_callable(&mut self, _callable_id: &CallableId) {
+            unimplemented!()
+        }
+        fn arora_call_indirect(&mut self, _callable_id: &CallableId) -> Result<Value, CallError> {
+            unimplemented!()
+        }
+    }
 
     fn passthrough(input: &str, output: &str) -> GraphSpec {
         let mut spec = json!({
@@ -140,11 +233,13 @@ mod tests {
             vec![TypedPath::parse("sensor/x").unwrap()],
         );
 
+        let mut bridge = NoopBridge;
+
         // A scalar flows store -> graph -> store.
         store
             .write(StateChange::set("sensor/x", float(0.75)))
             .unwrap();
-        graph.tick_store(&store, 0.016).expect("tick");
+        graph.tick_store(&store, &mut bridge, 0.016).expect("tick");
         assert_eq!(read(&store, "actuator/y"), Some(float(0.75)));
 
         // A Vizij composite (`Value::Structure`) flows through unchanged too.
@@ -152,7 +247,7 @@ mod tests {
         store
             .write(StateChange::set("sensor/x", pos.clone()))
             .unwrap();
-        graph.tick_store(&store, 0.016).expect("tick");
+        graph.tick_store(&store, &mut bridge, 0.016).expect("tick");
         assert_eq!(read(&store, "actuator/y"), Some(pos));
     }
 

--- a/crates/node-graph/vizij-graph-core/Cargo.toml
+++ b/crates/node-graph/vizij-graph-core/Cargo.toml
@@ -18,6 +18,7 @@ thiserror  = { workspace = true }
 hashbrown  = { workspace = true }
 anyhow     = { workspace = true }
 vizij-api-core = { version = "1", path = "../../api/vizij-api-core" }
+uuid = { version = "1", features = ["serde"] }
 k = { version = "0.32", optional = true, default-features = false }
 urdf-rs = { version = "0.9", optional = true }
 

--- a/crates/node-graph/vizij-graph-core/src/eval/eval_node.rs
+++ b/crates/node-graph/vizij-graph-core/src/eval/eval_node.rs
@@ -1,10 +1,12 @@
 //! Per-node evaluation logic for the Vizij graph runtime.
 
 use crate::eval::graph_runtime::{GraphRuntime, StagedInput};
+use crate::eval::node_function::NodeFunctions;
 use crate::eval::plan::{PlanCache, PortLayout};
 use crate::eval::variadic::collect_operand_ports;
 use crate::types::{NodeParams, NodeSpec, NodeType, RoundMode};
 use hashbrown::HashMap;
+use uuid::Uuid;
 use vizij_api_core::value as vocab;
 use vizij_api_core::{coercion, Shape, Value, WriteOp};
 
@@ -177,13 +179,29 @@ fn single_output(outputs: &mut OutputSlots, value: Value) -> Result<(), String> 
 }
 
 /// Evaluate a single node, updating `rt` with new outputs and queued writes.
+///
+/// This is the host-agnostic entry point; nodes that require a [`NodeFunctions`] host
+/// (currently only [`NodeType::ExternalFunction`]) will error when evaluated through this path.
+/// Use [`eval_node_inner`] with `Some(functions)` to enable them.
 pub fn eval_node(
     rt: &mut GraphRuntime,
     spec: &NodeSpec,
     inputs: &InputSlots,
     outputs: &mut OutputSlots,
 ) -> Result<(), String> {
-    evaluate_kind(rt, spec, inputs, outputs)?;
+    eval_node_inner(rt, spec, inputs, outputs, None)
+}
+
+/// Evaluate a single node, optionally threading a [`NodeFunctions`] host through to
+/// `ExternalFunction` nodes.
+pub fn eval_node_inner(
+    rt: &mut GraphRuntime,
+    spec: &NodeSpec,
+    inputs: &InputSlots,
+    outputs: &mut OutputSlots,
+    functions: Option<&mut dyn NodeFunctions>,
+) -> Result<(), String> {
+    evaluate_kind_inner(rt, spec, inputs, outputs, functions)?;
     enforce_output_shapes_slots(spec, outputs.layout, outputs.as_mut_slice())?;
 
     // Only explicit sink nodes (Output) publish external writes.
@@ -203,11 +221,12 @@ pub fn eval_node(
     Ok(())
 }
 
-fn evaluate_kind(
+fn evaluate_kind_inner(
     rt: &mut GraphRuntime,
     spec: &NodeSpec,
     inputs: &InputSlots,
     outputs: &mut OutputSlots,
+    functions: Option<&mut dyn NodeFunctions>,
 ) -> Result<(), String> {
     let params = &spec.params;
     match &spec.kind {
@@ -305,7 +324,36 @@ fn evaluate_kind(
         NodeType::MathSubRecord => eval_math_record(inputs, outputs, |a, b| a - b),
         NodeType::Input => eval_input_node(rt, spec, outputs),
         NodeType::Output => eval_output(inputs, outputs),
+        NodeType::ExternalFunction => eval_external_function(params, inputs, outputs, functions),
     }
+}
+
+fn eval_external_function(
+    params: &NodeParams,
+    inputs: &InputSlots,
+    outputs: &mut OutputSlots,
+    functions: Option<&mut dyn NodeFunctions>,
+) -> Result<(), String> {
+    let function = params
+        .function
+        .ok_or_else(|| "ExternalFunction node requires a function id".to_string())?;
+
+    let functions = functions.ok_or_else(|| {
+        "ExternalFunction node evaluated without a function host (graph run outside a host)"
+            .to_string()
+    })?;
+
+    // Zip the configured param ids with the variadic `args` input ports, in slot order.
+    let param_ids: &[Uuid] = params.param_ids.as_deref().unwrap_or(&[]);
+    let args: Vec<(Uuid, Value)> = param_ids
+        .iter()
+        .copied()
+        .zip(inputs.variadic("args").iter().map(|pv| pv.value.clone()))
+        .collect();
+
+    let ret = functions.call(function, &args)?;
+
+    outputs.set_value("out", ret)
 }
 
 fn input_or_default(inputs: &InputSlots, key: &str) -> PortValue {

--- a/crates/node-graph/vizij-graph-core/src/eval/external_function_tests.rs
+++ b/crates/node-graph/vizij-graph-core/src/eval/external_function_tests.rs
@@ -1,0 +1,145 @@
+// ExternalFunction node unit tests: host dispatch, arg zipping, and the no-host error path.
+
+use super::*;
+use crate::types::{
+    EdgeInputEndpoint, EdgeOutputEndpoint, EdgeSpec, GraphSpec, NodeParams, NodeSpec, NodeType,
+};
+use hashbrown::HashMap;
+use uuid::Uuid;
+use vizij_api_core::value as vocab;
+use vizij_api_core::Value;
+
+/// Records each `call` it receives and always returns Float(42.0).
+#[derive(Default)]
+struct RecordingFunctions {
+    calls: Vec<(Uuid, Vec<(Uuid, Value)>)>,
+}
+
+impl NodeFunctions for RecordingFunctions {
+    fn call(&mut self, function: Uuid, args: &[(Uuid, Value)]) -> Result<Value, String> {
+        self.calls.push((function, args.to_vec()));
+        Ok(vocab::float(42.0))
+    }
+}
+
+fn constant_node(id: &str, value: Value) -> NodeSpec {
+    NodeSpec {
+        id: id.to_string(),
+        kind: NodeType::Constant,
+        params: NodeParams {
+            value: Some(value),
+            ..Default::default()
+        },
+        output_shapes: HashMap::new(),
+        input_defaults: HashMap::new(),
+    }
+}
+
+fn link(from: &str, to: &str, input: &str) -> EdgeSpec {
+    EdgeSpec {
+        from: EdgeOutputEndpoint {
+            node_id: from.to_string(),
+            output: "out".to_string(),
+        },
+        to: EdgeInputEndpoint {
+            node_id: to.to_string(),
+            input: input.to_string(),
+        },
+        selector: None,
+    }
+}
+
+fn external_function_graph(function_id: Uuid, param_id: Uuid) -> GraphSpec {
+    GraphSpec {
+        nodes: vec![
+            constant_node("arg0", Value::F32(7.0)),
+            NodeSpec {
+                id: "call".to_string(),
+                kind: NodeType::ExternalFunction,
+                params: NodeParams {
+                    function: Some(function_id),
+                    param_ids: Some(vec![param_id]),
+                    ..Default::default()
+                },
+                output_shapes: HashMap::new(),
+                input_defaults: HashMap::new(),
+            },
+        ],
+        // The variadic "args" group is addressed as args_0, args_1, ...
+        edges: vec![link("arg0", "call", "args_0")],
+        ..Default::default()
+    }
+    .with_cache()
+}
+
+#[test]
+fn external_function_dispatches_through_host_and_sets_output() {
+    let function_id = Uuid::from_u128(0x2222);
+    let param_id = Uuid::from_u128(0x3333);
+    let graph = external_function_graph(function_id, param_id);
+
+    let mut rt = GraphRuntime::default();
+    let mut functions = RecordingFunctions::default();
+    evaluate_all_with_functions(&mut rt, &graph, &mut functions)
+        .expect("external function should evaluate");
+
+    // Output "out" carries the host's returned value.
+    let out = rt
+        .outputs
+        .get("call")
+        .and_then(|ports| ports.get("out"))
+        .expect("call out present");
+    match &out.value {
+        Value::F32(f) => assert!((*f - 42.0).abs() < 1e-6, "expected 42.0, got {f}"),
+        other => panic!("expected float out, got {other:?}"),
+    }
+
+    // The host received exactly one call with the configured id and zipped arg.
+    assert_eq!(functions.calls.len(), 1, "expected a single invocation");
+    let (got_function, ref args) = functions.calls[0];
+    assert_eq!(got_function, function_id, "function id");
+    assert_eq!(args.len(), 1, "expected one positional arg");
+    assert_eq!(args[0].0, param_id, "arg key should match param_ids");
+    match &args[0].1 {
+        Value::F32(f) => assert!((*f - 7.0).abs() < 1e-6, "expected arg 7.0, got {f}"),
+        other => panic!("expected float arg, got {other:?}"),
+    }
+}
+
+#[test]
+fn external_function_without_host_errors() {
+    let graph = external_function_graph(Uuid::from_u128(0x2222), Uuid::from_u128(0x3333));
+
+    let mut rt = GraphRuntime::default();
+    let err = evaluate_all(&mut rt, &graph)
+        .expect_err("evaluating an ExternalFunction without a host must error");
+    assert!(
+        err.contains("without a function host"),
+        "unexpected error message: {err}"
+    );
+}
+
+#[test]
+fn external_function_missing_id_errors() {
+    let graph = GraphSpec {
+        nodes: vec![NodeSpec {
+            id: "call".to_string(),
+            kind: NodeType::ExternalFunction,
+            params: NodeParams::default(),
+            output_shapes: HashMap::new(),
+            input_defaults: HashMap::new(),
+        }],
+        edges: vec![],
+        ..Default::default()
+    }
+    .with_cache();
+
+    let mut rt = GraphRuntime::default();
+    let mut functions = RecordingFunctions::default();
+    let err = evaluate_all_with_functions(&mut rt, &graph, &mut functions)
+        .expect_err("missing function id must error");
+    assert!(
+        err.contains("requires a function id"),
+        "unexpected error message: {err}"
+    );
+}

--- a/crates/node-graph/vizij-graph-core/src/eval/mod.rs
+++ b/crates/node-graph/vizij-graph-core/src/eval/mod.rs
@@ -18,6 +18,7 @@ use std::mem;
 
 pub mod eval_node;
 mod graph_runtime;
+mod node_function;
 mod noise;
 mod numeric;
 mod plan;
@@ -28,11 +29,14 @@ mod variadic;
 
 pub use eval_node::eval_node;
 pub use graph_runtime::{GraphRuntime, StagedInput};
+pub use node_function::{NodeFunction, NodeFunctionRegistry, NodeFunctions};
 pub use plan::{fingerprint_spec, PlanCache};
 pub use value_layout::PortValue;
 
 #[cfg(test)]
 mod blend_tests;
+#[cfg(test)]
+mod external_function_tests;
 #[cfg(test)]
 mod tests;
 
@@ -40,7 +44,30 @@ mod tests;
 ///
 /// The runtime is cleared before evaluation and is repopulated as nodes are visited in topological
 /// order. Any error propagated from an individual node halts evaluation.
+///
+/// This path has no [`NodeFunctions`] host, so any `ExternalFunction` node in `spec` errors.
+/// Use [`evaluate_all_with_functions`] to run graphs that invoke node-functions.
 pub fn evaluate_all(rt: &mut GraphRuntime, spec: &GraphSpec) -> Result<(), String> {
+    evaluate_all_inner(rt, spec, None)
+}
+
+/// Evaluate every node in `spec`, threading `functions` through to any `ExternalFunction` nodes.
+///
+/// Behaves exactly like [`evaluate_all`] except that `ExternalFunction` nodes dispatch through
+/// `functions` (the host node-function interface) instead of erroring.
+pub fn evaluate_all_with_functions(
+    rt: &mut GraphRuntime,
+    spec: &GraphSpec,
+    functions: &mut dyn NodeFunctions,
+) -> Result<(), String> {
+    evaluate_all_inner(rt, spec, Some(functions))
+}
+
+fn evaluate_all_inner(
+    rt: &mut GraphRuntime,
+    spec: &GraphSpec,
+    mut functions: Option<&mut dyn NodeFunctions>,
+) -> Result<(), String> {
     if spec.version > 0 {
         rt.plan.ensure_versioned(spec)?;
     } else {
@@ -78,7 +105,13 @@ pub fn evaluate_all(rt: &mut GraphRuntime, spec: &GraphSpec) -> Result<(), Strin
                 let mut outputs =
                     eval_node::OutputSlots::new(&mut vec_out, &plan.layouts[idx].outputs);
                 outputs.clear();
-                eval_node::eval_node(rt, node, &inputs, &mut outputs)?;
+                // Reborrow the optional host with a fresh, per-iteration lifetime so the mutable
+                // borrow does not outlive a single node evaluation.
+                let functions_ref: Option<&mut dyn NodeFunctions> = match functions {
+                    Some(ref mut f) => Some(&mut **f),
+                    None => None,
+                };
+                eval_node::eval_node_inner(rt, node, &inputs, &mut outputs, functions_ref)?;
             }
 
             let compat = eval_node::materialize_outputs(&plan.layouts[idx].outputs, &vec_out);

--- a/crates/node-graph/vizij-graph-core/src/eval/node_function.rs
+++ b/crates/node-graph/vizij-graph-core/src/eval/node_function.rs
@@ -1,0 +1,66 @@
+//! Node-function abstraction for the
+//! [`ExternalFunction`](crate::types::NodeType::ExternalFunction) node.
+//!
+//! The graph core knows nothing about how a node-function is resolved or run: an
+//! [`ExternalFunction`](crate::types::NodeType::ExternalFunction) node carries only a stable
+//! function id (a [`Uuid`]) plus opaque arg-key handles. Evaluating such a node calls out to a
+//! [`NodeFunctions`] host that owns all the domain meaning. Values are always the shared runtime
+//! type [`vizij_api_core::Value`].
+
+use hashbrown::HashMap;
+use uuid::Uuid;
+use vizij_api_core::Value;
+
+/// A single external function a node can invoke.
+///
+/// Identified by a stable [`id`](NodeFunction::id) used for serialization and by remote callers;
+/// [`call`](NodeFunction::call) maps the argument values to a result value.
+pub trait NodeFunction {
+    /// Stable identifier of this function.
+    fn id(&self) -> Uuid;
+    /// Invoke the function with `args`, returning its result value or an error message.
+    ///
+    /// Each entry pairs an opaque arg-key handle (from the node's `param_ids`) with the value
+    /// flowing into the matching variadic `args` input, in order.
+    fn call(&mut self, args: &[(Uuid, Value)]) -> Result<Value, String>;
+}
+
+/// The host the graph consults to invoke a node-function by id.
+///
+/// `function` is the stable id from the node's params; `args` pairs each opaque arg-key handle
+/// with the value flowing into the matching variadic `args` input, in order.
+pub trait NodeFunctions {
+    /// Invoke the function identified by `function` with `args`.
+    fn call(&mut self, function: Uuid, args: &[(Uuid, Value)]) -> Result<Value, String>;
+}
+
+/// A registry of [`NodeFunction`]s keyed by their stable id.
+///
+/// Implements [`NodeFunctions`] by dispatching each call to the matching entry, so a set of
+/// individual node-functions can serve as a host without further wiring.
+#[derive(Default)]
+pub struct NodeFunctionRegistry {
+    functions: HashMap<Uuid, Box<dyn NodeFunction>>,
+}
+
+impl NodeFunctionRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register `function` under its own [`NodeFunction::id`], replacing any prior entry.
+    pub fn register(&mut self, function: Box<dyn NodeFunction>) {
+        self.functions.insert(function.id(), function);
+    }
+}
+
+impl NodeFunctions for NodeFunctionRegistry {
+    fn call(&mut self, function: Uuid, args: &[(Uuid, Value)]) -> Result<Value, String> {
+        let entry = self
+            .functions
+            .get_mut(&function)
+            .ok_or_else(|| format!("no node-function registered for id '{function}'"))?;
+        entry.call(args)
+    }
+}

--- a/crates/node-graph/vizij-graph-core/src/lib.rs
+++ b/crates/node-graph/vizij-graph-core/src/lib.rs
@@ -9,7 +9,8 @@ pub mod topo;
 pub mod types;
 
 pub use eval::{
-    eval_node, evaluate_all, evaluate_all_cached, GraphRuntime, PortValue, StagedInput,
+    eval_node, evaluate_all, evaluate_all_cached, evaluate_all_with_functions, GraphRuntime,
+    NodeFunction, NodeFunctionRegistry, NodeFunctions, PortValue, StagedInput,
 };
 pub use schema::registry;
 pub use topo::topo_order;

--- a/crates/node-graph/vizij-graph-core/src/schema.rs
+++ b/crates/node-graph/vizij-graph-core/src/schema.rs
@@ -2670,6 +2670,34 @@ pub fn registry() -> Registry {
         params: vec![],
     });
 
+    // External function invocation (variadic args -> single result via host function interface)
+    nodes.push(NodeSignature {
+        type_id: ExternalFunction,
+        name: "External Function",
+        category: "Functions",
+        doc: "Invokes an external function (by opaque id) through the host-provided function \
+              interface, passing the variadic Args inputs zipped with the configured param_ids.",
+        inputs: vec![],
+        variadic_inputs: Some(VariadicSpec {
+            id: "args",
+            ty: PortType::Any,
+            label: "Arg",
+            doc: "Positional argument value bound to the matching entry in param_ids.",
+            min: 0,
+            max: None,
+            keyed: false,
+        }),
+        outputs: vec![PortSpec {
+            id: "out",
+            ty: PortType::Any,
+            label: "Out",
+            doc: "Value returned by the invoked external function.",
+            optional: false,
+        }],
+        variadic_outputs: None,
+        params: vec![],
+    });
+
     Registry {
         version: "1.0.0",
         nodes,

--- a/crates/node-graph/vizij-graph-core/src/types.rs
+++ b/crates/node-graph/vizij-graph-core/src/types.rs
@@ -5,6 +5,7 @@
 
 use hashbrown::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 use vizij_api_core::{Shape, TypedPath, Value};
 
 /// Stable node identifier within a single [`GraphSpec`].
@@ -151,6 +152,11 @@ pub enum NodeType {
     Input,
     /// Writes a value to a host-visible typed path sink.
     Output,
+
+    // External function invocation
+    /// Invokes an external function (resolved by opaque id) through the host-provided
+    /// [`NodeFunctions`](crate::eval::NodeFunctions) interface.
+    ExternalFunction,
 }
 
 /// Node-construction parameters consumed selectively by different [`NodeType`] variants.
@@ -272,6 +278,18 @@ pub struct NodeParams {
     /// Example: `"robot1/Arm/Joint3.translation"`.
     #[serde(default)]
     pub path: Option<TypedPath>,
+
+    /// Stable id of the node-function invoked by [`NodeType::ExternalFunction`].
+    ///
+    /// The graph attaches no meaning to this id beyond passing it to the host
+    /// [`NodeFunctions`](crate::eval::NodeFunctions); the host resolves and invokes it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub function: Option<Uuid>,
+    /// Ordered arg-key handles matching the [`NodeType::ExternalFunction`] variadic `args` inputs.
+    ///
+    /// These are opaque to the graph; the host pairs each with the positional value in the call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub param_ids: Option<Vec<Uuid>>,
 }
 
 /// Rounding strategy for [`NodeType::Round`].

--- a/npm/@vizij/node-graph-wasm/src/metadata/registry.json
+++ b/npm/@vizij/node-graph-wasm/src/metadata/registry.json
@@ -3103,6 +3103,31 @@
         }
       ],
       "params": []
+    },
+    {
+      "type_id": "externalfunction",
+      "name": "External Function",
+      "category": "Functions",
+      "doc": "Invokes an external function (by opaque id) through the host-provided function interface, passing the variadic Args inputs zipped with the configured param_ids.",
+      "inputs": [],
+      "variadic_inputs": {
+        "id": "args",
+        "ty": "any",
+        "label": "Arg",
+        "doc": "Positional argument value bound to the matching entry in param_ids.",
+        "min": 0,
+        "keyed": false
+      },
+      "outputs": [
+        {
+          "id": "out",
+          "ty": "any",
+          "label": "Out",
+          "doc": "Value returned by the invoked external function.",
+          "optional": false
+        }
+      ],
+      "params": []
     }
   ]
 }

--- a/npm/@vizij/node-graph-wasm/src/metadata/registry.ts
+++ b/npm/@vizij/node-graph-wasm/src/metadata/registry.ts
@@ -3106,6 +3106,31 @@ const registry: Registry = {
         }
       ],
       "params": []
+    },
+    {
+      "type_id": "externalfunction",
+      "name": "External Function",
+      "category": "Functions",
+      "doc": "Invokes an external function (by opaque id) through the host-provided function interface, passing the variadic Args inputs zipped with the configured param_ids.",
+      "inputs": [],
+      "variadic_inputs": {
+        "id": "args",
+        "ty": "any",
+        "label": "Arg",
+        "doc": "Positional argument value bound to the matching entry in param_ids.",
+        "min": 0,
+        "keyed": false
+      },
+      "outputs": [
+        {
+          "id": "out",
+          "ty": "any",
+          "label": "Out",
+          "doc": "Value returned by the invoked external function.",
+          "optional": false
+        }
+      ],
+      "params": []
     }
   ]
 };

--- a/npm/@vizij/node-graph-wasm/src/types.d.ts
+++ b/npm/@vizij/node-graph-wasm/src/types.d.ts
@@ -106,7 +106,8 @@ export type NodeType =
   | "mathdivrecord"
   | "mathsubrecord"
   | "input"
-  | "output";
+  | "output"
+  | "externalfunction";
 
 export type ShapeJSON =
   | { id: "Scalar"; meta?: Record<string, string> }


### PR DESCRIPTION
Adds an `ExternalFunction` node to the vizij node graph that dispatches through a host-provided call bridge, letting a graph invoke Arora module functions by UUID.

## What
- `NodeType::ExternalFunction` + `NodeParams { function: Option<Uuid>, param_ids: Option<Vec<Uuid>> }`.
- A `NodeFunction` / `NodeFunctions` seam in `vizij-graph-core` (`eval/node_function.rs`):
  - `NodeFunction { fn id(&self) -> Uuid; fn call(&mut self, args: &[(Uuid, Value)]) -> Result<Value, String> }`
  - `NodeFunctions { fn call(&mut self, function: Uuid, args: &[(Uuid, Value)]) -> Result<Value, String> }`
  - `NodeFunctionRegistry` (`HashMap<Uuid, Box<dyn NodeFunction>>`).
- `evaluate_all_with_functions(rt, spec, &mut dyn NodeFunctions)` alongside `evaluate_all` (host = `None`). An `ExternalFunction` node errors without a host.
- `vizij-arora-behavior` supplies `CallBridgeFunctions` over the Arora `CallBridge`, plus a `function -> module` map (`set_function_modules`); `ProcessingGraph::tick_store` runs the graph with the host.

## Deliberately NOT generic
Values are concrete `vizij_api_core::Value` (= Arora `Value`) throughout — **no `GraphValue` trait, no `<V>`**. Function ids are `Uuid` end to end (no String, no parse round-trip).

## Why this supersedes #42 and #45
#42 bundled this ExternalFunction kernel with a value-type-*generic* refactor of the whole graph crate; #45 was the follow-up dropping the `= Value` default. We concluded the genericity was ceremony over a single value type (`vizij_api_core::Value` *is* `arora_types::value::Value`) and abstracted nothing real (graph-core already depends on Arora transitively). This PR keeps only the useful kernel, concrete, so **#42 and #45 are superseded and being closed.**

## Verification
`cargo build --workspace --all-features` + default features, `clippy --all-features -D warnings`, 59 graph-core tests (incl. 3 external-function tests) + 3 arora-behavior tests — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)