### PR TITLE
ci: stop double CI runs on PRs (scope push to main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: ci
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
`ci.yml` triggered on bare `push:` + `pull_request:`, so same-repo PR branches ran the whole suite twice (once per event; the concurrency group keys on `github.ref`, which differs between `refs/heads/…` and `refs/pull/N/merge`, so the two never cancel). Scope `push` to `branches: [main]` — matching `docs.yml`. PRs now run once via the pull_request event; `main` still builds on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)