### PR TITLE
feat(node-graph): the path-less Output applies a keyed record batch to its keys

### DIFF
--- a/crates/api/vizij-api-core/src/value.rs
+++ b/crates/api/vizij-api-core/src/value.rs
@@ -29,10 +29,10 @@
 
 use arora_types::gen_uuid_from_str;
 use arora_types::keyvalue::{KeyValue, KeyValueField};
-use arora_types::value::{Enumeration, Structure, StructureField};
+use arora_types::value::{Enumeration, Structure};
 use uuid::Uuid;
 
-pub use arora_types::value::Value;
+pub use arora_types::value::{StructureField, StructureWithoutId, Value};
 
 // ---- declared type / field ids ------------------------------------------------
 

--- a/crates/interop/vizij-arora-behavior/src/lib.rs
+++ b/crates/interop/vizij-arora-behavior/src/lib.rs
@@ -356,4 +356,52 @@ mod tests {
             .unwrap();
         assert!((golden_dt_seconds(&store) - 0.016).abs() < 1e-6);
     }
+
+    /// A path-less `output` applies a keyed record batch — the shape a module
+    /// call's "what changed" arrives in — onto the store keys the records
+    /// name, through the tick's single StateChange flush.
+    #[test]
+    fn pathless_output_applies_a_keyed_batch_to_the_store() {
+        const KEY_FIELD: &str = "76697a69-0000-0000-0000-00000000aaaa";
+        const VALUE_FIELD: &str = "76697a69-0000-0000-0000-00000000bbbb";
+        const RECORD_TYPE: &str = "76697a69-0000-0000-0000-00000000cccc";
+
+        let record = |key: &str, v: f32| {
+            json!({ "fields": [
+                { "id": KEY_FIELD, "value": { "str": key } },
+                { "id": VALUE_FIELD, "value": { "f32": v } },
+            ]})
+        };
+        let mut spec = json!({
+            "nodes": [
+                { "id": "src", "type": "constant", "params": { "value": {
+                    "structs": { "id": RECORD_TYPE, "elements": [
+                        record("anim/x", 0.25),
+                        record("anim/y", 0.5),
+                        // A repeated key: batch order is preserved into the
+                        // write set, and the StateChange flush (a map) keeps
+                        // the last entry. Explicit combination of concurrent
+                        // publishers is VIZ-76's ground.
+                        record("anim/x", 0.75),
+                    ]}
+                }}},
+                { "id": "sink", "type": "output", "params": {
+                    "key_field": KEY_FIELD, "value_field": VALUE_FIELD
+                }}
+            ],
+            "edges": [
+                { "from": { "node_id": "src" }, "to": { "node_id": "sink", "input": "in" } }
+            ]
+        });
+        vizij_api_core::json::normalize_graph_spec_value(&mut spec).expect("normalize");
+        let spec: GraphSpec = serde_json::from_value(spec).expect("graph spec");
+
+        let store = SimpleDataStore::new();
+        let mut graph = ProcessingGraph::from_spec(spec, vec![]);
+        let mut bridge = NoopBridge;
+        graph.tick_store(&store, &mut bridge, 0.016).expect("tick");
+
+        assert_eq!(read(&store, "anim/x"), Some(float(0.75)));
+        assert_eq!(read(&store, "anim/y"), Some(float(0.5)));
+    }
 }

--- a/crates/node-graph/vizij-graph-core/src/eval/eval_node.rs
+++ b/crates/node-graph/vizij-graph-core/src/eval/eval_node.rs
@@ -8,7 +8,7 @@ use crate::types::{NodeParams, NodeSpec, NodeType, RoundMode};
 use hashbrown::HashMap;
 use uuid::Uuid;
 use vizij_api_core::value as vocab;
-use vizij_api_core::{coercion, Shape, Value, WriteOp};
+use vizij_api_core::{coercion, Shape, TypedPath, Value, WriteOp};
 
 use super::noise;
 use super::numeric::{as_bool, as_float, binary_numeric, unary_numeric};
@@ -216,7 +216,69 @@ pub fn eval_node_inner(
                     ));
                 }
             }
+        } else if let (Some(key_field), Some(value_field)) =
+            (spec.params.key_field, spec.params.value_field)
+        {
+            if let Some(slot) = outputs.layout.slot("out") {
+                if let Some(port) = outputs.as_slice().get(slot) {
+                    expand_keyed_batch(rt, &port.value, key_field, value_field)
+                        .map_err(|message| format!("node '{}': {message}", spec.id))?;
+                }
+            }
         }
