### PR TITLE
Vizij standalone on the arora 9 wave: run(), in-place graph load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,9 +144,9 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "arora"
-version = "8.1.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61981b1ca3827114996cbdce16f97dcf44f6bfb0fd0792139ec7cb025397002a"
+checksum = "8bfac93a71d2cfa8b112f94d3ede8b8c0d34a7949bc776ed46536f371b3bde3a"
 dependencies = [
  "anyhow",
  "arora-behavior",
@@ -157,15 +157,18 @@ dependencies = [
  "arora-simple-data-store",
  "arora-types",
  "futures",
+ "gloo-timers",
  "log",
+ "tokio",
  "uuid",
+ "web-time",
 ]
 
 [[package]]
 name = "arora-behavior"
-version = "4.0.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a59358d264db9a116904ade0d685a3ac7428691f157877e3414012038904e18b"
+checksum = "3fb04bb2692f56bdf70c7382cbec4206af8cd68cde47e8e41da04d0356045e95"
 dependencies = [
  "arora-types",
  "serde",
@@ -174,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "arora-behavior-tree"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf4b586610596f3c8e35bb434c876c328eef25400d43034ea791b95e15c0c4d"
+checksum = "ef4848d0c9c96d0c7f453f1b0721a6afb237720bbb48513484e58405b9c05314"
 dependencies = [
  "anyhow",
  "arora-behavior",
@@ -197,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "arora-behavior-tree-types"
-version = "0.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f136a84a870d32ec032e4c4ed62d2dfd513b632e378741fb87a31f16104a2b29"
+checksum = "b55473fe82fabd387c57c743c061a2509e4ad6f8263e28b0a888c8231e5646d6"
 dependencies = [
  "arora-types",
  "lazy_static",
@@ -209,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "arora-bridge"
-version = "3.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ad91fff7a4be172b8ffdd2c188dd66c9073304310b92d35b6a5cadea014a16"
+checksum = "eb06e17e4b19c0655a28086bc52444906784fac5acb95d86cbf7e366c160180a"
 dependencies = [
  "arora-types",
  "async-trait",
@@ -222,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "arora-buffers"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82708a96701c147829cd51ea405a1562c8f7f1fa86eb6b78a22470f4f5ecb796"
+checksum = "5d17ec0a4456ddc613cdcc83e500f569c44519579a36d32e31a8d114709a1977"
 dependencies = [
  "arora-types",
  "bytes",
@@ -236,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "arora-engine"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4442590a7cc9cab4811f1c641a5081d7221e17a39d72b40a2c5729af286beb11"
+checksum = "0fad162f6335cc7819b85d5cce0220da70fbbc641d819ea6d0db22495b4ca23a"
 dependencies = [
  "anyhow",
  "arora-buffers",
@@ -267,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "arora-hal"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0309f683585a6629d94abffd7b3ad21a7d91e3873efa374a75dfd2ea7b0d20b8"
+checksum = "f3bbdcf56318450a5601d25db2d23ace3a582ebfacddfb17353b9d3b78d0a739"
 dependencies = [
  "arora-types",
  "async-trait",
@@ -279,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "arora-module-core"
-version = "0.2.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "358d0d833ddf195e103de342587d0ab6bccf6116e84aedca15c3e128b9fdcf70"
+checksum = "e254adb2d910455e3116db83bc08ce0f40886b760d709062bf2ae21341619883"
 dependencies = [
  "arora-registry",
  "arora-types",
@@ -299,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "arora-module-rust"
-version = "0.2.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91902a5454e582566d826617e13364d49624da4af1bc0b50dc050c2273b90899"
+checksum = "445833061354fcc19f6efeec0902b6b15eb1cc7b0c09036ecb4e386bf166b180"
 dependencies = [
  "anyhow",
  "arora-module-core",
@@ -326,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "arora-registry"
-version = "0.1.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9477f2399b45395282152579752604b8b9ce4eb957b243c5d7f49716976695"
+checksum = "6c9d15505c15804abd15226a6f0112d68d20c3d0bb93826890cbaa5ea8722cef"
 dependencies = [
  "anyhow",
  "arora-types",
@@ -344,18 +347,18 @@ dependencies = [
 
 [[package]]
 name = "arora-simple-data-store"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6b1beaf5b408289a5b2269fdb447c19a488bb571fcc0d910f76f0ff145cc35"
+checksum = "fc8cbede58f2a86b8153eaa30b219b973331b9af5c23de859cf2de5d6fae7d67"
 dependencies = [
  "arora-types",
 ]
 
 [[package]]
 name = "arora-types"
-version = "1.9.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfadc34ee6f612d2f7047030c1a8628e78d10611e94dfdda8c4a69a2db52f644"
+checksum = "750822222b2135d4c174071e3c781126cea382fe742b170db370937e6c0bf23f"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -382,16 +385,12 @@ dependencies = [
 
 [[package]]
 name = "arora-web"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d547ec3a5f0735b6f14d1a121374146e726a70dc4725411cecc9183d8b9b69e8"
+checksum = "76b917b59d4bb5a99bebb691a65f6c135b471ce81f5ee7557043b3cf5c12fc05"
 dependencies = [
  "arora",
- "arora-behavior",
- "arora-bridge",
  "arora-engine",
- "arora-hal",
- "arora-simple-data-store",
  "arora-types",
  "console_error_panic_hook",
  "getrandom 0.4.3",
@@ -1370,6 +1369,18 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2934,12 +2945,10 @@ dependencies = [
 name = "vizij-arora-web"
 version = "0.0.0"
 dependencies = [
- "arora-bridge",
+ "arora",
  "arora-types",
  "arora-web",
- "async-trait",
  "console_error_panic_hook",
- "futures-channel",
  "getrandom 0.4.3",
  "js-sys",
  "serde-wasm-bindgen",
@@ -2949,7 +2958,6 @@ dependencies = [
  "vizij-arora-behavior",
  "vizij-arora-hal",
  "vizij-arora-store",
- "vizij-graph-core",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -3578,6 +3586,16 @@ name = "web-sys"
 version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crates/api/vizij-api-core/Cargo.toml
+++ b/crates/api/vizij-api-core/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-arora-types = "1"
+arora-types = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/interop/vizij-animation-module/Cargo.toml
+++ b/crates/interop/vizij-animation-module/Cargo.toml
@@ -9,8 +9,8 @@ description = "vizij-animation-core packaged as an Arora wasm module (build once
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-arora-buffers = "1"
-arora-types = "1"
+arora-buffers = "2"
+arora-types = "2"
 vizij-animation-core = { path = "../../animation/vizij-animation-core" }
 vizij-arora = { path = "../vizij-arora" }
 vizij-api-core = { path = "../../api/vizij-api-core" }
@@ -20,15 +20,15 @@ uuid = { version = "1", features = ["v4"] }
 
 [build-dependencies]
 anyhow = "1"
-arora-module-core = "0.2"
-arora-module-rust = "0.2"
-arora-registry = "0.1"
+arora-module-core = "1"
+arora-module-rust = "1"
+arora-registry = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]
 anyhow = "1"
-arora-engine = "2"
-arora-types = "1"
+arora-engine = "3"
+arora-types = "2"
 uuid = { version = "1", features = ["v4"] }
 serde_yaml = "0.9"
 vizij-arora = { path = "../vizij-arora" }

--- a/crates/interop/vizij-animation-module/tests/host_ramp.rs
+++ b/crates/interop/vizij-animation-module/tests/host_ramp.rs
@@ -154,9 +154,8 @@ fn ramp_advances_through_the_wasm_module() {
     let call = |engine: &mut _, fn_id: &str, args: Vec<StructureField>| -> Value {
         <_ as arora_types::call::CallBridge>::arora_call(
             engine,
-            &module,
             Call {
-                module_id: None,
+                module_id: Some(module),
                 id: u(fn_id),
                 args,
             },

--- a/crates/interop/vizij-arora-behavior/Cargo.toml
+++ b/crates/interop/vizij-arora-behavior/Cargo.toml
@@ -6,13 +6,13 @@ publish = false
 description = "Vizij node graph / orchestrator driven as Arora behavior interpreters (ProcessingGraph, OrchestratorBehavior)."
 
 [dependencies]
-arora-behavior = "4"
-arora-types = "1"
+arora-behavior = "5"
+arora-types = "2"
+serde_json = { workspace = true }
 uuid = "1"
 vizij-api-core = { path = "../../api/vizij-api-core" }
 vizij-graph-core = { path = "../../node-graph/vizij-graph-core" }
 vizij-orchestrator-core = { path = "../../orchestrator/vizij-orchestrator-core" }
 
 [dev-dependencies]
-arora-simple-data-store = "1"
-serde_json = { workspace = true }
+arora-simple-data-store = "2"

--- a/crates/interop/vizij-arora-behavior/src/lib.rs
+++ b/crates/interop/vizij-arora-behavior/src/lib.rs
@@ -10,34 +10,40 @@
 //! the runtime's golden store key ([`arora_behavior::golden::DT`], nanoseconds
 //! since the previous step), published before each tick.
 //!
-//! Queue one into an Arora runtime with
-//! `Runtime::queue_behavior(Box::new(pg))`; it then reads/writes the same
-//! blackboard the behavior tree and the bridge do.
+//! Inject one into an Arora device with
+//! `AroraBuilder::with_behavior_interpreter(Box::new(pg))`; it then
+//! reads/writes the same blackboard the bridge and the HAL do. Swapping the
+//! running graph does not rebuild the device: a [`spec_graph`] LOAD call
+//! reaches [`ProcessingGraph::load`] through the engine's interpreter module.
 //!
 //! [`orchestrator::OrchestratorBehavior`] wraps a whole Vizij orchestrator
 //! (many controllers + their merge) as one interpreter (VIZ-38).
+//!
+//! [`ProcessingGraph::load`]: arora_behavior::BehaviorInterpreter::load
 
 pub mod orchestrator;
+pub mod spec_graph;
 
 use std::collections::HashMap;
 
-use arora_behavior::{golden, BehaviorContext, BehaviorError, BehaviorInterpreter, BehaviorStatus};
+use arora_behavior::{
+    golden, BehaviorContext, BehaviorError, BehaviorInterpreter, BehaviorStatus, Graph,
+};
 use arora_types::call::{Call, CallBridge};
 use arora_types::data::{DataStore, Key, StateChange};
 use arora_types::value::{StructureField, Value};
 use uuid::Uuid;
 use vizij_api_core::TypedPath;
 use vizij_graph_core::eval::{evaluate_all_with_functions, GraphRuntime, NodeFunctions};
-use vizij_graph_core::types::GraphSpec;
+use vizij_graph_core::types::{GraphSpec, NodeType};
 
 /// Adapts an Arora [`CallBridge`] to graph-core's [`NodeFunctions`] host interface.
 ///
 /// A graph `ExternalFunction` node carries an opaque function [`Uuid`] for the function it invokes.
-/// Arora's [`CallBridge::arora_call`] dispatches by *module* id — and the engine looks the module
-/// up directly (see `arora-engine`'s `Engine::arora_call`). So this adapter must know which module
-/// each function lives in; it holds a `function -> module` map supplied at construction. The map is
-/// built from module-load summaries (arora-engine's `LoadedModule { id, function_ids }`); this
-/// crate does not own that plumbing.
+/// The engine routes a [`Call`] by its `module_id` and refuses one naming no module, so this
+/// adapter must know which module each function lives in; it holds a `function -> module` map
+/// supplied at construction. The map is built from module-load summaries (arora-engine's
+/// `LoadedModule { id, function_ids }`); this crate does not own that plumbing.
 struct CallBridgeFunctions<'a> {
     bridge: &'a mut dyn CallBridge,
     /// function id -> module id, so a bare function handle can be dispatched to `arora_call`.
@@ -59,14 +65,11 @@ impl NodeFunctions for CallBridgeFunctions<'_> {
             .collect();
         let result = self
             .bridge
-            .arora_call(
-                &module_id,
-                Call {
-                    module_id: Some(module_id),
-                    id: function,
-                    args,
-                },
-            )
+            .arora_call(Call {
+                module_id: Some(module_id),
+                id: function,
+                args,
+            })
             .map_err(|e| format!("module call failed: {e}"))?;
         Ok(result.ret)
     }
@@ -82,6 +85,26 @@ pub struct ProcessingGraph {
     /// [`CallBridge`]. See [`CallBridgeFunctions`] for why this map is needed and where it
     /// should come from.
     function_modules: HashMap<Uuid, Uuid>,
+}
+
+/// Normalize and deserialize a Vizij graph spec from JSON (any form the spec
+/// normalizer accepts).
+pub fn parse_spec(json: &str) -> Result<GraphSpec, String> {
+    let mut spec: serde_json::Value =
+        serde_json::from_str(json).map_err(|e| format!("graph spec is not JSON: {e}"))?;
+    vizij_api_core::json::normalize_graph_spec_value(&mut spec)
+        .map_err(|e| format!("normalize graph spec failed: {e}"))?;
+    serde_json::from_value(spec).map_err(|e| format!("invalid graph spec: {e}"))
+}
+
+/// The store paths the spec's `input` nodes read — what the graph subscribes
+/// to on the device's store.
+pub fn input_paths(spec: &GraphSpec) -> Vec<TypedPath> {
+    spec.nodes
+        .iter()
+        .filter(|node| matches!(node.kind, NodeType::Input))
+        .filter_map(|node| node.params.path.clone())
+        .collect()
 }
 
 impl ProcessingGraph {
@@ -161,6 +184,25 @@ impl BehaviorInterpreter for ProcessingGraph {
         // A node graph is continuous: tick it again next step.
         Ok(BehaviorStatus::Running)
     }
+
+    /// Replace the running Vizij graph in place — the interpreter module's
+    /// LOAD entry point, reached through the engine like any module call, so a
+    /// recompose never rebuilds the device (VIZ-57).
+    ///
+    /// `graph` must be a [`spec_graph`] carrier: the shared model's one-node
+    /// form whose literal input holds the Vizij spec JSON (see that module for
+    /// why the spec rides the shared model opaquely). The spec is parsed and
+    /// installed immediately with a fresh graph runtime; the store and the
+    /// `function -> module` map are untouched — the store belongs to the
+    /// device, and the loaded-module set is fixed at device build.
+    fn load(&mut self, graph: Graph) -> Result<(), BehaviorError> {
+        let json = spec_graph::decode(&graph).map_err(|message| BehaviorError { message })?;
+        let spec = parse_spec(&json).map_err(|message| BehaviorError { message })?;
+        self.inputs = input_paths(&spec);
+        self.spec = spec.with_cache();
+        self.rt = GraphRuntime::default();
+        Ok(())
+    }
 }
 
 /// The current step's `dt` in seconds, read from the runtime-maintained
@@ -185,7 +227,6 @@ mod tests {
     use arora_types::call::{Call, CallError, CallResult, Callable, CallableId};
     use serde_json::json;
     use std::rc::Rc;
-    use uuid::Uuid;
     use vizij_api_core::value::{float, vec3};
 
     /// A bridge the passthrough graphs never invoke (they contain no ExternalFunction nodes).
@@ -193,7 +234,7 @@ mod tests {
     struct NoopBridge;
 
     impl CallBridge for NoopBridge {
-        fn arora_call(&mut self, _module: &Uuid, _call: Call) -> Result<CallResult, CallError> {
+        fn arora_call(&mut self, _call: Call) -> Result<CallResult, CallError> {
             unimplemented!("passthrough graphs make no external function calls")
         }
         fn arora_register_callable(&mut self, _callable: Rc<dyn Callable>) -> CallableId {
@@ -249,6 +290,61 @@ mod tests {
             .unwrap();
         graph.tick_store(&store, &mut bridge, 0.016).expect("tick");
         assert_eq!(read(&store, "actuator/y"), Some(pos));
+    }
+
+    /// The in-place load path: a spec-carrier graph swaps the running Vizij
+    /// graph without touching the store or the device around it.
+    #[test]
+    fn load_swaps_the_graph_in_place() {
+        let store = SimpleDataStore::new();
+        let mut graph = ProcessingGraph::from_spec(
+            passthrough("sensor/x", "actuator/y"),
+            vec![TypedPath::parse("sensor/x").unwrap()],
+        );
+        let mut bridge = NoopBridge;
+
+        store
+            .write(StateChange::set("sensor/x", float(0.5)))
+            .unwrap();
+        graph.tick_store(&store, &mut bridge, 0.016).expect("tick");
+        assert_eq!(read(&store, "actuator/y"), Some(float(0.5)));
+
+        // Load a different passthrough; the next tick runs the new spec.
+        let json = serde_json::json!({
+            "nodes": [
+                { "id": "in",  "type": "input",  "params": { "path": "sensor/b" } },
+                { "id": "out", "type": "output", "params": { "path": "actuator/b" } }
+            ],
+            "edges": [
+                { "from": { "node_id": "in" }, "to": { "node_id": "out", "input": "in" } }
+            ]
+        })
+        .to_string();
+        graph
+            .load(spec_graph::encode(&json))
+            .expect("the carrier graph loads");
+
+        store
+            .write(StateChange::set("sensor/b", float(0.25)))
+            .unwrap();
+        graph.tick_store(&store, &mut bridge, 0.016).expect("tick");
+        assert_eq!(read(&store, "actuator/b"), Some(float(0.25)));
+        // The old spec no longer runs…
+        store
+            .write(StateChange::set("sensor/x", float(0.9)))
+            .unwrap();
+        graph.tick_store(&store, &mut bridge, 0.016).expect("tick");
+        assert_eq!(read(&store, "actuator/y"), Some(float(0.5)));
+        // …and the store around the swap was never reset.
+        assert_eq!(read(&store, "sensor/x"), Some(float(0.9)));
+    }
+
+    /// A non-carrier graph is refused: Vizij edition goes through the
+    /// spec-carrier load, not the shared model's structural form.
+    #[test]
+    fn load_rejects_a_non_carrier_graph() {
+        let mut graph = ProcessingGraph::from_spec(passthrough("a", "b"), vec![]);
+        assert!(graph.load(Graph::empty()).is_err());
     }
 
     #[test]

--- a/crates/interop/vizij-arora-behavior/src/spec_graph.rs
+++ b/crates/interop/vizij-arora-behavior/src/spec_graph.rs
@@ -1,0 +1,120 @@
+//! The Vizij graph spec carried as a shared behavior [`Graph`].
+//!
+//! Arora's one behavior-edition seam is the interpreter module: a `Call` to
+//! its LOAD function reaches [`BehaviorInterpreter::load`] through the
+//! engine's normal dispatch, carrying an [`arora_behavior::Graph`]. Vizij's
+//! authored model is a `vizij-graph-core` spec, whose node vocabulary the
+//! shared model does not (yet) mirror structurally — so the spec rides the
+//! shared model **opaquely**: one node bound to the [`GRAPH_PROGRAM`]
+//! function, whose single input is fed the normalized spec JSON as a literal.
+//! [`ProcessingGraph::load`](crate::ProcessingGraph) recognizes exactly that
+//! shape and installs the spec in place.
+//!
+//! A structural mapping (Vizij node kinds as shared-model functions, edited
+//! per-node through `GraphDiff`) would make Vizij graphs editable by any
+//! shared-model tool; until then [`GraphDiff`](arora_behavior::GraphDiff)
+//! edition is rejected and every edit is a whole-spec load.
+//!
+//! [`BehaviorInterpreter::load`]: arora_behavior::BehaviorInterpreter::load
+
+use arora_behavior::graph::{Io, Link, LinkSource, Node, Port};
+use arora_behavior::{interpreter_module, Graph};
+use arora_types::call::Call;
+use arora_types::value::Value;
+use uuid::{uuid, Uuid};
+
+/// Function id of the one carrier node: "run this Vizij graph spec".
+/// Self-identifying like the vizij type ids: the ASCII bytes of "vizij" lead
+/// the UUID, the behavior-carrier group tails it.
+pub const GRAPH_PROGRAM: Uuid = uuid!("76697a69-6a00-0000-0000-000000400001");
+
+/// Slot id of the carrier node's one input: the normalized spec JSON, fed by
+/// a literal link.
+pub const GRAPH_SPEC_SLOT: Uuid = uuid!("76697a69-6a00-0000-0000-000000400002");
+
+/// Wrap `spec_json` (a Vizij graph spec, in any form the spec normalizer
+/// accepts) into the one-node carrier [`Graph`].
+pub fn encode(spec_json: &str) -> Graph {
+    let mut graph = Graph::empty();
+    graph.nodes.insert(
+        GRAPH_PROGRAM,
+        Node {
+            id: GRAPH_PROGRAM,
+            function: GRAPH_PROGRAM,
+            inputs: vec![Io::new(GRAPH_SPEC_SLOT)],
+            ..Node::default()
+        },
+    );
+    graph.links.push(Link::new(
+        Port::new(GRAPH_PROGRAM, GRAPH_SPEC_SLOT),
+        LinkSource::Literal(Value::String(spec_json.to_string())),
+    ));
+    graph.root = Some(GRAPH_PROGRAM);
+    graph
+}
+
+/// Read the spec JSON back out of a carrier [`Graph`]. Errors when the graph
+/// is not the one-node carrier shape [`encode`] produces.
+pub fn decode(graph: &Graph) -> Result<String, String> {
+    let root = graph
+        .root
+        .ok_or_else(|| "the graph names no root node".to_string())?;
+    let node = graph
+        .node(&root)
+        .ok_or_else(|| format!("the root node {root} is not in the graph"))?;
+    if node.function != GRAPH_PROGRAM {
+        return Err(format!(
+            "the root node is bound to {}, not the Vizij graph-program function",
+            node.function
+        ));
+    }
+    match graph.link_to(&Port::new(node.id, GRAPH_SPEC_SLOT)) {
+        Some(Link {
+            source: LinkSource::Literal(Value::String(json)),
+            ..
+        }) => Ok(json.clone()),
+        Some(_) => Err("the graph-spec slot is not fed a literal string".to_string()),
+        None => Err("the graph-spec slot is not fed".to_string()),
+    }
+}
+
+/// Build the interpreter-module LOAD [`Call`] that installs `spec_json` as
+/// the running behavior — what an embedder dispatches (through an
+/// `arora::Caller` or `Arora::call`) to swap the Vizij graph in place.
+pub fn encode_load_call(spec_json: &str) -> Call {
+    interpreter_module::encode_load(&encode(spec_json))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_round_trips_the_spec_json() {
+        let json = r#"{"nodes":[],"edges":[]}"#;
+        assert_eq!(decode(&encode(json)).unwrap(), json);
+    }
+
+    #[test]
+    fn decode_rejects_non_carrier_graphs() {
+        // No root.
+        assert!(decode(&Graph::empty()).is_err());
+
+        // A root bound to some other function.
+        let mut graph = encode("{}");
+        graph.nodes.get_mut(&GRAPH_PROGRAM).unwrap().function = Uuid::from_u128(7);
+        assert!(decode(&graph).is_err());
+
+        // The spec slot unfed.
+        let mut graph = encode("{}");
+        graph.links.clear();
+        assert!(decode(&graph).is_err());
+    }
+
+    #[test]
+    fn load_call_round_trips_through_the_interpreter_module() {
+        let call = encode_load_call(r#"{"nodes":[]}"#);
+        let graph = interpreter_module::decode_load(&call).unwrap();
+        assert_eq!(decode(&graph).unwrap(), r#"{"nodes":[]}"#);
+    }
+}

--- a/crates/interop/vizij-arora-hal/Cargo.toml
+++ b/crates/interop/vizij-arora-hal/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 description = "Vizij rig presented as an Arora HAL (arora-hal)."
 
 [dependencies]
-arora-hal = "2"
-arora-types = "1"
+arora-hal = "3"
+arora-types = "2"
 async-trait = "0.1"
 futures-channel = "0.3"
 futures-core = "0.3"

--- a/crates/interop/vizij-arora-store/Cargo.toml
+++ b/crates/interop/vizij-arora-store/Cargo.toml
@@ -7,4 +7,4 @@ description = "Vizij's Blackboard exposed as an Arora DataStore (arora-types)."
 
 [dependencies]
 vizij-api-core = { path = "../../api/vizij-api-core" }
-arora-types = "1"
+arora-types = "2"

--- a/crates/interop/vizij-arora-store/src/lib.rs
+++ b/crates/interop/vizij-arora-store/src/lib.rs
@@ -149,8 +149,22 @@ impl DataStore for BlackboardStore {
 
     fn subscribe(&self) -> Subscription {
         let (tx, rx) = channel();
-        self.inner.subscribers.lock().unwrap().push(tx);
+        // The current state, as the subscription's first change: a subscriber
+        // starts from the full picture and stays current from what follows.
+        // Taken while holding the subscriber list so a concurrent write lands
+        // either in this opening state or in a later change, never in neither.
+        let mut subscribers = self.inner.subscribers.lock().unwrap();
+        let mut initial = StateChange::new();
+        for (key, value) in self.snapshot().storage {
+            initial.set.insert(key, value);
+        }
+        let _ = tx.send(initial);
+        subscribers.push(tx);
         Subscription::new(rx)
+    }
+
+    fn clone_box(&self) -> Box<dyn DataStore> {
+        Box::new(self.clone())
     }
 }
 
@@ -239,8 +253,40 @@ mod tests {
     fn subscribe_delivers_changes() {
         let store = BlackboardStore::new();
         let sub = store.subscribe();
+        sub.try_recv().expect("opening state");
         store.write(StateChange::set("k", bool_(true))).unwrap();
         assert!(sub.try_recv().expect("change").contains(&Key::from("k")));
+    }
+
+    /// A subscription opens on everything the store already holds, so a
+    /// subscriber never has to read a snapshot separately and race the
+    /// changes that follow.
+    #[test]
+    fn subscribe_opens_on_the_current_state() {
+        let store = BlackboardStore::new();
+        store
+            .write(StateChange::set("already", bool_(true)))
+            .unwrap();
+
+        let sub = store.subscribe();
+        let opening = sub.try_recv().expect("opening state");
+        assert!(opening.contains(&Key::from("already")));
+
+        store
+            .write(StateChange::set("later", bool_(false)))
+            .unwrap();
+        assert!(sub
+            .try_recv()
+            .expect("change")
+            .contains(&Key::from("later")));
+    }
+
+    #[test]
+    fn clone_box_is_a_sibling_handle() {
+        let store = BlackboardStore::new();
+        let sibling = store.clone_box();
+        store.write(StateChange::set("k", float(1.0))).unwrap();
+        assert_eq!(sibling.read(&[Key::from("k")]), vec![Some(float(1.0))]);
     }
 
     #[test]

--- a/crates/interop/vizij-arora-web/Cargo.toml
+++ b/crates/interop/vizij-arora-web/Cargo.toml
@@ -3,25 +3,25 @@ name = "vizij-arora-web"
 version = "0.0.0"
 edition.workspace = true
 publish = false
-description = "Run a Vizij runtime in the browser as an Arora device: a thin wasm-bindgen cdylib over arora-web's BrowserRuntime, injected with a BlackboardStore + RigHal + a Vizij Behavior (VIZ-14)."
+description = "Run a Vizij runtime in the browser as an Arora device: a thin wasm-bindgen cdylib composing an arora::Arora over a BlackboardStore + RigHal + a Vizij graph behavior, wrapped with arora-web's AroraWeb (VIZ-14)."
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-# The whole crate is `wasm32`-only (arora-web's browser runtime is), so every
+# The whole crate is `wasm32`-only (arora-web's JS surface is), so every
 # dependency is gated to that target. On the host the crate is an empty shim with
 # no dependencies, so it still participates in a native `cargo build`/`cargo test`
-# without pulling the browser runtime into a host link.
+# without pulling the browser device into a host link.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-# The published browser-runtime primitive: assembles arora's Runtime over an
-# injected HAL/bridge/store and exposes step() + the Value<->JSON store accessors.
-# 5.3 is the floor: `BrowserRuntime::builder()` (with_module) arrives there.
-arora-web = "5.3"
-# The Bridge seam: the device's one bridge here is the in-process `JsBridge`,
-# feeding JS-issued commands (module calls) into the step sweep.
-arora-bridge = "3"
+# The device runtime: AroraBuilder composes the device over the injected
+# HAL/store/behavior seams; its LocalCaller dispatches in-process Calls.
+# `native` off: the browser's WebAssembly host executes modules, not wasmtime.
+arora = { version = "9", default-features = false }
+# The shared browser JS surface: AroraWeb (step/run/call + the Value<->JSON
+# store accessors) wraps the composed device.
+arora-web = "6"
 # Call/Header/Value vocabulary crossing the JS boundary as JSON.
-arora-types = "1"
+arora-types = "2"
 
 # The interop crates that already implement the Arora traits over Vizij.
 vizij-arora-store = { path = "../vizij-arora-store" }
@@ -30,17 +30,12 @@ vizij-arora-behavior = { path = "../vizij-arora-behavior" }
 
 # Vizij pieces the browser wrapper builds the injected behavior from.
 vizij-api-core = { path = "../../api/vizij-api-core" }
-vizij-graph-core = { path = "../../node-graph/vizij-graph-core" }
 
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = "0.4"
 js-sys = { workspace = true }
 serde_json = { workspace = true }
 console_error_panic_hook = "0.1"
-# The Bridge trait's contract types: async methods (async-trait) and the
-# command/reply channels (futures-channel, the same crate arora-bridge uses).
-async-trait = "0.1"
-futures-channel = "0.3"
 uuid = "1"
 # uuid v4 on wasm needs a browser RNG (selects getrandom's wasm_js backend).
 getrandom = { version = "0.4", features = ["wasm_js"] }

--- a/crates/interop/vizij-arora-web/src/lib.rs
+++ b/crates/interop/vizij-arora-web/src/lib.rs
@@ -1,28 +1,31 @@
 //! Run a Vizij runtime *as* an Arora device in the browser.
 //!
-//! This is a thin wasm-bindgen wrapper: it assembles the Vizij interop pieces
-//! and hands them to [`arora_web::BrowserRuntime`], the reusable browser-device
-//! primitive, then forwards the JS-facing methods. All the runtime scaffolding
-//! (the arora step loop, the golden clock, the Value↔JSON store accessors)
-//! lives in `arora-web`; here we only choose the backends:
+//! This is a thin wasm-bindgen wrapper: it composes an [`arora::Arora`] from
+//! the Vizij interop pieces with [`arora::AroraBuilder`], wraps it with
+//! [`arora_web::AroraWeb`] (the shared browser JS surface: `step`, the
+//! self-pacing `run`, the Value↔JSON store accessors), and forwards the
+//! JS-facing methods. Here we only choose the backends:
 //!
 //! - the store is a [`BlackboardStore`] (a Vizij `Blackboard` as an Arora
 //!   `DataStore`);
 //! - the HAL is a [`RigHal`] (a Vizij rig as an Arora HAL);
-//! - the bridge is a [`JsBridge`], an in-process endpoint whose "remote" is the
-//!   embedding JavaScript — [`VizijArora::call`] feeds it;
 //! - the behavior is a [`ProcessingGraph`] (a Vizij node graph driven as the
 //!   device's `BehaviorInterpreter`), built from the caller's graph spec.
 //!
 //! JavaScript constructs it with [`VizijArora::start`] (passing a Vizij graph
-//! spec as JSON, in any accepted form — the spec normalizer runs here, plus
-//! optionally the Arora wasm modules to load into the device's engine), drives
-//! it one tick at a time with [`VizijArora::step`] from `requestAnimationFrame`
-//! timestamps, and reads or writes keys on the injected store through the
-//! forwarded accessors. Values cross the JS boundary as JSON in the Arora
-//! `Value` vocabulary (e.g. `{"f32": 0.75}`). Module functions are reached with
-//! [`VizijArora::call`], which dispatches through the device's step like any
-//! bridge command.
+//! spec as JSON, in any accepted form — the spec normalizer runs device-side —
+//! plus optionally the Arora wasm modules to load into the device's engine).
+//! It then either hands the device to its own loop with
+//! [`run`](VizijArora::run) or drives it one tick at a time with
+//! [`step`](VizijArora::step); the rest of the surface stays live either way,
+//! because none of it touches the stepping device. Values cross the JS
+//! boundary as JSON in the Arora `Value` vocabulary (e.g. `{"f32": 0.75}`).
+//!
+//! Module functions are reached with [`call`](VizijArora::call), and the
+//! running graph is swapped **in place** with
+//! [`loadGraph`](VizijArora::load_graph) — both dispatch through the device's
+//! in-process [`arora::Caller`], applied at the next step like a remote's
+//! command, so neither requires rebuilding the device (VIZ-57).
 //!
 //! This crate only carries content when built for `wasm32`; on the host it is
 //! an empty shim so it can participate in `cargo build`/`cargo test` on the
@@ -31,22 +34,15 @@
 #![cfg(target_arch = "wasm32")]
 
 use std::collections::HashMap;
-use std::time::Duration;
 
-use arora_bridge::{
-    Bridge, BridgeCommand, BridgeOp, BridgeResult, DeviceInfo, Inbound, InboundStream,
-};
+use arora::{Arora, Caller, LocalCaller};
 use arora_types::call::Call;
 use arora_types::module::low::Header;
-use arora_web::BrowserRuntime;
-use async_trait::async_trait;
-use futures_channel::{mpsc, oneshot};
+use arora_web::AroraWeb;
 use uuid::Uuid;
-use vizij_api_core::TypedPath;
-use vizij_arora_behavior::ProcessingGraph;
+use vizij_arora_behavior::{input_paths, parse_spec, spec_graph, ProcessingGraph};
 use vizij_arora_hal::RigHal;
 use vizij_arora_store::BlackboardStore;
-use vizij_graph_core::types::{GraphSpec, NodeType};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
@@ -55,57 +51,20 @@ const GRAPH_INPUT: &str = "sensor/x";
 /// The store path the default proof graph writes to.
 const GRAPH_OUTPUT: &str = "actuator/y";
 
-/// An in-process bridge endpoint whose "remote" is the embedding JavaScript.
+/// A Vizij-on-Arora device, JS-callable.
 ///
-/// Commands enqueued by [`VizijArora::call`] arrive on the device's inbound
-/// stream and dispatch during the next step's sweep — the same seam a remote
-/// (Studio) bridge command takes, so a JS call behaves exactly like a bridged
-/// one: it executes inside `step`, through the engine's `CallBridge`, and
-/// replies on its one-shot channel. Outbound state changes are dropped (this
-/// endpoint has no remote store).
-struct JsBridge {
-    /// Handed over (once) by [`Bridge::take_inbound`].
-    inbound: Option<mpsc::UnboundedReceiver<Inbound>>,
-}
-
-impl JsBridge {
-    /// The endpoint plus the sender JS-side methods enqueue commands on.
-    fn new() -> (Self, mpsc::UnboundedSender<Inbound>) {
-        let (tx, rx) = mpsc::unbounded();
-        (Self { inbound: Some(rx) }, tx)
-    }
-}
-
-#[async_trait]
-impl Bridge for JsBridge {
-    fn take_inbound(&mut self) -> InboundStream {
-        Box::pin(self.inbound.take().expect("inbound stream already taken"))
-    }
-
-    fn try_send(&mut self, _change: &arora_types::data::StateChange) {}
-
-    async fn get_device_info(&self) -> BridgeResult<Option<DeviceInfo>> {
-        Ok(None)
-    }
-
-    async fn update_device_info(
-        &self,
-        info: Option<DeviceInfo>,
-    ) -> BridgeResult<Option<DeviceInfo>> {
-        Ok(info)
-    }
-}
-
-/// A running Vizij-on-Arora device, JS-callable.
-///
-/// Holds an [`arora_web::BrowserRuntime`] assembled over the Vizij interop
-/// pieces; every method forwards to it.
+/// Wraps the composed [`Arora`] with [`arora_web::AroraWeb`] and keeps two
+/// Vizij-side extras: the device's in-process [`LocalCaller`] (behind
+/// [`call`](Self::call) and [`loadGraph`](Self::load_graph)) and the
+/// `function id -> module id` map that routes a bare function reference to
+/// the engine's by-module dispatch.
 #[wasm_bindgen]
 pub struct VizijArora {
-    inner: BrowserRuntime,
-    /// Where [`call`](Self::call) enqueues commands for the device's
-    /// [`JsBridge`]; the next step dispatches them.
-    commands: mpsc::UnboundedSender<Inbound>,
+    inner: AroraWeb,
+    /// Dispatches in-process `Call`s into the device — enqueued at once,
+    /// applied at the next step, resolved on that step's reply. Usable while
+    /// [`run`](Self::run) owns the device.
+    caller: LocalCaller,
     /// function id -> module id over every loaded module's exports, so a call
     /// (or a graph `ExternalFunction` node) can name just the function.
     function_modules: HashMap<Uuid, Uuid>,
@@ -113,9 +72,8 @@ pub struct VizijArora {
 
 #[wasm_bindgen]
 impl VizijArora {
-    /// Start the device in the browser: inject a [`BlackboardStore`] +
-    /// [`RigHal`] + a [`JsBridge`] into a [`BrowserRuntime`] with a
-    /// [`ProcessingGraph`] as its behavior.
+    /// Build the device: a [`BlackboardStore`] + [`RigHal`] + a
+    /// [`ProcessingGraph`] behavior, composed with [`arora::AroraBuilder`].
     ///
     /// `graph_json` is a Vizij graph spec (any form the spec normalizer
     /// accepts); its `input` nodes' paths become the store keys the graph
@@ -126,15 +84,19 @@ impl VizijArora {
     /// a JS array of `{ headerJson, wasmBytes }` (the module's header as JSON
     /// and its `.wasm` bytes as a `Uint8Array`). Their functions are then
     /// reachable with [`call`](Self::call) and from the graph's
-    /// `ExternalFunction` nodes. Drive with [`step`](Self::step).
+    /// `ExternalFunction` nodes. The module set is fixed at build.
+    ///
+    /// Drive the device with [`run`](Self::run) (self-paced) or
+    /// [`step`](Self::step) (your own clock).
     pub async fn start(
         graph_json: Option<String>,
         modules: Option<js_sys::Array>,
     ) -> Result<VizijArora, JsValue> {
         let spec = match graph_json {
-            Some(json) => parse_graph(&json)?,
-            None => parse_graph(&passthrough_json(GRAPH_INPUT, GRAPH_OUTPUT))?,
-        };
+            Some(json) => parse_spec(&json),
+            None => parse_spec(&passthrough_json(GRAPH_INPUT, GRAPH_OUTPUT)),
+        }
+        .map_err(|e| JsValue::from_str(&e))?;
         let modules = parse_modules(modules)?;
         let function_modules = function_modules(&modules);
 
@@ -142,35 +104,53 @@ impl VizijArora {
         let mut graph = ProcessingGraph::from_spec(spec, inputs);
         graph.set_function_modules(function_modules.clone());
 
-        let (bridge, commands) = JsBridge::new();
-        let mut builder = BrowserRuntime::builder()
+        let mut builder = Arora::builder()
             .with_hal(Box::new(RigHal::new()))
-            .with_bridge(Box::new(bridge))
             .with_data_store(Box::new(BlackboardStore::new()))
             .with_behavior_interpreter(Box::new(graph));
         for (header, wasm) in modules {
             builder = builder.with_module(header, wasm);
         }
-        let inner = builder.build()?;
+        let arora = builder
+            .build()
+            .map_err(|e| JsValue::from_str(&format!("arora build failed: {e:?}")))?;
+        let caller = arora.caller();
 
         Ok(VizijArora {
-            inner,
-            commands,
+            inner: AroraWeb::from(arora),
+            caller,
             function_modules,
         })
     }
 
+    /// Advance the device one step. `dt_ms` is the wall time elapsed since
+    /// the previous step, in milliseconds — the difference of two
+    /// `requestAnimationFrame` timestamps. Unavailable once
+    /// [`run`](Self::run) has taken the device.
+    pub fn step(&self, dt_ms: f64) -> Result<(), JsValue> {
+        self.inner.step(dt_ms)
+    }
+
+    /// Hand the device to its own loop, for good: a self-paced run at
+    /// `period_ms` (default: the runtime's ~100 Hz) that owns the device
+    /// until stepping fails — the returned promise only ever rejects, and
+    /// [`step`](Self::step) is unavailable from then on. The rest of the
+    /// surface keeps working: it never touches the stepping device.
+    pub fn run(&self, period_ms: Option<f64>) -> js_sys::Promise {
+        self.inner.run(period_ms)
+    }
+
     /// Call a loaded module's function through the device. `call_json` is an
     /// Arora `Call` as JSON (`{ "id": <function uuid>, "args": [...] }`, args
-    /// and result in the Arora `Value` vocabulary); `module_id` may be omitted
-    /// when the function belongs to a module loaded at
+    /// and result in the Arora `Value` vocabulary); `module_id` may be
+    /// omitted when the function belongs to a module loaded at
     /// [`start`](Self::start).
     ///
-    /// The call dispatches inside the device's **next** [`step`](Self::step)
-    /// — the same phase a remote bridge command executes in — so the returned
-    /// promise (of the `CallResult` as JSON) resolves only after that step
-    /// runs. Under a `requestAnimationFrame` loop just `await` it; a direct
-    /// driver calls `step` in between.
+    /// The call dispatches through the device's in-process caller inside the
+    /// **next** step — the same phase a remote bridge command executes in —
+    /// so the returned promise (of the `CallResult` as JSON) resolves only
+    /// after that step runs. The device must be stepping (a [`run`](Self::run)
+    /// loop, or your own [`step`](Self::step) calls) for it to land.
     pub fn call(&self, call_json: &str) -> Result<js_sys::Promise, JsValue> {
         let mut call: Call = serde_json::from_str(call_json)
             .map_err(|e| JsValue::from_str(&format!("invalid call json: {e}")))?;
@@ -183,33 +163,49 @@ impl VizijArora {
                 call.id
             )));
         }
+        Ok(self.dispatch(call))
+    }
 
-        let (reply, response) = oneshot::channel();
-        self.commands
-            .unbounded_send(Inbound::Command(BridgeCommand::new(
-                BridgeOp::Call(call),
-                reply,
-            )))
-            .map_err(|_| JsValue::from_str("the device no longer accepts commands"))?;
+    /// Replace the device's running Vizij graph **in place** (VIZ-57).
+    /// `graph_json` is a Vizij graph spec in any accepted form; it reaches
+    /// the device's interpreter as the engine's LOAD call (see
+    /// `vizij_arora_behavior::spec_graph`), so the store, the loaded modules,
+    /// and the device itself all survive the swap.
+    ///
+    /// Applied — like any call — at the next step; the promise resolves once
+    /// the new graph is installed and rejects if the spec does not parse.
+    #[wasm_bindgen(js_name = loadGraph)]
+    pub fn load_graph(&self, graph_json: &str) -> js_sys::Promise {
+        self.dispatch(spec_graph::encode_load_call(graph_json))
+    }
 
-        Ok(wasm_bindgen_futures::future_to_promise(async move {
-            let result = response
-                .await
-                .map_err(|_| JsValue::from_str("the device dropped the call unanswered"))?
-                .map_err(|e| JsValue::from_str(&e))?;
+    /// Dispatch `call` through the in-process caller; the promise resolves to
+    /// the `CallResult` as JSON after the step that applies it.
+    ///
+    /// The caller's future enqueues the call on its first poll, and the
+    /// promise machinery first polls in a microtask — after the current JS
+    /// turn. Polling once here instead makes the call enqueued **before this
+    /// returns**, so a manual driver can dispatch and step in the same turn
+    /// (`device.loadGraph(spec); device.step(0);`).
+    fn dispatch(&self, call: Call) -> js_sys::Promise {
+        use std::future::Future;
+        use std::task::{Context, Poll, Waker};
+
+        let caller = self.caller.clone();
+        let mut pending = Box::pin(async move { caller.call(call).await });
+        let first = pending
+            .as_mut()
+            .poll(&mut Context::from_waker(Waker::noop()));
+        wasm_bindgen_futures::future_to_promise(async move {
+            let result = match first {
+                Poll::Ready(result) => result,
+                Poll::Pending => pending.await,
+            }
+            .map_err(|e| JsValue::from_str(&format!("call failed: {e}")))?;
             serde_json::to_string(&result)
                 .map(|json| JsValue::from_str(&json))
                 .map_err(|e| JsValue::from_str(&format!("serialize call result: {e}")))
-        }))
-    }
-
-    /// Advance the device one tick. `dt_ms` is the wall time elapsed since the
-    /// previous step, in milliseconds — the difference of two
-    /// `requestAnimationFrame` timestamps. Returns `true` while live, `false`
-    /// once the device is unregistered (stop stepping then).
-    pub fn step(&mut self, dt_ms: f64) -> Result<bool, JsValue> {
-        self.inner
-            .step(Duration::from_secs_f64((dt_ms / 1000.0).max(0.0)))
+        })
     }
 
     /// Write one key into the store. `value_json` is a value in any accepted
@@ -245,8 +241,8 @@ impl VizijArora {
     }
 
     /// Drain the keys that changed since the last call, as a path → `Value`
-    /// object (or `null` for a cleared key). Call it right after
-    /// [`step`](Self::step).
+    /// object (or `null` for a cleared key). The first drain returns the
+    /// store's whole current state — the subscription opens on it.
     #[wasm_bindgen(js_name = drainChanges)]
     pub fn drain_changes(&self) -> Result<JsValue, JsValue> {
         self.inner.drain_changes()
@@ -287,7 +283,7 @@ fn parse_modules(modules: Option<js_sys::Array>) -> Result<Vec<(Header, Vec<u8>)
 
 /// function id -> module id over every module's exports — how a bare function
 /// reference (a JS call without `module_id`, a graph `ExternalFunction` node)
-/// is routed to `arora_call`'s by-module dispatch.
+/// is routed to the engine's by-module dispatch.
 fn function_modules(modules: &[(Header, Vec<u8>)]) -> HashMap<Uuid, Uuid> {
     modules
         .iter()
@@ -298,15 +294,6 @@ fn function_modules(modules: &[(Header, Vec<u8>)]) -> HashMap<Uuid, Uuid> {
                 .map(move |export| (*export.id(), header.id))
         })
         .collect()
-}
-
-/// Normalize and deserialize a Vizij graph spec from JSON.
-fn parse_graph(json: &str) -> Result<GraphSpec, JsValue> {
-    let mut spec: serde_json::Value = serde_json::from_str(json)
-        .map_err(|e| JsValue::from_str(&format!("graph spec is not JSON: {e}")))?;
-    vizij_api_core::json::normalize_graph_spec_value(&mut spec)
-        .map_err(|e| JsValue::from_str(&format!("normalize graph spec failed: {e}")))?;
-    serde_json::from_value(spec).map_err(|e| JsValue::from_str(&format!("invalid graph spec: {e}")))
 }
 
 /// Normalize one value's JSON from any accepted vizij payload form (canonical
@@ -332,16 +319,6 @@ fn normalize_values_map_str(values_json: &str) -> Result<String, JsValue> {
         .collect();
     serde_json::to_string(&normalized)
         .map_err(|e| JsValue::from_str(&format!("serialize values: {e}")))
-}
-
-/// The store paths the spec's `input` nodes read — what the graph subscribes
-/// to on the device's store.
-fn input_paths(spec: &GraphSpec) -> Vec<TypedPath> {
-    spec.nodes
-        .iter()
-        .filter(|node| matches!(node.kind, NodeType::Input))
-        .filter_map(|node| node.params.path.clone())
-        .collect()
 }
 
 /// The passthrough proof graph (`input` path → `output` path), as spec JSON.

--- a/crates/interop/vizij-arora-web/tests/proof.rs
+++ b/crates/interop/vizij-arora-web/tests/proof.rs
@@ -1,17 +1,21 @@
 //! Values flow JS → store → arora tick → store → JS, through arora-web.
 //!
-//! Boots the thin Vizij-on-Arora device (which builds an `arora_web::BrowserRuntime`
-//! over a `BlackboardStore` + `RigHal` + a passthrough Vizij graph), writes an
-//! input key from "JS", steps the arora tick, and reads the graph's output key
-//! back out — proving the whole seam end to end in wasm through the published
-//! browser-runtime primitive.
+//! Boots the thin Vizij-on-Arora device (an `arora::Arora` composed over a
+//! `BlackboardStore` + `RigHal` + a passthrough Vizij graph, wrapped with
+//! `arora_web::AroraWeb`), writes an input key from "JS", steps the arora
+//! tick, and reads the graph's output key back out — proving the whole seam
+//! end to end in wasm. Then swaps the graph in place through the caller's
+//! LOAD path (VIZ-57) and proves the device and its store survived.
 
 #![cfg(target_arch = "wasm32")]
 
 use serde_json::{json, Value as Json};
 use vizij_arora_web::VizijArora;
 use wasm_bindgen::JsValue;
+use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
 
 /// Build a JS `string[]` from string slices.
 fn paths(ps: &[&str]) -> JsValue {
@@ -25,7 +29,7 @@ fn as_json(v: JsValue) -> Json {
 
 #[wasm_bindgen_test]
 async fn values_flow_js_store_tick_store_js() {
-    let mut rt = VizijArora::start(None, None).await.expect("runtime starts");
+    let rt = VizijArora::start(None, None).await.expect("runtime starts");
 
     // The graph's output key is absent before any tick runs.
     let before = as_json(rt.read_values(paths(&["actuator/y"])).unwrap());
@@ -37,7 +41,7 @@ async fn values_flow_js_store_tick_store_js() {
 
     // One tick: the arora runtime ticks the installed Vizij graph, which reads
     // sensor/x from the store and writes actuator/y back.
-    assert!(rt.step(16.0).unwrap(), "runtime stays live");
+    rt.step(16.0).expect("the device steps");
 
     // "JS" reads the transformed output back out of the same store.
     let after = as_json(rt.read_values(paths(&["sensor/x", "actuator/y"])).unwrap());
@@ -51,11 +55,69 @@ async fn values_flow_js_store_tick_store_js() {
     // A second value proves it keeps flowing tick to tick.
     rt.write_values(&json!({ "sensor/x": { "f32": 0.25 } }).to_string())
         .unwrap();
-    assert!(rt.step(16.0).unwrap());
+    rt.step(16.0).expect("the device steps");
     let after2 = as_json(rt.read_values(paths(&["actuator/y"])).unwrap());
     assert_eq!(after2["actuator/y"], json!({ "f32": 0.25 }));
 
     // The change feed saw the graph's write this step.
     let changes = as_json(rt.drain_changes().unwrap());
     assert_eq!(changes["actuator/y"], json!({ "f32": 0.25 }));
+}
+
+/// The first drain returns the store's whole current state — the subscription
+/// opens on it — so a consumer needs no separate init snapshot.
+#[wasm_bindgen_test]
+async fn the_first_drain_is_the_whole_state() {
+    let rt = VizijArora::start(None, None).await.expect("runtime starts");
+    rt.set_value("sensor/x", &json!({ "f32": 0.5 }).to_string())
+        .unwrap();
+    let opening = as_json(rt.drain_changes().unwrap());
+    assert_eq!(opening["sensor/x"], json!({ "f32": 0.5 }));
+}
+
+/// The in-place load path (VIZ-57): a `loadGraph` dispatched through the
+/// device's caller lands at the next step, swaps the running graph, and the
+/// device and its store survive the swap.
+#[wasm_bindgen_test]
+async fn load_graph_swaps_the_behavior_in_place() {
+    let rt = VizijArora::start(None, None).await.expect("runtime starts");
+
+    rt.set_value("sensor/x", &json!({ "f32": 0.75 }).to_string())
+        .unwrap();
+    rt.step(16.0).expect("the device steps");
+
+    // Swap to a different passthrough. The call applies at the next step,
+    // whose tick already runs the new graph — the input's declared default
+    // covers it until sensor/b is first written.
+    let loaded = rt.load_graph(
+        &json!({
+            "nodes": [
+                {
+                    "id": "in",
+                    "type": "input",
+                    "params": { "path": "sensor/b", "value": { "float": 0.0 } }
+                },
+                { "id": "out", "type": "output", "params": { "path": "actuator/b" } }
+            ],
+            "edges": [
+                { "from": { "node_id": "in" }, "to": { "node_id": "out", "input": "in" } }
+            ]
+        })
+        .to_string(),
+    );
+    rt.step(16.0).expect("the device steps");
+    JsFuture::from(loaded).await.expect("the load call lands");
+
+    // The new graph runs on the same device and store.
+    rt.set_value("sensor/b", &json!({ "f32": 0.25 }).to_string())
+        .unwrap();
+    rt.step(16.0).expect("the device steps");
+    let after = as_json(
+        rt.read_values(paths(&["actuator/b", "sensor/x", "actuator/y"]))
+            .unwrap(),
+    );
+    assert_eq!(after["actuator/b"], json!({ "f32": 0.25 }));
+    // The store carried across the swap untouched.
+    assert_eq!(after["sensor/x"], json!({ "f32": 0.75 }));
+    assert_eq!(after["actuator/y"], json!({ "f32": 0.75 }));
 }

--- a/npm/@vizij/arora-web-wasm/README.md
+++ b/npm/@vizij/arora-web-wasm/README.md
@@ -4,11 +4,12 @@ Run a Vizij runtime in the browser **as an Arora device**.
 
 The wasm module (built from
 [`crates/interop/vizij-arora-web`](https://github.com/vizij-ai/vizij-rs/tree/main/crates/interop/vizij-arora-web))
-assembles an [`arora-web`](https://crates.io/crates/arora-web) `BrowserRuntime`
-over the Vizij interop seams — a blackboard store, a rig HAL, and your node
-graph as the device's behavior. One device, one store, one step loop: the
-graph reads its `input` nodes' paths from the store each tick and writes its
-outputs back, and JS talks to the same store.
+composes an [`arora`](https://crates.io/crates/arora) device over the Vizij
+interop seams — a blackboard store, a rig HAL, and your node graph as the
+device's behavior — and wraps it with
+[`arora-web`](https://crates.io/crates/arora-web)'s browser JS surface. One
+device, one store: the graph reads its `input` nodes' paths from the store
+each tick and writes its outputs back, and JS talks to the same store.
 
 ## Use
 
@@ -17,14 +18,20 @@ import { init, startDevice } from "@vizij/arora-web-wasm";
 
 await init();
 const device = await startDevice(graphSpec); // a Vizij graph spec (object or JSON)
+device.run(); // the device paces itself from here on (the promise only ever rejects)
 
-// each animation frame (dt in ms, e.g. from requestAnimationFrame timestamps):
+// any time — the store surface stays live while the device runs:
 device.setValue("sensor/x", { f32: 0.75 });
-device.step(dtMs);
 const changes = device.drainChanges(); // path -> ValueJSON | null
+// The FIRST drain returns the store's whole current state.
 
-device.dispose();
+// swap the running graph in place (store, modules, device all survive):
+await device.loadGraph(otherGraphSpec);
 ```
+
+A host with its own clock skips `run()` and calls `device.step(dtMs)` per
+frame instead (e.g. from `requestAnimationFrame` timestamps); `step()`
+becomes unavailable once `run()` has taken the device.
 
 Values cross the boundary in the normalized `ValueJSON` vocabulary from
 [`@vizij/value-json`](https://www.npmjs.com/package/@vizij/value-json);

--- a/npm/@vizij/arora-web-wasm/package.json
+++ b/npm/@vizij/arora-web-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizij/arora-web-wasm",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Run a Vizij runtime in the browser as an Arora device: wasm bindings over arora-web's BrowserRuntime.",
   "license": "MIT",
   "repository": {

--- a/npm/@vizij/arora-web-wasm/src/index.ts
+++ b/npm/@vizij/arora-web-wasm/src/index.ts
@@ -14,11 +14,14 @@
  *
  * await init();
  * const device = await startDevice(graphSpec);
+ * device.run(); // the device paces itself from here on
  * // each animation frame:
  * device.setValue("sensor/x", { f32: 0.75 });
- * device.step(dtMs);
  * const changes = device.drainChanges();
  * ```
+ *
+ * A host with its own clock skips `run()` and calls `device.step(dtMs)`
+ * per frame instead.
  */
 import { toValueJSON, type ValueJSON, type ValueInput } from "@vizij/value-json";
 import {
@@ -55,8 +58,10 @@ export interface DeviceCallResult {
 }
 
 interface WasmVizijArora {
-  step(dt_ms: number): boolean;
+  step(dt_ms: number): void;
+  run(period_ms?: number): Promise<never>;
   call(call_json: string): Promise<string>;
+  loadGraph(graph_json: string): Promise<string>;
   setValue(path: string, value_json: string): void;
   writeValues(values_json: string): void;
   readValues(paths: string[]): Record<string, ValueJSON | null>;
@@ -164,6 +169,7 @@ export function init(input?: InitInput): Promise<void> {
  */
 export class AroraDevice {
   private inner: WasmVizijArora;
+  private selfPaced = false;
 
   constructor(inner: WasmVizijArora) {
     this.inner = inner;
@@ -172,23 +178,56 @@ export class AroraDevice {
   /**
    * Advance the device one tick. `dtMs` is the wall time since the previous
    * step in milliseconds (the difference of two `requestAnimationFrame`
-   * timestamps). Returns `true` while the device is live; once it returns
-   * `false` the device is unregistered — stop stepping.
+   * timestamps). Unavailable once `run()` has taken the device — it paces
+   * itself from then on.
    */
-  step(dtMs: number): boolean {
-    return this.inner.step(dtMs);
+  step(dtMs: number): void {
+    this.inner.step(dtMs);
   }
 
   /**
-   * Call a loaded module's function through the device. The call dispatches
-   * inside the device's **next** `step` — the same phase a remote bridge
-   * command executes in — so the returned promise resolves only after that
-   * step runs. Under a `requestAnimationFrame` loop just `await` it; a direct
-   * driver calls `step` in between.
+   * Hand the device to its own loop, for good: a self-paced run at
+   * `periodMs` (default: the runtime's ~100 Hz) that owns the device until
+   * stepping fails — the returned promise only ever rejects, and `step()`
+   * is unavailable from then on. The rest of this surface keeps working
+   * while the device runs; it never touches the stepping device.
+   */
+  run(periodMs?: number): Promise<never> {
+    this.selfPaced = true;
+    return this.inner.run(periodMs);
+  }
+
+  /** Whether `run()` has taken the device (so `step()` is unavailable). */
+  get running(): boolean {
+    return this.selfPaced;
+  }
+
+  /**
+   * Call a loaded module's function through the device. The call is enqueued
+   * before this returns and dispatches inside the device's **next** step —
+   * the same phase a remote bridge command executes in — so the returned
+   * promise resolves only after that step runs. Under `run()` just `await`
+   * it; a direct driver calls `step` after issuing it.
    */
   call(call: DeviceCall): Promise<DeviceCallResult> {
     const json = typeof call === "string" ? call : JSON.stringify(call);
     return this.inner.call(json).then((result) => JSON.parse(result) as DeviceCallResult);
+  }
+
+  /**
+   * Replace the device's running graph **in place**: the spec reaches the
+   * interpreter as the engine's LOAD call, so the store, the loaded modules,
+   * and the device itself all survive the swap. Resolves once the new graph
+   * is installed; on a device not under `run()` a zero-dt step is taken so
+   * the swap lands without an external driver.
+   */
+  loadGraph(graph: GraphSpecInput): Promise<void> {
+    const json = typeof graph === "string" ? graph : JSON.stringify(graph);
+    const loaded = this.inner.loadGraph(json);
+    if (!this.selfPaced) {
+      this.inner.step(0);
+    }
+    return loaded.then(() => undefined);
   }
 
   /** Write one store key. Accepts any `ValueInput` shorthand. */
@@ -216,8 +255,9 @@ export class AroraDevice {
   }
 
   /**
-   * The keys that changed since the last call (`null` = cleared). Call right
-   * after `step` to feed a renderer.
+   * The keys that changed since the last call (`null` = cleared) — poll it to
+   * feed a renderer. The first drain returns the store's whole current state:
+   * the subscription opens on it, so no separate init snapshot is needed.
    */
   drainChanges(): Record<string, ValueJSON | null> {
     return this.inner.drainChanges();

--- a/npm/@vizij/arora-web-wasm/tests/animation-module.mjs
+++ b/npm/@vizij/arora-web-wasm/tests/animation-module.mjs
@@ -109,7 +109,7 @@ const pending = [
   device.call({ id: FN_LOAD, args: [field(P_CLIP, clip)] }),
   device.call({ id: FN_CREATE_PLAYER, args: [field(P_NAME, { str: "p" })] }),
 ];
-assert.equal(device.step(0), true, "device stays live");
+device.step(0);
 const [anim, player] = await Promise.all(pending);
 assert.ok("u32" in anim.ret, "load_animation returns an animation id");
 assert.ok("u32" in player.ret, "create_player returns a player id");

--- a/npm/@vizij/arora-web-wasm/tests/smoke.mjs
+++ b/npm/@vizij/arora-web-wasm/tests/smoke.mjs
@@ -5,12 +5,15 @@ import { startDevice } from "../dist/arora-web-wasm/src/index.js";
 
 const device = await startDevice(); // built-in passthrough graph: sensor/x -> actuator/y
 
+// The first drain is the store's whole current state (empty at boot).
+assert.deepEqual(device.drainChanges(), {}, "opening state of an empty store");
+
 device.setValue("sensor/x", { f32: 0.5 });
-assert.equal(device.step(16), true, "device stays live");
+device.step(16);
 assert.deepEqual(device.readValues(["actuator/y"]), { "actuator/y": { f32: 0.5 } });
 
 device.writeValues({ "sensor/x": { f32: 0.25 } });
-assert.equal(device.step(16), true);
+device.step(16);
 assert.deepEqual(device.readValues(["actuator/y"]), { "actuator/y": { f32: 0.25 } });
 
 const changes = device.drainChanges();
@@ -19,5 +22,45 @@ assert.deepEqual(changes["actuator/y"], { f32: 0.25 }, "change feed saw the grap
 const snapshot = device.snapshot();
 assert.deepEqual(snapshot["sensor/x"], { f32: 0.25 });
 
+// In-place graph swap (VIZ-57): the device and its store survive.
+await device.loadGraph({
+  nodes: [
+    { id: "in", type: "input", params: { path: "sensor/b", value: { float: 0 } } },
+    { id: "out", type: "output", params: { path: "actuator/b" } },
+  ],
+  edges: [{ from: { node_id: "in" }, to: { node_id: "out", input: "in" } }],
+});
+device.setValue("sensor/b", { f32: 0.75 });
+device.step(16);
+assert.deepEqual(device.readValues(["actuator/b"]), { "actuator/b": { f32: 0.75 } });
+assert.deepEqual(
+  device.readValues(["sensor/x"]),
+  { "sensor/x": { f32: 0.25 } },
+  "the store carried across the swap",
+);
+
+// run(): the device paces itself; the store surface stays live.
+assert.equal(device.running, false);
+const rejected = new Promise((resolve) => {
+  device.run(5).catch(resolve);
+});
+assert.equal(device.running, true);
+let stepError = null;
+try {
+  device.step(16);
+} catch (err) {
+  stepError = err;
+}
+assert.match(String(stepError), /run\(\) drives the device/, "step is gone under run()");
+device.setValue("sensor/b", { f32: 0.5 });
+await new Promise((resolve) => setTimeout(resolve, 50));
+assert.deepEqual(
+  device.readValues(["actuator/b"]),
+  { "actuator/b": { f32: 0.5 } },
+  "the self-paced loop ticked the graph",
+);
+void rejected; // only ever rejects — when stepping fails, which this test never triggers
+
 device.dispose();
 console.log("arora-web-wasm smoke: ok");
+process.exit(0); // the run() loop never returns; don't wait on its timers


### PR DESCRIPTION
Migrates the Vizij-on-Arora device to the published arora-types 2 wave (arora 9 / arora-web 6 / arora-behavior 5 / arora-hal 3 / arora-simple-data-store 2), tracking [VIZ-53](https://linear.app/semio-ai/issue/VIZ-53) with the in-place behavior load of [VIZ-57](https://linear.app/semio-ai/issue/VIZ-57).

## What changes

- **`vizij-arora-store`** — `BlackboardStore` implements arora-types 2's `DataStore` contract: `clone_box` (sibling handle) and a subscription that opens on the store's whole current state.
- **`vizij-arora-behavior`** — the `CallBridge` adapter dispatches the single-argument `arora_call` (routed by `Call::module_id`). `ProcessingGraph` implements `BehaviorInterpreter::load`, so the engine's interpreter-module LOAD swaps the running Vizij graph **in place** — store, modules, and device all survive. The Vizij spec rides the shared behavior `Graph` opaquely as the new `spec_graph` one-node carrier (spec JSON as a literal link); a structural mapping onto the shared model remains future work, and `GraphDiff` edition is rejected until then.
- **`vizij-arora-web`** — `VizijArora` composes its `arora::Arora` with `AroraBuilder` and wraps it with `AroraWeb`, gaining the shared JS surface: self-pacing `run()`, `step()` until `run()` takes the device, store accessors live while running. The `JsBridge` endpoint is gone; `call()` and the new `loadGraph()` go through the device's in-process `LocalCaller`. `dispatch` polls the caller future once before returning so a call is enqueued within the same JS turn — a manual driver can `loadGraph(); step(0)` deterministically.
- **`@vizij/arora-web-wasm` 1.0.0** (breaking) — `run(periodMs?)` + `running`, `loadGraph(spec)` (nudges a zero-dt step on a non-running device so the swap lands), `step()` returns `void`, and the first `drainChanges()` is the whole store state (no separate init snapshot).

## Verification

- `cargo test --workspace --all-features` — 50 suites green
- `cargo clippy --workspace --all-features --bins --examples --tests -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `GECKODRIVER=$(which geckodriver) wasm-pack test --headless --firefox crates/interop/vizij-arora-web --test proof` — 3 tests green (value flow, whole-state first drain, in-place swap)
- `pnpm run test:wasm` — all wrapper suites green, including the new `run()` + `loadGraph` smoke coverage in node

The companion vizij-web branch (`feat/viz-53-device-run`) adopts `run()` and the in-place load in `@vizij/runtime-react`; it needs `@vizij/arora-web-wasm@1.0.0` published from this PR's merge before its lockfile can resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)