### PR TITLE
refactor(api-core): move the Blackboard out of the orchestrator crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2928,7 +2928,6 @@ version = "0.0.0"
 dependencies = [
  "arora-types",
  "vizij-api-core",
- "vizij-orchestrator-core",
 ]
 
 [[package]]

--- a/crates/api/vizij-api-core/src/blackboard.rs
+++ b/crates/api/vizij-api-core/src/blackboard.rs
@@ -1,11 +1,25 @@
 //! Blackboard storage and conflict tracking for orchestrator frames.
 
-use anyhow::{anyhow, Result};
 use std::collections::HashMap;
+use std::fmt;
+
+/// Error from a blackboard JSON write: what failed to parse, as text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlackboardError(pub String);
+
+impl fmt::Display for BlackboardError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for BlackboardError {}
+
+type Result<T> = std::result::Result<T, BlackboardError>;
 
 use serde::{Deserialize, Serialize};
 
-use vizij_api_core::{json, Shape, TypedPath, Value, WriteBatch};
+use crate::{json, Shape, TypedPath, Value, WriteBatch};
 
 /// Single blackboard entry with provenance information.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -92,7 +106,8 @@ impl Blackboard {
         epoch: u64,
         source: String,
     ) -> Result<()> {
-        let tp = TypedPath::parse(path).map_err(|e| anyhow!("typedpath parse error: {}", e))?;
+        let tp = TypedPath::parse(path)
+            .map_err(|e| BlackboardError(format!("typedpath parse error: {}", e)))?;
         let entry = BlackboardEntry::new(value, shape, epoch, source, 0);
         self.inner.insert(tp, entry);
         Ok(())
@@ -110,12 +125,13 @@ impl Blackboard {
         epoch: u64,
         source: String,
     ) -> Result<()> {
-        let value: Value =
-            json::parse_value(value_json).map_err(|e| anyhow!("value deserialize: {}", e))?;
+        let value: Value = json::parse_value(value_json)
+            .map_err(|e| BlackboardError(format!("value deserialize: {}", e)))?;
         let shape: Option<Shape> = match shape_json {
-            Some(sj) => {
-                Some(serde_json::from_value(sj).map_err(|e| anyhow!("shape deserialize: {}", e))?)
-            }
+            Some(sj) => Some(
+                serde_json::from_value(sj)
+                    .map_err(|e| BlackboardError(format!("shape deserialize: {}", e)))?,
+            ),
             None => None,
         };
         self.set(path, value, shape, epoch, source)
@@ -209,8 +225,8 @@ impl Blackboard {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use vizij_api_core::value::{as_vec3, float, vec3};
-    use vizij_api_core::{WriteBatch, WriteOp};
+    use crate::value::{as_vec3, float, vec3};
+    use crate::{WriteBatch, WriteOp};
 
     #[test]
     fn set_and_get_entry() {

--- a/crates/api/vizij-api-core/src/lib.rs
+++ b/crates/api/vizij-api-core/src/lib.rs
@@ -3,6 +3,7 @@
 //! shared across Vizij runtimes.
 
 /// Blend helpers shared by animation and graph runtimes.
+pub mod blackboard;
 pub mod blend;
 /// Coercion helpers for adapting values across shape boundaries.
 pub mod coercion;

--- a/crates/interop/vizij-arora-store/Cargo.toml
+++ b/crates/interop/vizij-arora-store/Cargo.toml
@@ -7,5 +7,4 @@ description = "Vizij's Blackboard exposed as an Arora DataStore (arora-types)."
 
 [dependencies]
 vizij-api-core = { path = "../../api/vizij-api-core" }
-vizij-orchestrator-core = { path = "../../orchestrator/vizij-orchestrator-core" }
 arora-types = "1"

--- a/crates/interop/vizij-arora-store/src/lib.rs
+++ b/crates/interop/vizij-arora-store/src/lib.rs
@@ -19,8 +19,8 @@ use std::sync::mpsc::{channel, Sender};
 use std::sync::{Arc, Mutex, RwLock};
 
 use arora_types::data::{DataError, DataStore, Key, Slot, State, StateChange, Subscription};
+use vizij_api_core::blackboard::{Blackboard, BlackboardEntry};
 use vizij_api_core::{TypedPath, Value};
-use vizij_orchestrator::blackboard::{Blackboard, BlackboardEntry};
 
 /// Source label recorded on entries written through the Arora `DataStore` view.
 const SOURCE: &str = "arora";

--- a/crates/orchestrator/vizij-orchestrator-core/src/lib.rs
+++ b/crates/orchestrator/vizij-orchestrator-core/src/lib.rs
@@ -4,7 +4,10 @@
 //! runs them according to a configurable schedule, and returns merged writes plus conflict
 //! diagnostics for each frame.
 
-pub mod blackboard;
+// The blackboard lives in `vizij-api-core` (it is shared vocabulary, wrapped
+// by `vizij-arora-store` as an Arora `DataStore`); re-exported here so
+// `vizij_orchestrator::blackboard::…` paths keep working.
+pub use vizij_api_core::blackboard;
 pub mod controllers;
 pub mod diagnostics;
 pub mod fixtures;


### PR DESCRIPTION
`vizij-arora-store` (the device store) depended on `vizij-orchestrator-core` just for `Blackboard`/`BlackboardEntry` — an anchor to a crate the orchestrator dissolution retires, and a blocker for making the store consumable by a native device host (VIZ-74's end-state).

- `Blackboard`/`BlackboardEntry`/`ConflictLog` move to **`vizij_api_core::blackboard`** (their only dependency); `vizij_orchestrator::blackboard` stays as a re-export, so existing paths compile unchanged.
- api-core stays anyhow-free: the module's JSON-write errors become a small typed `BlackboardError` (`std::error::Error`, so `anyhow` callers keep `?`).
- `vizij-arora-store` now depends only on `vizij-api-core` + `arora-types` — orchestrator-free.

Verified: `cargo check --workspace` clean; tests green (api-core 53, arora-store 6+16, orchestrator-core 14); fmt/clippy via pre-commit hook.