+    }
+    Ok(())
+}
+
+/// Expand a keyed record batch into one write per record: how a **path-less**
+/// [`NodeType::Output`] applies a value that names its own keys (e.g. a module
+/// call's "what changed") onto them by default.
+///
+/// The batch is a `Value::ArrayStructure`; in every record, `key_field` holds
+/// the target path as a string and `value_field` the value to write. A record
+/// missing either (or keying on a non-string) is an **evaluation error** — a
+/// miswired batch, not data — while an empty batch simply writes nothing.
+/// Records repeating a key produce writes in batch order, and the per-tick
+/// flush keeps the last one; explicit combination of concurrent publishers is
+/// VIZ-76's ground (https://linear.app/semio-ai/issue/VIZ-76).
+fn expand_keyed_batch(
+    rt: &mut GraphRuntime,
+    batch: &Value,
+    key_field: Uuid,
+    value_field: Uuid,
+) -> Result<(), String> {
+    let Value::ArrayStructure { elements, .. } = batch else {
+        return Err(
+            "a path-less Output applies a keyed record batch (an array of structures); \
+             set `path` to write a single value"
+                .to_string(),
+        );
+    };
+    for (index, record) in elements.iter().enumerate() {
+        let mut key: Option<&str> = None;
+        let mut value: Option<&Value> = None;
+        for field in &record.fields {
+            if field.id == key_field {
+                key = match field.value.as_ref() {
+                    Value::String(s) => Some(s.as_str()),
+                    other => {
+                        return Err(format!(
+                            "record {index}: key field must be a string path, got {other:?}"
+                        ));
+                    }
+                };
+            } else if field.id == value_field {
+                value = Some(field.value.as_ref());
+            }
+        }
+        let (Some(key), Some(value)) = (key, value) else {
+            return Err(format!(
+                "record {index}: missing key field {key_field} or value field {value_field}"
+            ));
+        };
+        let path = TypedPath::parse(key)
+            .map_err(|e| format!("record {index}: key {key:?} is not a path: {e}"))?;
+        rt.writes.push(WriteOp::new(path, value.clone()));
     }
     Ok(())
 }

--- a/crates/node-graph/vizij-graph-core/src/eval/tests.rs
+++ b/crates/node-graph/vizij-graph-core/src/eval/tests.rs
@@ -2252,3 +2252,197 @@ fn noise_nodes_are_deterministic_and_in_range() {
         );
     }
 }
