### PR TITLE
chore: reconstruct CHANGELOGs for packages missing them

### DIFF
--- a/crates/animation/vizij-animation-core/CHANGELOG.md
+++ b/crates/animation/vizij-animation-core/CHANGELOG.md
@@ -1,0 +1,62 @@
+# Changelog
+
+All notable changes to `vizij-animation-core`. The format follows
+[Keep a Changelog](https://keepachangelog.com/); versions follow
+[Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Changed
+
+- Freshened workspace dependencies to current majors.
+
+## [1.0.0] - 2026-07-10
+
+### Breaking
+
+- Built on the unified Value: `vizij_api_core::Value` is now
+  `arora_types::value::Value` (vizij-api-core 1.0.0). Keypoints decode once at
+  ingestion into POD `TrackValue` (`[f32; N]`); sampling, interpolation, and
+  accumulation run on the PODs (same math, byte-identical blending), with the
+  dynamic `Value` appearing only at boundaries. Values the engine emits (frame
+  changes, baked tracks) are in arora serde form; consumers must read them
+  through the arora accessors instead of pattern-matching the old JSON shape.
+
+### Fixed
+
+- Accumulation and pre-binding bugs in layered playback.
+
+### Changed
+
+- Standardized `Value` usage and type casing across the engine; test fixtures
+  reorganized around the shared value-json helpers.
+
+## [0.3.0] - 2025-09-28
+
+### Added
+
+- Derivative update and baking APIs: per-frame derivative calculations and
+  baked-track output exposed through the core (and surfaced in the wasm/npm
+  layers).
+
+## [0.2.0] - 2025-09-23
+
+### Added
+
+- Full animation-player port; multi-slider node.
+
+### Changed
+
+- Extracted the shared types and interfaces into a common API
+  (vizij-api-core); refactor around vector data; crate metadata prepared for
+  publishing.
+
+### Fixed
+
+- Timing bugs; offset and scale calculations on instances.
+
+## [0.1.0] - 2025-09-05
+
+### Added
+
+- Initial release: engine-agnostic core animation logic for Vizij.

--- a/crates/animation/vizij-animation-wasm/CHANGELOG.md
+++ b/crates/animation/vizij-animation-wasm/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to `vizij-animation-wasm`. The format follows
+[Keep a Changelog](https://keepachangelog.com/); versions follow
+[Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Changed
+
+- Freshened workspace dependencies to current majors.
+
+## [1.0.0] - 2026-07-10
+
+### Breaking
+
+- Built on vizij-animation-core 1.0.0 / vizij-api-core 1.0.0: values the engine
+  emits (frame changes, baked tracks) are now in arora serde form. Read them
+  through the `@vizij/value-json` accessors; code that pattern-matched the raw
+  JSON shape must switch to the accessors. Legacy input forms are normalized on
+  ingress.
+
+### Changed
+
+- Standardized `Value` usage and casing; fixtures and value-json packages
+  refactored.
+
+### Fixed
+
+- Accumulation and pre-binding bugs surfaced through the wasm bridge.
+
+## [0.3.0] - 2025-09-28
+
+### Added
+
+- Baked animation exposed through the wasm/npm API; derivative update API.
+
+## [0.2.0] - 2025-09-23
+
+### Added
+
+- Full animation-player port; multi-slider node.
+
+### Changed
+
+- Extracted the shared API (vizij-api-core); refactor around vector data; crate
+  metadata prepared for publishing.
+
+### Fixed
+
+- Offset and scale calculations on instances.
+
+## [0.1.0] - 2025-09-05
+
+### Added
+
+- Initial release: wasm-bindgen interface for the Vizij animation engine.

--- a/crates/node-graph/vizij-graph-core/CHANGELOG.md
+++ b/crates/node-graph/vizij-graph-core/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog
+
+All notable changes to `vizij-graph-core`. The format follows
+[Keep a Changelog](https://keepachangelog.com/); versions follow
+[Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- `ExternalFunction` node plus the `NodeFunctions` call-bridge seam: a graph
+  node can call out to host-provided functions.
+- The path-less `Output` node applies a keyed record batch to its keys: an
+  `output` without `path` takes `key_field`/`value_field` params (record field
+  ids) and writes each record's value under the path its key field names.
+
+### Changed
+
+- Freshened workspace dependencies to current majors.
+
+## [1.0.0] - 2026-07-10
+
+### Breaking
+
+- Built on the unified Value (vizij-api-core 1.0.0 = `arora_types` `Value`): the
+  graph evaluates on PODs with `Value` only at node boundaries; node-registry
+  defaults and evaluation output are in arora serde form. `List`/`Tuple`/`Array`
+  collapse into one `ArrayValue`; enums ride arora's `Enumeration`.
+
+### Added
+
+- Record nodes; noise generator nodes; to/from vector nodes; a new blend-node
+  default.
+
+### Changed
+
+- Graph plan cache and warm WASM fast paths for lower evaluation overhead;
+  slot-based port layouts; delta staging tightened; defaults included in
+  fingerprinting; caching policy documented.
+
+### Fixed
+
+- Transition nodes not receiving `dt` updates; piecewise-remap plateau handling;
+  hardened `evaluate_all_cached` plan validation and selector projection errors;
+  clippy `into_iter` lint.
+
+## [0.3.0] - 2025-09-28
+
+### Changed
+
+- Cleaned up and extended graph support for IK; added comprehensive blend-node
+  test coverage.
+
+## [0.2.0] - 2025-09-23
+
+### Added
+
+- IK nodes and a demo IK node; an FK node; transition nodes; multi-slider node;
+  external inputs to the graph with stronger shape selection by nodes; range-node
+  params.
+
+### Changed
+
+- Refactored the node-eval monolith and the node schema; extracted the shared
+  types and interfaces into a common API (vizij-api-core); typed paths with
+  refined shape/value handling; refactor around vector data.
+
+### Fixed
+
+- Oscillator and join node fixes; new-node evaluation fixes.
+
+## [0.1.0] - 2025-09-05
+
+### Added
+
+- Initial release: core node-graph engine for Vizij.

--- a/crates/node-graph/vizij-graph-wasm/CHANGELOG.md
+++ b/crates/node-graph/vizij-graph-wasm/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+All notable changes to `vizij-graph-wasm`. The format follows
+[Keep a Changelog](https://keepachangelog.com/); versions follow
+[Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Changed
+
+- Freshened workspace dependencies to current majors.
+
+## [1.0.0] - 2026-07-10
+
+### Breaking
+
+- Built on vizij-graph-core 1.0.0 / vizij-api-core 1.0.0: values from graph
+  evaluation and the node-registry defaults are now in arora serde form. Read
+  them through the `@vizij/value-json` accessors; code that pattern-matched the
+  raw JSON shape must switch to the accessors. Legacy input forms are normalized
+  on ingress.
+
+### Added
+
+- Record nodes and to/from vector nodes exposed; noise params supported in the
+  runtime `set_param` paths.
+
+### Changed
+
+- Graph plan cache and WASM fast paths; delta staging tightened in the wasm
+  wrapper; caching policy documented.
+
+### Fixed
+
+- Casing on wasm conversion; borrow/self-aliasing in the wasm delta-snapshot
+  helper.
+
+## [0.3.0] - 2025-09-28
+
+### Changed
+
+- Cleaned up graph support for IK; added blend-node test coverage.
+
+## [0.2.0] - 2025-09-23
+
+### Added
+
+- IK nodes and a demo IK node; transition nodes; multi-slider node; range-node
+  params; graph input/output wiring exposed through the WASM/NPM packages;
+  examples and tests; console panic hook.
+
+### Changed
+
+- Refactored the node schema; extracted the shared API (vizij-api-core); typed
+  paths with refined shape/value handling; refactor around vector data.
+
+## [0.1.0] - 2025-09-05
+
+### Added
+
+- Initial release: wasm-bindgen interface for the Vizij node graph.

--- a/crates/orchestrator/vizij-orchestrator-wasm/CHANGELOG.md
+++ b/crates/orchestrator/vizij-orchestrator-wasm/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to `vizij-orchestrator-wasm`. The format follows
+[Keep a Changelog](https://keepachangelog.com/); versions follow
+[Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Changed
+
+- Freshened workspace dependencies to current majors.
+
+## [1.0.0] - 2026-07-10
+
+### Breaking
+
+- Built on vizij-orchestrator-core 1.0.0 / vizij-api-core 1.0.0: values crossing
+  the orchestrator boundary are now in arora serde form. Read them through the
+  `@vizij/value-json` accessors; code that pattern-matched the raw JSON shape
+  must switch to the accessors. Legacy input forms are normalized on ingress.
+
+### Added
+
+- `replaceGraph` for structural edits, which invalidates the plan cache.
+
+### Changed
+
+- WASM bindings, typing, and docs aligned with the core; lowered the
+  orchestrator log level.
+
+### Fixed
+
+- Transition nodes not receiving `dt` updates; casing on wasm conversion.
+
+## [0.1.0] - 2025-09-29
+
+### Added
+
+- Initial release: WASM bindings for the vizij orchestrator core (JS-friendly
+  wrapper), with publishing setup.


### PR DESCRIPTION
Reconstructs Keep a Changelog histories for the publishable crates that had no CHANGELOG. Only `CHANGELOG.md` files are added — no code, docs, or config touched.

## Crates given new CHANGELOGs

All five are crates.io-publishable (crates.io metadata present, no `publish = false`) and had **no** CHANGELOG. Versions and dates reconstructed from git tags (`crates/0.2.0` → 2025-09-23, `release-0.3.0` → 2025-09-28) and version-bump commits (`7bc3e5b` 0.2.0, `98bb0c0` 0.3.0, `c727f5b` 1.0.0 — the Value-unification major on 2026-07-10). Per-version change summaries come from commits touching each crate's directory between those boundaries.

| Crate | Versions covered | Source |
| --- | --- | --- |
| `vizij-animation-core` | 0.1.0 → 1.0.0 (+ Unreleased) | tags + version-bump commits |
| `vizij-animation-wasm` | 0.1.0 → 1.0.0 (+ Unreleased) | tags + version-bump commits |
| `vizij-graph-core` | 0.1.0 → 1.0.0 (+ Unreleased) | tags + version-bump commits |
| `vizij-graph-wasm` | 0.1.0 → 1.0.0 (+ Unreleased) | tags + version-bump commits |
| `vizij-orchestrator-wasm` | 0.1.0 (2025-09-29) → 1.0.0 (+ Unreleased) | version-bump commits (`8c7b840`, `c727f5b`) |

The `Unreleased` sections capture post-1.0.0 work that hasn't been version-bumped: for `vizij-graph-core`, the `ExternalFunction` node + `NodeFunctions` call-bridge and the path-less keyed-record `Output`; for the rest, the workspace dependency freshen.

## Already current — left untouched

All npm packages already carry Changesets-generated CHANGELOGs whose top entry matches the current `package.json` version, so none were modified:

- `@vizij/runtime` 1.1.0, `@vizij/animation-module` 0.2.0 (the style templates)
- `@vizij/animation-wasm` 0.4.0, `@vizij/node-graph-wasm` 0.7.0, `@vizij/orchestrator-wasm` 0.4.0, `@vizij/value-json` 0.2.0, `@vizij/wasm-loader` 0.1.5

## Skipped

- `publish = false` crates (not crates.io-publishable): `vizij-api-core`, `vizij-api-wasm`, `vizij-orchestrator-core`, the whole `crates/interop/*` family (`vizij-arora`, `vizij-arora-web`, `vizij-arora-store`, `vizij-arora-hal`, `vizij-arora-behavior`, `vizij-animation-module`), `vizij-test-fixtures`, and the `vizij-glb-migrate` tool.
- `vizij-graph-registry-export` — has no `publish = false` but also **no** crates.io metadata (no license/description/repository); it is an internal registry-export helper, not a published crate.
- `@vizij/test-fixtures` — `private: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)