### PR TITLE
docs: refresh vizij-rs docs (drop removed Bevy integration, fix stale refs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,10 @@ file summarises, it does not replace, those sources.
   `vizij-graph-wasm`, and npm `@vizij/node-graph-wasm`.
 - **Orchestrator stack**: `vizij-orchestrator-core` runtime coordinating
   graphs/animations, `vizij-orchestrator-wasm`, and npm `@vizij/orchestrator-wasm`.
+- **Interop (Arora) stack**: `crates/interop/*` adapts the Vizij stacks onto
+  Arora runtime seams — `vizij-arora` (Value interop), `vizij-arora-store`,
+  `vizij-arora-hal`, `vizij-arora-behavior`, `vizij-arora-web` (npm
+  `@vizij/runtime`), and `vizij-animation-module` (npm `@vizij/animation-module`).
 - **Test fixtures**: `vizij-test-fixtures` crate that exposes the shared JSON
   manifest, mirrored to npm `@vizij/test-fixtures` for browsers.
 - **Support packages**: npm `@vizij/value-json`, `@vizij/wasm-loader`, and
@@ -98,7 +102,7 @@ Prerequisite: add the wasm32 target with `rustup target add wasm32-unknown-unkno
   inputs/outputs and enforces ABI version checks mirrored in the npm wrapper.
 - **Node graph**: `vizij-graph-core` evaluates deterministic data-flow graphs.
   Features like `urdf_ik` are enabled by default and surfaced through the wasm
-  build scripts. The Bevy adapter and wasm crate share JSON normalisation logic.
+  build scripts. The wasm crate handles JSON normalisation for JS consumers.
 - **Orchestrator**: `vizij-orchestrator-core` (`src/lib.rs`, `controllers/*`)
   coordinates animation engines and graph controllers. Check the crate README
   for scheduler semantics, blackboard conventions, and example entry points.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 This repository contains the Rust source for Vizij’s animation, node graph, and orchestration stacks together with the tooling needed to surface them in web applications. Each domain ships as a trio of crates:
 
 - a **core crate** with deterministic runtime logic,
-- and a **WASM binding** that is re-exported through `npm/@vizij/*-wasm`.
+- and a **WASM binding** that is re-exported through the matching `npm/@vizij/*` wrapper package.
+
+A separate `crates/interop/*` family adapts these stacks onto [Arora](#interop-arora) runtime seams.
 
 What you read here should give you everything you need to build, test, and publish those artifacts.
 
@@ -43,12 +45,21 @@ vizij-rs/
 │  ├─ orchestrator/
 │  │  ├─ vizij-orchestrator-core   # Blackboard + pass scheduling runtime
 │  │  └─ vizij-orchestrator-wasm   # wasm-bindgen binding
+│  ├─ interop/                     # Adapters that run the Vizij stacks on Arora seams
+│  │  ├─ vizij-arora               # Vizij↔Arora Value interop (identity + Shape.meta sidecar)
+│  │  ├─ vizij-arora-store         # Vizij Blackboard exposed as an Arora DataStore
+│  │  ├─ vizij-arora-hal           # Vizij rig presented as an Arora HAL
+│  │  ├─ vizij-arora-behavior      # Vizij graph/orchestrator as Arora behavior interpreters
+│  │  ├─ vizij-arora-web           # Browser wasm cdylib: Vizij runtime as an Arora device
+│  │  └─ vizij-animation-module    # vizij-animation-core packaged as an Arora wasm module
 │  └─ test-fixtures/
 │     └─ vizij-test-fixtures       # Loads JSON fixtures referenced across stacks
 ├─ npm/
+│  ├─ @vizij/animation-module      # vizij-animation-core built as an Arora wasm module (assets)
 │  ├─ @vizij/animation-wasm        # Stable ESM wrapper around `vizij-animation-wasm`
 │  ├─ @vizij/node-graph-wasm       # Wrapper around `vizij-graph-wasm`
 │  ├─ @vizij/orchestrator-wasm     # Wrapper around `vizij-orchestrator-wasm`
+│  ├─ @vizij/runtime               # Browser Vizij runtime as an Arora device (wasm bindings)
 │  ├─ @vizij/test-fixtures         # Browser bundle of shared JSON fixtures
 │  ├─ @vizij/value-json            # Shared JSON coercion helpers
 │  └─ @vizij/wasm-loader           # Loader that enforces ABI compatibility
@@ -73,6 +84,19 @@ Shared API crates (`vizij-api-core`, `vizij-api-wasm`) provide the Value/Shape/T
 `vizij-test-fixtures` exposes the JSON assets defined under `fixtures/`, while `vizij-graph-registry-export` supports registry generation for the node-graph npm tooling.
 
 Each WASM crate exposes a stable `abi_version()` (currently `2`); the npm wrappers verify this at runtime and instruct you to rebuild if versions drift.
+
+### Interop (Arora)
+
+The `crates/interop/*` family adapts the Vizij stacks onto Arora runtime seams so a Vizij runtime can run as an Arora device (browser or native). These crates are internal to the workspace; only the wasm-facing ones ship an npm package.
+
+| Crate | Purpose | npm package |
+| ------------------------ | ---------------------------------------------------------------------- | -------------------------- |
+| `vizij-arora`            | Vizij↔Arora `Value` interop: identity passthroughs + `Shape.meta` sidecar helpers. | — |
+| `vizij-arora-store`      | Vizij Blackboard exposed as an Arora `DataStore`.                      | — |
+| `vizij-arora-hal`        | Vizij rig presented as an Arora HAL.                                   | — |
+| `vizij-arora-behavior`   | Vizij node graph / orchestrator driven as Arora behavior interpreters. | — |
+| `vizij-arora-web`        | Browser wasm cdylib composing a Vizij runtime as an Arora device.      | `@vizij/runtime` |
+| `vizij-animation-module` | `vizij-animation-core` packaged as an Arora wasm module.               | `@vizij/animation-module` |
 
 ### Support Packages
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,16 +21,15 @@
 
 ### Animation Stack
 - Add native↔wasm parity tests to catch divergence before publishing.
-- Ship a minimal Bevy example app demonstrating animation playback.
 - Investigate profiling hooks (feature-flagged metrics) and faster watcher iterations.
 
 ### API Stack
 - Explore generating JSON/TypeScript schemas directly from `vizij-api-core`.
-- Provide derive macros or builders to reduce setter boilerplate in Bevy integrations.
+- Provide derive macros or builders to reduce setter boilerplate.
 - Investigate `no_std` support for constrained targets.
 
 ### Node Graph Stack
-- Add optional tracing/diagnostic events for Bevy consumers.
+- Add optional tracing/diagnostic events for downstream consumers.
 - Prototype incremental/streaming evaluation APIs in the wasm bridge.
 - Evaluate selector-heavy graphs and record benchmark results over time.
 

--- a/build-record-node-spec.md
+++ b/build-record-node-spec.md
@@ -11,7 +11,11 @@ This document covers all changes required across three layers:
 
 ## Why `Value::Record` and not `arora_schema::KeyValue`
 
-`arora_schema::KeyValue` is a type from a completely separate crate (`arora-schema`) that the vizij-rs node-graph stack has **zero dependency on** — `vizij-graph-core`, where the URDF IK nodes live, does not reference `arora` at all. (The `crates/interop/*` family does depend on Arora's runtime crates, but never on `arora-schema`, and the graph nodes stay independent of both.)
+> Historical note: `arora-schema` has since been retired from the Arora
+> workspace, so this is no longer a live alternative — the reasoning below is
+> kept for the record. The decision to use `Value::Record` stands.
+
+`arora_schema::KeyValue` was a type from a separate crate (`arora-schema`) that the vizij-rs node-graph stack had **zero dependency on** — `vizij-graph-core`, where the URDF IK nodes live, does not reference `arora-schema` at all. (The `crates/interop/*` family depends on Arora's runtime crates, but never on `arora-schema`, and the graph nodes stay independent of both.)
 
 Beyond the dependency issue, `arora_schema::KeyValue` is a heavier, schema-metadata type — every container and every field carries a `Uuid` for traceability, and its values are typed by arora's own `Value` enum (covering Rust primitives, structures, enumerations, etc.), not by vizij's animation-centric `vizij_api_core::Value`.
 

--- a/build-record-node-spec.md
+++ b/build-record-node-spec.md
@@ -11,7 +11,7 @@ This document covers all changes required across three layers:
 
 ## Why `Value::Record` and not `arora_schema::KeyValue`
 
-`arora_schema::KeyValue` is a type from a completely separate, unrelated crate (`C:\repo\semio\arora-schema`) that vizij-rs has **zero dependency on** — there is not a single mention of "arora" in any `Cargo.toml` in the vizij-rs workspace.
+`arora_schema::KeyValue` is a type from a completely separate crate (`arora-schema`) that the vizij-rs node-graph stack has **zero dependency on** — `vizij-graph-core`, where the URDF IK nodes live, does not reference `arora` at all. (The `crates/interop/*` family does depend on Arora's runtime crates, but never on `arora-schema`, and the graph nodes stay independent of both.)
 
 Beyond the dependency issue, `arora_schema::KeyValue` is a heavier, schema-metadata type — every container and every field carries a `Uuid` for traceability, and its values are typed by arora's own `Value` enum (covering Rust primitives, structures, enumerations, etc.), not by vizij's animation-centric `vizij_api_core::Value`.
 

--- a/crates/animation/README.md
+++ b/crates/animation/README.md
@@ -20,12 +20,6 @@ The `crates/animation` directory contains the Rust-side animation stack. The thr
 3. Create an `Engine`, register animations, create players/instances, and call `update_values(dt, inputs)` every frame.
 4. Apply `Outputs.changes` to your host and consume `Outputs.events` as needed.
 
-### Bevy app
-
-2. Insert `VizijAnimationPlugin`.
-3. Mark a hierarchy root with `VizijTargetRoot` and optional overrides with `VizijBindingHint`.
-4. Load animations through the shared `VizijEngine` resource and let the plugin drive fixed updates.
-
 ### JavaScript / TypeScript
 
 1. Build the wasm package with `pnpm run build:wasm:animation`.

--- a/crates/animation/agents.md
+++ b/crates/animation/agents.md
@@ -5,4 +5,4 @@
   - Watcher: `pnpm run watch:wasm:animation` (requires `cargo-watch`).
 - **Fixture helpers**: Use `vizij_test_fixtures::animations` or `@vizij/test-fixtures/animations` when writing tests or demos.
 - **Docs**: Revisit `crates/animation/README.md` and crate-specific sections before editing; keep ABI guard (`abi_version()`) in sync with npm packages.
-- **Common traps**: Rebuild the wasm crate after touching `vizij-animation-core`; watch for Bevy feature flags when introducing new dependencies.
+- **Common traps**: Rebuild the wasm crate after touching `vizij-animation-core`; check wasm compatibility when introducing new dependencies.

--- a/crates/animation/run-testing-suite.sh
+++ b/crates/animation/run-testing-suite.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Orchestrate testing suite:
 #  1) Core native tests
-#  2) Bevy adapter tests
+#  2) Ensure wasm32 target is installed
 #  3) WASM tests (Node) via wasm-bindgen-test
 #
 # Usage:

--- a/crates/animation/vizij-animation-core/agents.md
+++ b/crates/animation/vizij-animation-core/agents.md
@@ -1,6 +1,6 @@
 # vizij-animation-core — Agent Notes
 
-- **Purpose**: Deterministic animation engine powering Bevy, wasm, and orchestrator integrations.
+- **Purpose**: Deterministic animation engine powering wasm and orchestrator integrations.
 - **Hot spots**: `src/lib.rs` (engine API), `src/engine/`, `src/baking/`. Config tuning lives in `config.rs`.
 - **Tests**: `cargo test -p vizij-animation-core` (unit + integration). Use fixtures via `vizij_test_fixtures::animations`.
 - **Key dependencies**: `vizij-api-core` for values/paths; `vizij-test-fixtures` for sample assets.

--- a/crates/animation/vizij-animation-core/src/binding.rs
+++ b/crates/animation/vizij-animation-core/src/binding.rs
@@ -19,7 +19,7 @@ pub struct ChannelKey {
 }
 
 /// Trait for resolving canonical target paths to opaque handles.
-/// Adapters (Bevy/WASM) implement this and pass into Engine::prebind().
+/// Adapters (WASM and native hosts) implement this and pass into Engine::prebind().
 pub trait TargetResolver {
     fn resolve(&mut self, path: &str) -> Option<TargetHandle>;
 }

--- a/crates/animation/vizij-animation-core/src/inputs.rs
+++ b/crates/animation/vizij-animation-core/src/inputs.rs
@@ -2,7 +2,7 @@
 //! Input contracts for the core engine.
 //!
 //! v1 keeps this minimal: per-player commands and per-instance updates. Adapters
-//! (web/Bevy) build and pass these into Engine::update() each fixed tick.
+//! (web and native hosts) build and pass these into Engine::update() each fixed tick.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/animation/vizij-animation-core/src/outputs.rs
+++ b/crates/animation/vizij-animation-core/src/outputs.rs
@@ -3,7 +3,7 @@
 //!
 //! Outputs carry only the numeric/value changes for this tick, keyed by
 //! stable string TargetHandle, and a separate list of semantic events.
-//! Adapters (Bevy/WASM) apply changes to the host and transport events.
+//! Adapters (WASM and native hosts) apply changes to the host and transport events.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/api/agents.md
+++ b/crates/api/agents.md
@@ -1,8 +1,8 @@
 # API Stack — Agent Notes
 
 - **Scope**: `vizij-api-core`, `vizij-api-wasm`.
-- **Purpose**: Shared Value/Shape/TypedPath contracts and Bevy/WASM helpers that keep stacks interoperable.
-- **Key commands**: `cargo test -p vizij-api-core`, `cargo test -p bevy_vizij_api`, `cargo test -p vizij-api-wasm`, `pnpm --filter @vizij/value-json test`.
+- **Purpose**: Shared Value/Shape/TypedPath contracts and WASM helpers that keep stacks interoperable.
+- **Key commands**: `cargo test -p vizij-api-core`, `cargo test -p vizij-api-wasm`, `pnpm --filter @vizij/value-json test`.
 - **Dependencies**: Changes ripple into animation, graph, orchestrator stacks—coordinate via `ROADMAP.md`.
 - **Doc hygiene**: Keep crate READMEs up to date when altering serialization, setter registries, or wasm exports.
 - **Cross-repo**: Sync schema changes with `vizij-web` to avoid breaking browser clients.

--- a/crates/node-graph/agents.md
+++ b/crates/node-graph/agents.md
@@ -1,6 +1,6 @@
 # Node Graph Stack — Agent Notes
 
-- **Purpose**: Deterministic data-flow evaluation across Rust, Bevy, and wasm hosts.
+- **Purpose**: Deterministic data-flow evaluation across Rust and wasm hosts.
 - **Fixtures**: Use `vizij_test_fixtures::node_graphs` / `@vizij/test-fixtures` for specs + stage payloads.
 - **Docs**: Consult the stack README before edits; capture selector/parameter guidance changes.
 - **Special care**: Keep `urdf_ik` feature defaults aligned across crates; orchestrator depends on consistent behaviour.

--- a/crates/node-graph/vizij-graph-core/README.md
+++ b/crates/node-graph/vizij-graph-core/README.md
@@ -2,7 +2,7 @@
 
 > **Deterministic data-flow evaluation for Vizij graphs – pure Rust with predictable staging, shapes, and side effects.**
 
-`vizij-graph-core` turns declarative `GraphSpec` documents into structured values and typed write operations. The crate powers Vizij’s node graph tooling, Bevy integrations, and WebAssembly bindings.
+`vizij-graph-core` turns declarative `GraphSpec` documents into structured values and typed write operations. The crate powers Vizij’s node graph tooling and WebAssembly bindings.
 
 ---
 

--- a/crates/orchestrator/vizij-orchestrator-core/merge_tutorial.md
+++ b/crates/orchestrator/vizij-orchestrator-core/merge_tutorial.md
@@ -47,7 +47,7 @@ Keep separate controllers when:
 `GraphMergeOptions` controls what happens when multiple graphs produce the same `TypedPath`.
 
 ```rust
-use vizij_orchestrator_core::{
+use vizij_orchestrator::{
     controllers::{GraphControllerConfig, GraphMergeOptions, OutputConflictStrategy},
     Orchestrator, Schedule,
 };

--- a/crates/orchestrator/vizij-orchestrator-core/tutorial.md
+++ b/crates/orchestrator/vizij-orchestrator-core/tutorial.md
@@ -43,7 +43,7 @@ You will commonly pair it with the companion crates:
 ## 3. Hello Orchestrator
 
 ```rust
-use vizij_orchestrator_core::{
+use vizij_orchestrator::{
     controllers::{GraphControllerConfig, Subscriptions},
     Orchestrator, Schedule,
 };
@@ -103,7 +103,7 @@ fn main() -> anyhow::Result<()> {
 ## 4. Working with the Blackboard
 
 ```rust
-use vizij_orchestrator_core::{Blackboard, BlackboardEntry, Orchestrator, Schedule};
+use vizij_orchestrator::{Blackboard, BlackboardEntry, Orchestrator, Schedule};
 use vizij_api_core::value::float;
 use vizij_api_core::{TypedPath, WriteBatch, WriteOp};
 
@@ -142,7 +142,7 @@ Change schedules when creating the orchestrator or at runtime (if you rebuild co
 ## 6. Animations + Graphs
 
 ```rust
-use vizij_orchestrator_core::{
+use vizij_orchestrator::{
     controllers::{animation::AnimationControllerConfig, GraphControllerConfig, Subscriptions},
 };
 
@@ -172,7 +172,7 @@ Graph specs often form domains (IO graph, compute graph, etc.). Instead of stagi
 via the blackboard every frame, merge them into a single controller:
 
 ```rust
-use vizij_orchestrator_core::controllers::GraphControllerConfig;
+use vizij_orchestrator::controllers::GraphControllerConfig;
 
 let merged = GraphControllerConfig::merged_with_options(
     "graph:merged",

--- a/npm/@vizij/node-graph-wasm/README.md
+++ b/npm/@vizij/node-graph-wasm/README.md
@@ -130,14 +130,11 @@ The package exports named graph samples and fixture loaders:
 ```ts
 import { loadNodeGraphBundle } from "@vizij/node-graph-wasm";
 
-const { spec, stage } = await loadNodeGraphBundle("urdf-ik-position");
+const { spec } = await loadNodeGraphBundle("urdf-ik-position");
 graph.loadGraph(spec);
-if (stage) {
-  for (const [path, payload] of Object.entries(stage)) {
-    graph.stageInput(path, payload.value, payload.shape);
-  }
-}
 ```
+
+`loadNodeGraphBundle` now returns only `{ spec }`; stage inputs are no longer bundled with fixtures and should be staged per usage site with `graph.stageInput(path, value, shape)`.
 
 ## Troubleshooting
 

--- a/npm/@vizij/value-json/README.md
+++ b/npm/@vizij/value-json/README.md
@@ -21,7 +21,7 @@
 
 ## Overview
 
-- Mirrors the canonical `{ type: "...", data: ... }` envelope emitted by Vizij engines and WASM runtimes.
+- Mirrors the canonical `{ type: "...", data: ... }` envelope and the Arora serde value forms emitted by current Vizij engines and WASM runtimes.
 - Accepts legacy `{ float: 1 }`, `{ vec3: [...] }` shapes for backwards compatibility while gently nudging you toward the normalised form.
 - Ships coercion helpers (`toValueJSON`, `valueAsNumber`, `valueAsTransform`, etc.) that front-ends and tooling can rely on.
 - Ensures discriminants stay lowercase so string comparisons remain consistent across ecosystems.
@@ -89,6 +89,8 @@ type ValueJSON = NormalizedValue | { float: number } | { vec3: [number, number, 
 - `ValueJSON` – accepts both normalized values and legacy aliases/primitives for input convenience.
 - `ValueInput` – alias for `ValueJSON | number[]`, used by staging helpers in other packages.
 - `NormalizedTransform` – `{ translation: [x,y,z], rotation: [x,y,z,w], scale: [x,y,z] }`.
+- `AroraValueJSON` – union describing Arora's serde value forms (the shape current Vizij runtimes emit); decode it with `fromAroraValueJSON`.
+- `VIZIJ_*_TYPE` – UUID type-id constants (`VIZIJ_VEC3_TYPE`, `VIZIJ_QUAT_TYPE`, `VIZIJ_TRANSFORM_TYPE`, …) that identify Vizij's Arora value types.
 
 ---
 
@@ -103,6 +105,7 @@ type ValueJSON = NormalizedValue | { float: number } | { vec3: [number, number, 
 | `valueAsVector(value)` | Returns a numeric array or `undefined` if coercion fails. |
 | `valueAsTransform(value)` | Returns a `[translation, rotation, scale]` tuple with defaults for missing components. |
 | `valueAsQuat`, `valueAsVec3`, `valueAsColorRgba`, `valueAsBool`, `valueAsText` | Convenience accessors for common types. |
+| `fromAroraValueJSON(value): NormalizedValue \| undefined` | Decodes an Arora serde value form (as emitted by current Vizij runtimes) into a canonical `NormalizedValue`. |
 
 All readers return `undefined` when coercion fails, letting callers handle optional values explicitly.
 


### PR DESCRIPTION
Documentation-staleness sweep across the workspace. Docs only — no runtime code changed (source edits are comment-only).

## Bevy removal (VIZ-63)
Bevy was removed from the workspace, but several docs still described it. Dropped the dead references:
- `crates/animation/README.md` — removed the "Bevy app" workflow (`VizijAnimationPlugin`/`VizijTargetRoot`/`VizijBindingHint`/`VizijEngine` no longer exist).
- `crates/node-graph/vizij-graph-core/README.md` — dropped "Bevy integrations".
- `crates/api/agents.md` — dropped the "Bevy/WASM helpers" claim and the nonexistent `cargo test -p bevy_vizij_api` command.
- Root `AGENTS.md` — removed the "Bevy adapter" claim.
- `ROADMAP.md` — reworded/dropped the three Bevy backlog items.
- `crates/animation/agents.md`, `crates/animation/vizij-animation-core/agents.md`, `crates/node-graph/agents.md` — reworded to drop Bevy.
- `vizij-animation-core` source doc-comments (`inputs.rs`, `outputs.rs`, `binding.rs`) and the `run-testing-suite.sh` header — dropped stale Bevy mentions.

## Orchestrator import path
`crates/orchestrator/vizij-orchestrator-core/tutorial.md` + `merge_tutorial.md` used `use vizij_orchestrator_core::…`, but the crate's `[lib] name` is `vizij_orchestrator`. Fixed all import paths to match (the crate README already used the correct one).

## Inventory refresh
The root `README.md` layout diagram + tables and `AGENTS.md` snapshot omitted the `crates/interop/*` (Arora) family and its npm packages. Added:
- `vizij-arora`, `vizij-arora-store`, `vizij-arora-hal`, `vizij-arora-behavior`, `vizij-arora-web`, `vizij-animation-module` (new "Interop (Arora)" section + diagram entries).
- npm `@vizij/runtime` and `@vizij/animation-module`.
- Reworded the stale `@vizij/*-wasm` blanket claim, since `@vizij/runtime` carries no `-wasm` suffix after the rename from `@vizij/arora-web-wasm`.

## node-graph `stage`
`npm/@vizij/node-graph-wasm/README.md` — `loadNodeGraphBundle` now returns only `{ spec }` (per `src/fixtures.ts`); the example destructured a removed `{ stage }`. Fixed.

## Lower-priority
- `npm/@vizij/value-json/README.md` — acknowledged the Arora serde value forms current runtimes emit; documented `fromAroraValueJSON` / `AroraValueJSON` / `VIZIJ_*_TYPE`.
- `build-record-node-spec.md` — corrected the now-false "no mention of arora in any Cargo.toml" claim (the interop crates depend on Arora; `vizij-graph-core`, which hosts the URDF IK nodes, does not).

Not touched (out of scope / by design): CHANGELOGs, historical/plan/proposal/archive docs, and the Bevy system-dep step names in `.github/workflows/*.yml` (functional CI config, not docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)