+
+// --- path-less Output: keyed record batches ----------------------------------
+
+use uuid::Uuid;
+use vizij_api_core::value::{StructureField, StructureWithoutId};
+
+const KEY_FIELD: Uuid = Uuid::from_u128(0x11);
+const VALUE_FIELD: Uuid = Uuid::from_u128(0x22);
+
+fn record_field(id: Uuid, value: Value) -> StructureField {
+    StructureField {
+        id,
+        value: Box::new(value),
+    }
+}
+
+fn keyed_record(key: Value, value: Value) -> StructureWithoutId {
+    StructureWithoutId {
+        fields: vec![
+            record_field(KEY_FIELD, key),
+            record_field(VALUE_FIELD, value),
+        ],
+    }
+}
+
+fn keyed_batch(elements: Vec<StructureWithoutId>) -> Value {
+    Value::ArrayStructure {
+        id: Uuid::from_u128(0xBA7C4),
+        elements,
+    }
+}
+
+fn pathless_output_node(id: &str) -> NodeSpec {
+    NodeSpec {
+        id: id.to_string(),
+        kind: NodeType::Output,
+        params: NodeParams {
+            key_field: Some(KEY_FIELD),
+            value_field: Some(VALUE_FIELD),
+            ..Default::default()
+        },
+        output_shapes: HashMap::new(),
+        input_defaults: HashMap::new(),
+    }
+}
+
+#[test]
+fn pathless_output_expands_a_keyed_batch_into_per_key_writes() {
+    let graph = GraphSpec {
+        nodes: vec![
+            constant_node(
+                "src",
+                keyed_batch(vec![
+                    keyed_record(Value::String("anim/x".into()), Value::F32(0.25)),
+                    keyed_record(Value::String("anim/y".into()), Value::F32(0.75)),
+                ]),
+            ),
+            pathless_output_node("sink"),
+        ],
+        edges: vec![link("src", "sink", "in")],
+        ..Default::default()
+    }
+    .with_cache();
+
+    let mut rt = GraphRuntime::default();
+    evaluate_all(&mut rt, &graph).expect("graph should evaluate");
+    let writes: Vec<_> = rt.writes.iter().collect();
+    assert_eq!(writes.len(), 2);
+    assert_eq!(writes[0].path.to_string(), "anim/x");
+    assert!(matches!(writes[0].value, Value::F32(v) if v == 0.25));
+    assert_eq!(writes[1].path.to_string(), "anim/y");
+    assert!(matches!(writes[1].value, Value::F32(v) if v == 0.75));
+}
+
+#[test]
+fn pathless_output_writes_nothing_for_an_empty_batch() {
+    let graph = GraphSpec {
+        nodes: vec![
+            constant_node("src", keyed_batch(vec![])),
+            pathless_output_node("sink"),
+        ],
+        edges: vec![link("src", "sink", "in")],
+        ..Default::default()
+    }
+    .with_cache();
+
+    let mut rt = GraphRuntime::default();
+    evaluate_all(&mut rt, &graph).expect("an empty batch is not an error");
+    assert_eq!(rt.writes.iter().count(), 0);
+}
+
+#[test]
+fn pathless_output_keeps_batch_order_for_a_repeated_key() {
+    // Batch order is preserved in the write set; the per-tick flush (a map)
+    // keeps the last write. Explicit combination is VIZ-76's ground.
+    let graph = GraphSpec {
+        nodes: vec![
+            constant_node(
+                "src",
+                keyed_batch(vec![
+                    keyed_record(Value::String("anim/x".into()), Value::F32(1.0)),
+                    keyed_record(Value::String("anim/x".into()), Value::F32(2.0)),
+                ]),
+            ),
+            pathless_output_node("sink"),
+        ],
+        edges: vec![link("src", "sink", "in")],
+        ..Default::default()
+    }
+    .with_cache();
+
+    let mut rt = GraphRuntime::default();
+    evaluate_all(&mut rt, &graph).expect("graph should evaluate");
+    let writes: Vec<_> = rt.writes.iter().collect();
+    assert_eq!(writes.len(), 2);
+    assert!(matches!(writes[0].value, Value::F32(v) if v == 1.0));
+    assert!(matches!(writes[1].value, Value::F32(v) if v == 2.0));
+}
+
+#[test]
+fn pathless_output_errors_on_a_malformed_record() {
+    // A record without the declared value field is a miswired batch: loud.
+    let graph = GraphSpec {
+        nodes: vec![
+            constant_node(
+                "src",
+                keyed_batch(vec![StructureWithoutId {
+                    fields: vec![record_field(KEY_FIELD, Value::String("anim/x".into()))],
+                }]),
+            ),
+            pathless_output_node("sink"),
+        ],
+        edges: vec![link("src", "sink", "in")],
+        ..Default::default()
+    }
+    .with_cache();
+
+    let mut rt = GraphRuntime::default();
+    let err = evaluate_all(&mut rt, &graph).expect_err("a malformed record is an error");
+    assert!(err.contains("sink"), "error names the node: {err}");
+    assert!(err.contains("missing"), "error names the gap: {err}");
+}
+
+#[test]
+fn pathless_output_errors_on_a_non_batch_value() {
+    let graph = GraphSpec {
+        nodes: vec![
+            constant_node("src", Value::F32(1.0)),
+            pathless_output_node("sink"),
+        ],
+        edges: vec![link("src", "sink", "in")],
+        ..Default::default()
+    }
+    .with_cache();
+
+    let mut rt = GraphRuntime::default();
+    let err = evaluate_all(&mut rt, &graph).expect_err("a scalar is not a record batch");
+    assert!(err.contains("record batch"), "error names the shape: {err}");
+}
+
+#[test]
+fn output_path_takes_precedence_over_key_fields() {
+    let batch = keyed_batch(vec![keyed_record(
+        Value::String("anim/x".into()),
+        Value::F32(0.5),
+    )]);
+    let graph = GraphSpec {
+        nodes: vec![
+            constant_node("src", batch.clone()),
+            NodeSpec {
+                id: "sink".to_string(),
+                kind: NodeType::Output,
+                params: NodeParams {
+                    path: Some(TypedPath::parse("whole/batch").expect("valid path")),
+                    key_field: Some(KEY_FIELD),
+                    value_field: Some(VALUE_FIELD),
+                    ..Default::default()
+                },
+                output_shapes: HashMap::new(),
+                input_defaults: HashMap::new(),
+            },
+        ],
+        edges: vec![link("src", "sink", "in")],
+        ..Default::default()
+    }
+    .with_cache();
+
+    let mut rt = GraphRuntime::default();
+    evaluate_all(&mut rt, &graph).expect("graph should evaluate");
+    let writes: Vec<_> = rt.writes.iter().collect();
+    assert_eq!(writes.len(), 1, "an explicit path writes the value whole");
+    assert_eq!(writes[0].path.to_string(), "whole/batch");
+    assert_eq!(writes[0].value, batch);
+}

