### PR TITLE
feat(animation-module): expose baking (bake + derivatives)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,6 +2852,7 @@ dependencies = [
  "arora-types",
  "derive_more",
  "lazy_static",
+ "serde_json",
  "serde_yaml",
  "tokio",
  "uuid",

--- a/crates/interop/vizij-animation-module/Cargo.toml
+++ b/crates/interop/vizij-animation-module/Cargo.toml
@@ -30,5 +30,6 @@ anyhow = "1"
 arora-engine = "3"
 arora-types = "2"
 uuid = { version = "1", features = ["v4"] }
+serde_json = "1"
 serde_yaml = "0.9"
 vizij-arora = { path = "../vizij-arora" }

--- a/crates/interop/vizij-animation-module/module.yaml
+++ b/crates/interop/vizij-animation-module/module.yaml
@@ -163,6 +163,48 @@ exports:
     parameters: []
     ret: { kind: array, id: 76697a69-6a00-0000-0000-000000000111 }
 
+  # baking ---------------------------------------------------------------------
+  # Bake a loaded animation to sampled per-track values over a fixed window and
+  # return the result as a JSON string. `frame_rate` (Hz) defaults to 60,
+  # `start_time` (s) to 0, `end_time` (s) to the clip duration. Empty string when
+  # `anim` is not loaded. `bake_with_derivatives` additionally samples per-frame
+  # derivatives.
+  - type: function
+    id: 76697a69-6a00-0000-0f00-00000000000e
+    name: bake
+    parameters:
+      - id: 76697a69-6a00-0000-0f0e-000000000001
+        name: anim
+        type: { kind: scalar, id: u32 }
+      - id: 76697a69-6a00-0000-0f0e-000000000002
+        name: frame_rate
+        type: { kind: scalar, id: f32 }
+      - id: 76697a69-6a00-0000-0f0e-000000000003
+        name: start_time
+        type: { kind: scalar, id: f32 }
+      - id: 76697a69-6a00-0000-0f0e-000000000004
+        name: end_time
+        type: { kind: scalar, id: f32 }
+    ret: { kind: scalar, id: str }
+
+  - type: function
+    id: 76697a69-6a00-0000-0f00-00000000000f
+    name: bake_with_derivatives
+    parameters:
+      - id: 76697a69-6a00-0000-0f0f-000000000001
+        name: anim
+        type: { kind: scalar, id: u32 }
+      - id: 76697a69-6a00-0000-0f0f-000000000002
+        name: frame_rate
+        type: { kind: scalar, id: f32 }
+      - id: 76697a69-6a00-0000-0f0f-000000000003
+        name: start_time
+        type: { kind: scalar, id: f32 }
+      - id: 76697a69-6a00-0000-0f0f-000000000004
+        name: end_time
+        type: { kind: scalar, id: f32 }
+    ret: { kind: scalar, id: str }
+
 imports: []
 dependencies:
   - { id: 76697a69-6a00-0000-0000-000000000100, version: "1.1.0" }

--- a/crates/interop/vizij-animation-module/src/lib.rs
+++ b/crates/interop/vizij-animation-module/src/lib.rs
@@ -41,9 +41,9 @@ use arora_generated::vizij::{
 };
 
 use vizij_animation_core::{
-    AnimId, AnimationData, Config, Engine, Inputs, InstId, InstanceCfg, InstanceUpdate,
-    Keypoint as CoreKeypoint, LoopMode, PlayerCommand, PlayerId, Track as CoreTrack, Transitions,
-    Vec2,
+    export_baked_json, export_baked_with_derivatives_json, AnimId, AnimationData, BakingConfig,
+    Config, Engine, Inputs, InstId, InstanceCfg, InstanceUpdate, Keypoint as CoreKeypoint,
+    LoopMode, PlayerCommand, PlayerId, Track as CoreTrack, Transitions, Vec2,
 };
 
 lazy_static::lazy_static! {
@@ -267,6 +267,75 @@ fn player_states() -> Vec<PlayerState> {
             speed: info.speed,
         })
         .collect()
+}
+
+// baking ---------------------------------------------------------------------
+
+/// Build a [`BakingConfig`] from the module's optional scalar arguments,
+/// falling back to the core defaults (frame rate 60 Hz, start 0 s, end = clip
+/// duration) for any argument left unset.
+fn baking_config(
+    frame_rate: Option<f32>,
+    start_time: Option<f32>,
+    end_time: Option<f32>,
+) -> BakingConfig {
+    let defaults = BakingConfig::default();
+    BakingConfig {
+        frame_rate: frame_rate.unwrap_or(defaults.frame_rate),
+        start_time: start_time.unwrap_or(defaults.start_time),
+        end_time: end_time.or(defaults.end_time),
+        derivative_epsilon: defaults.derivative_epsilon,
+    }
+}
+
+/// Bake animation `anim` to sampled per-track values over a fixed window and
+/// return the result as a JSON string (`vizij-animation-core`'s
+/// `export_baked_json` shape). `frame_rate` (Hz) defaults to 60, `start_time`
+/// (seconds) to 0, and `end_time` (seconds) to the clip duration. Returns an
+/// empty string if `anim` is not loaded.
+fn bake(
+    anim: Option<u32>,
+    frame_rate: Option<f32>,
+    start_time: Option<f32>,
+    end_time: Option<f32>,
+) -> String {
+    let Some(anim) = anim else {
+        return String::new();
+    };
+    let cfg = baking_config(frame_rate, start_time, end_time);
+    match ENGINE
+        .lock()
+        .expect("engine")
+        .bake_animation(AnimId(anim), &cfg)
+    {
+        Some(baked) => export_baked_json(&baked).to_string(),
+        None => String::new(),
+    }
+}
+
+/// Like [`bake`], but also samples per-frame derivatives; returns the combined
+/// values-and-derivatives JSON (`export_baked_with_derivatives_json` shape).
+/// Returns an empty string if `anim` is not loaded.
+fn bake_with_derivatives(
+    anim: Option<u32>,
+    frame_rate: Option<f32>,
+    start_time: Option<f32>,
+    end_time: Option<f32>,
+) -> String {
+    let Some(anim) = anim else {
+        return String::new();
+    };
+    let cfg = baking_config(frame_rate, start_time, end_time);
+    match ENGINE
+        .lock()
+        .expect("engine")
+        .bake_animation_with_derivatives(AnimId(anim), &cfg)
+    {
+        Some((baked, derivatives)) => {
+            export_baked_with_derivatives_json(&baked, &derivatives).to_string()
+        }
+        None => String::new(),
+    }
 }
 
 /// Advance the engine by `dt_ns` nanoseconds and return per-track outputs.
