### PR TITLE
feat(vizij-arora-web): arora 9.1 — run() yields under overrun; standing behavior errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,9 +144,9 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "arora"
-version = "9.0.0"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bfac93a71d2cfa8b112f94d3ede8b8c0d34a7949bc776ed46536f371b3bde3a"
+checksum = "71e4c79483b039c338ca97bd6be293855c5f1f498777c33cf78a15d9292abb2e"
 dependencies = [
  "anyhow",
  "arora-behavior",
@@ -385,19 +385,21 @@ dependencies = [
 
 [[package]]
 name = "arora-web"
-version = "6.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b917b59d4bb5a99bebb691a65f6c135b471ce81f5ee7557043b3cf5c12fc05"
+checksum = "54a8c392e81f09866153d837c2b93787aee955e810150126a07bbca6f839721c"
 dependencies = [
  "arora",
  "arora-engine",
  "arora-types",
  "console_error_panic_hook",
+ "futures",
  "getrandom 0.4.3",
  "js-sys",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
+ "tokio",
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/crates/interop/vizij-arora-web/src/lib.rs
+++ b/crates/interop/vizij-arora-web/src/lib.rs
@@ -131,13 +131,34 @@ impl VizijArora {
         self.inner.step(dt_ms)
     }
 
-    /// Hand the device to its own loop, for good: a self-paced run at
-    /// `period_ms` (default: the runtime's ~100 Hz) that owns the device
-    /// until stepping fails — the returned promise only ever rejects, and
-    /// [`step`](Self::step) is unavailable from then on. The rest of the
-    /// surface keeps working: it never touches the stepping device.
+    /// Hand the device to its own loop: a self-paced run at `period_ms`
+    /// (default: the runtime's ~100 Hz). While it runs, [`step`](Self::step)
+    /// is unavailable and the rest of the surface keeps working: it never
+    /// touches the stepping device. A failing behavior tick does **not** end
+    /// the loop — it stands as [`behavior_error`](Self::behavior_error) until
+    /// a tick recovers; the promise rejects only if the runtime itself fails,
+    /// and the device stays usable (steppable, runnable again) afterwards.
     pub fn run(&self, period_ms: Option<f64>) -> js_sys::Promise {
         self.inner.run(period_ms)
+    }
+
+    /// The behavior's standing error — the message of its latest failed
+    /// tick, `undefined` while the behavior is healthy or none is installed.
+    /// A failing tick does not stop the device or its [`run`](Self::run)
+    /// loop; the reading stays available throughout.
+    #[wasm_bindgen(getter, js_name = behaviorError)]
+    pub fn behavior_error(&self) -> Option<String> {
+        self.inner.behavior_error()
+    }
+
+    /// Resolves on the next change of the behavior's standing error, with
+    /// the new reading: a message when a distinct failure appears,
+    /// `undefined` when a tick recovers. Sequential awaits share one cursor,
+    /// so no change is missed between them; one await may be pending at a
+    /// time. Rejects when the device is gone.
+    #[wasm_bindgen(js_name = behaviorErrorChanged)]
+    pub fn behavior_error_changed(&self) -> js_sys::Promise {
+        self.inner.behavior_error_changed()
     }
 
     /// Call a loaded module's function through the device. `call_json` is an
@@ -182,17 +203,23 @@ impl VizijArora {
     /// Dispatch `call` through the in-process caller; the promise resolves to
     /// the `CallResult` as JSON after the step that applies it.
     ///
-    /// The caller's future enqueues the call on its first poll, and the
-    /// promise machinery first polls in a microtask — after the current JS
-    /// turn. Polling once here instead makes the call enqueued **before this
-    /// returns**, so a manual driver can dispatch and step in the same turn
-    /// (`device.loadGraph(spec); device.step(0);`).
+    /// `LocalCaller::call` enqueues the call synchronously inside `call()` —
+    /// its future is only the reply — but `call()` itself runs at the
+    /// composed future's first poll, and the promise machinery first polls in
+    /// a microtask, after the current JS turn. The one poll here runs it now,
+    /// so the call is enqueued **before this returns** and a manual driver
+    /// can dispatch and step in the same turn
+    /// (`device.loadGraph(spec); device.step(0);`). Parking on the throwaway
+    /// waker loses no wakeup: the reply channel re-registers its waker on
+    /// every poll.
     fn dispatch(&self, call: Call) -> js_sys::Promise {
         use std::future::Future;
         use std::task::{Context, Poll, Waker};
 
         let caller = self.caller.clone();
         let mut pending = Box::pin(async move { caller.call(call).await });
+        // Ready on the first poll = the device is gone (the enqueue failed);
+        // an applied call can only resolve through a later step.
         let first = pending
             .as_mut()
             .poll(&mut Context::from_waker(Waker::noop()));

--- a/npm/@vizij/runtime/CHANGELOG.md
+++ b/npm/@vizij/runtime/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to `@vizij/runtime`. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.0.2] - 2026-07-22
+
+### Changed
+
+- Built on arora 9.1 / arora-web 6.1: the self-paced loop yields to the JS
+  event loop even when a step overruns its period, so `run()` no longer
+  freezes the page under sustained load.
+- A failing behavior tick no longer ends `run()` (and no longer rejects its
+  promise): the failure stands as a readable error until a tick recovers,
+  and a failed run leaves the device usable.
+
+### Added
+
+- `AroraDevice.behaviorError` — the behavior's standing error: the message
+  of its latest failed tick, `undefined` while healthy.
+- `AroraDevice.behaviorErrorChanged()` — resolves on the next change of the
+  standing error (a message when a failure appears, `undefined` when a tick
+  recovers); sequential awaits share one cursor, so no change is missed.
+
 ## [1.0.1] - 2026-07-21
 
 ### Fixed

--- a/npm/@vizij/runtime/package.json
+++ b/npm/@vizij/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizij/runtime",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Run a Vizij runtime in the browser as an Arora device: wasm bindings over arora-web's BrowserRuntime.",
   "license": "MIT",
   "repository": {

--- a/npm/@vizij/runtime/src/index.ts
+++ b/npm/@vizij/runtime/src/index.ts
@@ -60,6 +60,8 @@ export interface DeviceCallResult {
 interface WasmVizijArora {
   step(dt_ms: number): void;
   run(period_ms?: number): Promise<never>;
+  readonly behaviorError: string | undefined;
+  behaviorErrorChanged(): Promise<string | undefined>;
   call(call_json: string): Promise<string>;
   loadGraph(graph_json: string): Promise<string>;
   setValue(path: string, value_json: string): void;
@@ -187,10 +189,11 @@ export class AroraDevice {
 
   /**
    * Hand the device to its own loop, for good: a self-paced run at
-   * `periodMs` (default: the runtime's ~100 Hz) that owns the device until
-   * stepping fails — the returned promise only ever rejects, and `step()`
-   * is unavailable from then on. The rest of this surface keeps working
-   * while the device runs; it never touches the stepping device.
+   * `periodMs` (default: the runtime's ~100 Hz). While it runs, `step()` is
+   * unavailable and the rest of this surface keeps working; it never touches
+   * the stepping device. A failing behavior tick does **not** end the loop —
+   * it stands as `behaviorError` until a tick recovers; the returned promise
+   * rejects only if the runtime itself fails.
    */
   run(periodMs?: number): Promise<never> {
     this.selfPaced = true;
@@ -200,6 +203,27 @@ export class AroraDevice {
   /** Whether `run()` has taken the device (so `step()` is unavailable). */
   get running(): boolean {
     return this.selfPaced;
+  }
+
+  /**
+   * The behavior's standing error — the message of its latest failed tick,
+   * `undefined` while the behavior is healthy or none is installed. A
+   * failing tick does not stop the device or its `run()` loop; the reading
+   * stays available throughout.
+   */
+  get behaviorError(): string | undefined {
+    return this.inner.behaviorError;
+  }
+
+  /**
+   * Resolves on the next change of the standing behavior error, with the new
+   * reading: a message when a distinct failure appears, `undefined` when a
+   * tick recovers. Sequential awaits share one cursor, so no change is
+   * missed between them; one await may be pending at a time. Rejects when
+   * the device is gone.
+   */
+  behaviorErrorChanged(): Promise<string | undefined> {
+    return this.inner.behaviorErrorChanged();
   }
 
   /**

--- a/npm/@vizij/runtime/tests/smoke.mjs
+++ b/npm/@vizij/runtime/tests/smoke.mjs
@@ -59,7 +59,34 @@ assert.deepEqual(
   { "actuator/b": { f32: 0.5 } },
   "the self-paced loop ticked the graph",
 );
-void rejected; // only ever rejects — when stepping fails, which this test never triggers
+void rejected; // rejects only if the runtime itself fails, which this test never triggers
+
+// Behavior errors stand, they don't stop the loop (arora 9.1): swap in a
+// graph whose input has no default and no staged value — ticks fail, the
+// error is observable, and the device keeps running.
+assert.equal(device.behaviorError, undefined, "healthy behavior reads undefined");
+const failed = device.behaviorErrorChanged();
+await device.loadGraph({
+  nodes: [
+    { id: "in", type: "input", params: { path: "sensor/missing" } },
+    { id: "out", type: "output", params: { path: "actuator/c" } },
+  ],
+  edges: [{ from: { node_id: "in" }, to: { node_id: "out", input: "in" } }],
+});
+assert.match(
+  String(await failed),
+  /missing staged value/,
+  "the failing tick's message stands as the behavior error",
+);
+const recovered = device.behaviorErrorChanged();
+device.setValue("sensor/missing", { f32: 0.125 });
+assert.equal(await recovered, undefined, "a recovering tick clears the error");
+await new Promise((resolve) => setTimeout(resolve, 30));
+assert.deepEqual(
+  device.readValues(["actuator/c"]),
+  { "actuator/c": { f32: 0.125 } },
+  "the run loop kept ticking through the failure",
+);
 
 device.dispose();
 console.log("@vizij/runtime smoke: ok");


### PR DESCRIPTION
## What

Adopts arora 9.1.0 / arora-web 6.1.0 ([semio-ai/arora-sdk#167](https://github.com/semio-ai/arora-sdk/pull/167)) in the browser device and ships **@vizij/runtime 1.0.2**:

- **run() no longer freezes the page.** The metronome's overrun arm now yields through its timer, so a device whose steps consistently overrun the period keeps sharing the main thread — the root cause behind vizij-web #78's e2e freezes.
- **Failing ticks stand, they don't kill.** A failing behavior tick no longer ends `run()` (nor rejects its promise), and a failed run leaves the device steppable/runnable. New surface, passed through the wrapper: `AroraDevice.behaviorError` (standing error, `undefined` while healthy) and `AroraDevice.behaviorErrorChanged()` (resolves per change — message on failure, `undefined` on recovery — with a shared cursor so sequential awaits miss nothing).
- **Dispatch note:** the synchronous first poll in `dispatch` stays, redocumented. 9.1's `LocalCaller` enqueues inside `call()`, but `call()` itself only runs at the composed future's first poll — a microtask after `dispatch` returned — so the poll is still what makes `device.loadGraph(spec); device.step(0)` land in one turn. Verified empirically: with a plain relay instead, the wrapper's same-turn tests hang (`CallFuture<'_>` is borrow-tied, so the invoke-inside-async-block shape is forced).

## Verification

- wasm build + wrapper build clean; both node suites pass (`smoke`, `animation-module`), including a new smoke section: failure stands under `run()`, the loop keeps ticking, recovery reads `undefined`.
- Starvation repro (`run(0)`, guaranteed permanent overrun): event loop stays alive — 189 interval ticks in 1 s (the 9.0 build hangs this forever).
- Failed-first-step repro (proof graph, nothing staged): `run()` keeps going, `behaviorError` reads the tick message, `loadGraph` still works (no "the device is gone"), recovery clears to `undefined`.

Part of the arora 9 wave migration ([VIZ-53](https://linear.app/semio-ai/issue/VIZ-53)). Publishing 1.0.2 unblocks the vizij-web re-lock and the #78 e2e rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)