--- a/crates/node-graph/vizij-graph-core/src/schema.rs
+++ b/crates/node-graph/vizij-graph-core/src/schema.rs
@@ -2349,7 +2349,10 @@ pub fn registry() -> Registry {
         type_id: Output,
         name: "Output",
         category: "IO",
-        doc: "Publishes In to the host path while passing the value through for downstream nodes.",
+        doc: "Publishes In to the host path while passing the value through for downstream nodes. \
+              Without a path, In is a keyed record batch and each record writes to the path its \
+              key_field names (value from value_field) — records that name their own keys apply \
+              to them by default.",
         inputs: vec![PortSpec {
             id: "in",
             ty: PortType::Any,
@@ -2366,15 +2369,35 @@ pub fn registry() -> Registry {
             optional: false,
         }],
         variadic_outputs: None,
-        params: vec![ParamSpec {
-            id: "path",
-            ty: ParamType::Any,
-            label: "Path",
-            doc: "TypedPath string used when queuing external writes.",
-            default_json: None,
-            min: None,
-            max: None,
-        }],
+        params: vec![
+            ParamSpec {
+                id: "path",
+                ty: ParamType::Any,
+                label: "Path",
+                doc: "TypedPath string used when queuing external writes.",
+                default_json: None,
+                min: None,
+                max: None,
+            },
+            ParamSpec {
+                id: "key_field",
+                ty: ParamType::Any,
+                label: "Key Field",
+                doc: "Path-less mode: record field id (UUID) holding each entry's target path.",
+                default_json: None,
+                min: None,
+                max: None,
+            },
+            ParamSpec {
+                id: "value_field",
+                ty: ParamType::Any,
+                label: "Value Field",
+                doc: "Path-less mode: record field id (UUID) holding each entry's value.",
+                default_json: None,
+                min: None,
+                max: None,
+            },
+        ],
     });
 
     // Records

--- a/crates/node-graph/vizij-graph-core/src/types.rs
+++ b/crates/node-graph/vizij-graph-core/src/types.rs
@@ -290,6 +290,16 @@ pub struct NodeParams {
     /// These are opaque to the graph; the host pairs each with the positional value in the call.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub param_ids: Option<Vec<Uuid>>,
+    /// Record field carrying each entry's **target path** in the keyed batch a
+    /// **path-less** [`NodeType::Output`] applies. With
+    /// [`value_field`](Self::value_field), it turns the node's input — a batch
+    /// of records naming their own keys (e.g. a module call's "what changed")
+    /// — into one write per record. Ignored when [`path`](Self::path) is set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key_field: Option<Uuid>,
+    /// Record field carrying each entry's value; see [`key_field`](Self::key_field).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value_field: Option<Uuid>,
 }
 
 /// Rounding strategy for [`NodeType::Round`].

--- a/npm/@vizij/node-graph-wasm/src/metadata/registry.json
+++ b/npm/@vizij/node-graph-wasm/src/metadata/registry.json
@@ -2801,7 +2801,7 @@
       "type_id": "output",
       "name": "Output",
       "category": "IO",
-      "doc": "Publishes In to the host path while passing the value through for downstream nodes.",
+      "doc": "Publishes In to the host path while passing the value through for downstream nodes. Without a path, In is a keyed record batch and each record writes to the path its key_field names (value from value_field) — records that name their own keys apply to them by default.",
       "inputs": [
         {
           "id": "in",
@@ -2826,6 +2826,18 @@
           "ty": "any",
           "label": "Path",
           "doc": "TypedPath string used when queuing external writes."
+        },
+        {
+          "id": "key_field",
+          "ty": "any",
+          "label": "Key Field",
+          "doc": "Path-less mode: record field id (UUID) holding each entry's target path."
+        },
+        {
+          "id": "value_field",
+          "ty": "any",
+          "label": "Value Field",
+          "doc": "Path-less mode: record field id (UUID) holding each entry's value."
         }
       ]
     },