@@ -591,5 +660,38 @@ mod tests {
             value_of(&outputs, "mix/x").is_none(),
             "no instances, no output for the key"
         );
+    }
+
+    #[test]
+    fn bake_exports_sampled_tracks_as_json() {
+        let _serial = serial();
+        let anim = load_animation(Some(constant_clip("bake-me", "joint/x", 0.5)));
+
+        // A loaded clip bakes to a JSON object echoing the requested frame rate
+        // and carrying at least one track of sampled values.
+        let json = bake(Some(anim), Some(30.0), None, None);
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("baked JSON parses");
+        assert_eq!(parsed["frame_rate"].as_f64(), Some(30.0));
+        let tracks = parsed["tracks"].as_array().expect("tracks array");
+        assert!(!tracks.is_empty(), "at least one baked track");
+        assert!(
+            tracks[0].get("target_path").is_some(),
+            "track carries a path"
+        );
+        assert!(
+            tracks[0]["values"]
+                .as_array()
+                .is_some_and(|v| !v.is_empty()),
+            "track has sampled values"
+        );
+
+        // The derivatives variant wraps values + derivatives.
+        let deriv = bake_with_derivatives(Some(anim), Some(30.0), None, None);
+        let dparsed: serde_json::Value =
+            serde_json::from_str(&deriv).expect("derivative JSON parses");
+        assert!(dparsed.get("values").is_some() && dparsed.get("derivatives").is_some());
+
+        // An unloaded animation bakes to an empty string.
+        assert!(bake(Some(u32::MAX), None, None, None).is_empty());
     }
 }

--- a/npm/@vizij/animation-module/CHANGELOG.md
+++ b/npm/@vizij/animation-module/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `@vizij/animation-module`. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [0.3.0] - 2026-07-22
+
+### Added
+
+- Baking on the module surface: `bake(anim, frame_rate?, start_time?, end_time?)`
+  and `bake_with_derivatives(...)`, returning the sampled result as a JSON string
+  (`vizij-animation-core`'s `export_baked_json` / `export_baked_with_derivatives_json`
+  shape). `frame_rate` defaults to 60 Hz, `start_time` to 0 s, and `end_time` to
+  the clip duration; an unloaded `anim` returns an empty string. Brings the
+  module to feature parity with the direct library for baking.
+
 ## [0.2.0] - 2026-07-22
 
 ### Added

--- a/npm/@vizij/animation-module/package.json
+++ b/npm/@vizij/animation-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizij/animation-module",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "vizij-animation-core packaged as an Arora wasm module: the built artifact (wasm + header) as importable assets.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
`@vizij/animation-module` wraps `vizij-animation-core` but previously left its **baking** unexposed — the gap that blocked module consumers (e.g. `demo-animation-studio`) from using the arora-module path for baked/derivative workflows. This surfaces it.

## What's added (additive module functions)
- **`bake(anim, frame_rate?, start_time?, end_time?) -> string`** — samples a loaded animation over a fixed window; returns the baked data as JSON (`vizij-animation-core`'s `export_baked_json` shape: `{ anim, frame_rate, start_time, end_time, tracks: [{ target_path, values }] }`).
- **`bake_with_derivatives(...) -> string`** — same, plus per-frame derivatives (`{ values, derivatives }`).

Defaults mirror the core: `frame_rate` 60 Hz, `start_time` 0 s, `end_time` = clip duration. An unloaded `anim` returns an empty string. Implemented via the existing `Engine::bake_animation` / `bake_animation_with_derivatives` (which do the id lookup internally), matching the module's `player_states` style.

## JS usage
```js
const json = device.call({ module, id: BAKE, args: { anim, frame_rate: 30 } });
const baked = JSON.parse(json); // { frame_rate, tracks: [{ target_path, values }] }
```

## Verification
- `cargo build -p vizij-animation-module` — codegen wires the new module.yaml functions.
- `cargo test -p vizij-animation-module --lib` — **6/6** incl. a new `bake_exports_sampled_tracks_as_json` (asserts frame-rate echo, non-empty sampled tracks, the derivatives wrapper, and empty-string for an unloaded id).
- pre-commit `cargo fmt` + `clippy --workspace -D warnings` and pre-push registry verify — all green.

npm wrapper `@vizij/animation-module` 0.2.0 → 0.3.0 (+ changelog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)