--- a/npm/@vizij/node-graph-wasm/src/metadata/registry.ts
+++ b/npm/@vizij/node-graph-wasm/src/metadata/registry.ts
@@ -2804,7 +2804,7 @@ const registry: Registry = {
       "type_id": "output",
       "name": "Output",
       "category": "IO",
-      "doc": "Publishes In to the host path while passing the value through for downstream nodes.",
+      "doc": "Publishes In to the host path while passing the value through for downstream nodes. Without a path, In is a keyed record batch and each record writes to the path its key_field names (value from value_field) — records that name their own keys apply to them by default.",
       "inputs": [
         {
           "id": "in",
@@ -2829,6 +2829,18 @@ const registry: Registry = {
           "ty": "any",
           "label": "Path",
           "doc": "TypedPath string used when queuing external writes."
+        },
+        {
+          "id": "key_field",
+          "ty": "any",
+          "label": "Key Field",
+          "doc": "Path-less mode: record field id (UUID) holding each entry's target path."
+        },
+        {
+          "id": "value_field",
+          "ty": "any",
+          "label": "Value Field",
+          "doc": "Path-less mode: record field id (UUID) holding each entry's value."
         }
       ]
     },

--- a/npm/@vizij/runtime/CHANGELOG.md
+++ b/npm/@vizij/runtime/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `@vizij/runtime`. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] - 2026-07-22
+
+### Added
+
+- Device graphs can apply a keyed record batch to the store by default: an
+  `output` node **without** `path` takes `key_field`/`value_field` params
+  (record field ids, UUIDs) and writes each record's value under the path
+  its key field names — e.g. an `externalfunction` module call's "what
+  changed" applied onto its own keys. An empty batch writes nothing; a
+  record missing either field is an evaluation error; a repeated key keeps
+  the batch's last entry in the tick's flush.
+
 ## [1.0.2] - 2026-07-22
 
 ### Changed

--- a/npm/@vizij/runtime/package.json
+++ b/npm/@vizij/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizij/runtime",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Run a Vizij runtime in the browser as an Arora device: wasm bindings over arora-web's BrowserRuntime.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What

[VIZ-61](https://linear.app/semio-ai/issue/VIZ-61) Stage A — the graph-side inch of the approved state-change design:

An `output` node **without** `path`, given `key_field`/`value_field` params (record field ids, UUIDs), expands its incoming batch — an array of structures naming their own target paths, e.g. an `externalfunction` module call's "what changed" (`[TrackOutput]`) — into **one write per record**, merged into `tick_store`'s existing single per-tick `StateChange` flush. Records that name their own keys apply to them by default; an explicit `path` still writes the value whole and takes precedence.

Deliberate, documented edges:
- an **empty batch** writes nothing (nothing changed);
- a record **missing** the key or value field, or keying on a non-string, is an **evaluation error** — a miswired batch, not data (surfaces as the standing behavior error under arora 9.1's run loop);
- a **repeated key** preserves batch order into the write set; the flush (a map) keeps the last entry. Explicit combination of concurrent publishers is [VIZ-76](https://linear.app/semio-ai/issue/VIZ-76)'s ground — no publisher rules are invented here.

Also: `vizij-api-core` re-exports `StructureField`/`StructureWithoutId` alongside `Value`; the node-registry artifacts are regenerated; **`@vizij/runtime` 1.1.0** (additive) ships the vocabulary in its wasm for the vizij-web swap.

## Verification

- graph-core: 6 new unit tests (expansion, empty batch, malformed-record error naming the node, non-batch error, repeated-key order, path precedence) — 65/65 green.
- vizij-arora-behavior: interop test drives a module-shaped batch through `ProcessingGraph::tick_store` into a real `SimpleDataStore` — per-key values land, repeated key keeps the last entry.
- `@vizij/runtime` wasm rebuild + both node suites green; workspace fmt + clippy `-D warnings` green (pre-commit), node-registry verify green (pre-push).

## npm status (for the publish dispatch)

`@vizij/animation-module` on the registry is still **0.1.1** — 0.2.0 (merged in #57) is unpublished. Publishing this PR's `@vizij/runtime` 1.1.0 and `@vizij/animation-module` 0.2.0 together unblocks the vizij-web swap (Stage B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)