### PR TITLE
chore: rename @vizij/runtime API to runtime vocabulary (startDevice→startRuntime, AroraDevice→Runtime)

### DIFF
--- a/npm/@vizij/runtime/CHANGELOG.md
+++ b/npm/@vizij/runtime/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `@vizij/runtime`. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [2.0.0] - 2026-07-22
+
+### Breaking
+
+- The client-facing API drops the "device"/"Arora" vocabulary for "runtime":
+  `startDevice` → `startRuntime`, the `AroraDevice` class → `Runtime`,
+  `DeviceModule` → `RuntimeModule`, `DeviceCall` → `RuntimeCall`,
+  `DeviceCallResult` → `RuntimeCallResult`. Behavior is unchanged; only the
+  names differ. Update imports and the class name at call sites.
+
 ## [1.1.0] - 2026-07-22
 
 ### Added

--- a/npm/@vizij/runtime/README.md
+++ b/npm/@vizij/runtime/README.md
@@ -1,37 +1,37 @@
 # @vizij/runtime
 
-Run a Vizij runtime in the browser **as an Arora device**.
+Run a Vizij runtime in the browser.
 
 The wasm module (built from
 [`crates/interop/vizij-arora-web`](https://github.com/vizij-ai/vizij-rs/tree/main/crates/interop/vizij-arora-web))
 composes an [`arora`](https://crates.io/crates/arora) device over the Vizij
-interop seams — a blackboard store, a rig HAL, and your node graph as the
-device's behavior — and wraps it with
+interop seams — a blackboard store, a rig HAL, and your node graph as its
+behavior — and wraps it with
 [`arora-web`](https://crates.io/crates/arora-web)'s browser JS surface. One
-device, one store: the graph reads its `input` nodes' paths from the store
+runtime, one store: the graph reads its `input` nodes' paths from the store
 each tick and writes its outputs back, and JS talks to the same store.
 
 ## Use
 
 ```ts
-import { init, startDevice } from "@vizij/runtime";
+import { init, startRuntime } from "@vizij/runtime";
 
 await init();
-const device = await startDevice(graphSpec); // a Vizij graph spec (object or JSON)
-device.run(); // the device paces itself from here on (the promise only ever rejects)
+const runtime = await startRuntime(graphSpec); // a Vizij graph spec (object or JSON)
+runtime.run(); // the runtime paces itself from here on (the promise only ever rejects)
 
-// any time — the store surface stays live while the device runs:
-device.setValue("sensor/x", { f32: 0.75 });
-const changes = device.drainChanges(); // path -> ValueJSON | null
+// any time — the store surface stays live while the runtime runs:
+runtime.setValue("sensor/x", { f32: 0.75 });
+const changes = runtime.drainChanges(); // path -> ValueJSON | null
 // The FIRST drain returns the store's whole current state.
 
-// swap the running graph in place (store, modules, device all survive):
-await device.loadGraph(otherGraphSpec);
+// swap the running graph in place (store, modules, runtime all survive):
+await runtime.loadGraph(otherGraphSpec);
 ```
 
-A host with its own clock skips `run()` and calls `device.step(dtMs)` per
+A host with its own clock skips `run()` and calls `runtime.step(dtMs)` per
 frame instead (e.g. from `requestAnimationFrame` timestamps); `step()`
-becomes unavailable once `run()` has taken the device.
+becomes unavailable once `run()` has taken the runtime.
 
 Values cross the boundary in the normalized `ValueJSON` vocabulary from
 [`@vizij/value-json`](https://www.npmjs.com/package/@vizij/value-json);

--- a/npm/@vizij/runtime/package.json
+++ b/npm/@vizij/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizij/runtime",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Run a Vizij runtime in the browser as an Arora device: wasm bindings over arora-web's BrowserRuntime.",
   "license": "MIT",
   "repository": {

--- a/npm/@vizij/runtime/src/index.ts
+++ b/npm/@vizij/runtime/src/index.ts
@@ -1,26 +1,26 @@
 /**
  * Stable ESM entrypoint for `@vizij/runtime`.
  *
- * Runs a Vizij runtime in the browser *as an Arora device*: the wasm module
+ * Runs a Vizij runtime in the browser on an Arora engine: the wasm module
  * (`crates/interop/vizij-arora-web`) assembles an `arora_web::BrowserRuntime`
  * over a Vizij blackboard store, rig HAL, and the caller's node graph as the
- * device's behavior. This wrapper loads the wasm once and exposes the device
+ * runtime's behavior. This wrapper loads the wasm once and exposes the runtime
  * with idiomatic JS types: values cross the boundary in the normalized
  * `ValueJSON` vocabulary shared with the other Vizij packages.
  *
  * Typical use:
  * ```ts
- * import { init, startDevice } from "@vizij/runtime";
+ * import { init, startRuntime } from "@vizij/runtime";
  *
  * await init();
- * const device = await startDevice(graphSpec);
- * device.run(); // the device paces itself from here on
+ * const runtime = await startRuntime(graphSpec);
+ * runtime.run(); // the runtime paces itself from here on
  * // each animation frame:
- * device.setValue("sensor/x", { f32: 0.75 });
- * const changes = device.drainChanges();
+ * runtime.setValue("sensor/x", { f32: 0.75 });
+ * const changes = runtime.drainChanges();
  * ```
  *
- * A host with its own clock skips `run()` and calls `device.step(dtMs)`
+ * A host with its own clock skips `run()` and calls `runtime.step(dtMs)`
  * per frame instead.
  */
 import { toValueJSON, type ValueJSON, type ValueInput } from "@vizij/value-json";
@@ -34,11 +34,11 @@ import { loadBindings as loadWasmBindingsBrowser } from "@vizij/wasm-loader/brow
 export type GraphSpecInput = object | string;
 
 /**
- * An Arora wasm module to load into the device's engine: its header as JSON
+ * An Arora wasm module to load into the runtime's engine: its header as JSON
  * plus its `.wasm` executable bytes — e.g. what `@vizij/animation-module`'s
  * `loadAnimationModule()` returns.
  */
-export interface DeviceModule {
+export interface RuntimeModule {
   headerJson: string;
   wasmBytes: Uint8Array;
 }
@@ -49,10 +49,10 @@ export interface DeviceModule {
  * modules when omitted), and `args` as `{ id, value }` pairs in the Arora
  * `Value` vocabulary.
  */
-export type DeviceCall = object | string;
+export type RuntimeCall = object | string;
 
-/** What a device call resolves to: the returned Arora `Value`. */
-export interface DeviceCallResult {
+/** What a runtime call resolves to: the returned Arora `Value`. */
+export interface RuntimeCallResult {
   ret: unknown;
   mutated?: unknown[];
 }
@@ -75,7 +75,7 @@ interface WasmVizijArora {
 interface WasmBindings {
   default: (input?: unknown) => Promise<unknown>;
   VizijArora: {
-    start(graph_json?: string, modules?: DeviceModule[]): Promise<WasmVizijArora>;
+    start(graph_json?: string, modules?: RuntimeModule[]): Promise<WasmVizijArora>;
   };
 }
 
@@ -155,7 +155,7 @@ let _initPromise: Promise<void> | null = null;
 
 /**
  * Initialize the wasm module once. The returned promise is memoized; await it
- * during startup before calling `startDevice`.
+ * during startup before calling `startRuntime`.
  */
 export function init(input?: InitInput): Promise<void> {
   if (_initPromise) return _initPromise;
@@ -166,10 +166,10 @@ export function init(input?: InitInput): Promise<void> {
 }
 
 /**
- * The running Vizij-on-Arora device. All methods talk to the device's shared
- * store; the graph installed at `startDevice` reads and writes the same keys.
+ * The running Vizij runtime. All methods talk to the runtime's shared
+ * store; the graph installed at `startRuntime` reads and writes the same keys.
  */
-export class AroraDevice {
+export class Runtime {
   private inner: WasmVizijArora;
   private selfPaced = false;
 
@@ -178,9 +178,9 @@ export class AroraDevice {
   }
 
   /**
-   * Advance the device one tick. `dtMs` is the wall time since the previous
+   * Advance the runtime one tick. `dtMs` is the wall time since the previous
    * step in milliseconds (the difference of two `requestAnimationFrame`
-   * timestamps). Unavailable once `run()` has taken the device — it paces
+   * timestamps). Unavailable once `run()` has taken the runtime — it paces
    * itself from then on.
    */
   step(dtMs: number): void {
@@ -188,10 +188,10 @@ export class AroraDevice {
   }
 
   /**
-   * Hand the device to its own loop, for good: a self-paced run at
+   * Hand the runtime to its own loop, for good: a self-paced run at
    * `periodMs` (default: the runtime's ~100 Hz). While it runs, `step()` is
    * unavailable and the rest of this surface keeps working; it never touches
-   * the stepping device. A failing behavior tick does **not** end the loop —
+   * the stepping runtime. A failing behavior tick does **not** end the loop —
    * it stands as `behaviorError` until a tick recovers; the returned promise
    * rejects only if the runtime itself fails.
    */
@@ -200,7 +200,7 @@ export class AroraDevice {
     return this.inner.run(periodMs);
   }
 
-  /** Whether `run()` has taken the device (so `step()` is unavailable). */
+  /** Whether `run()` has taken the runtime (so `step()` is unavailable). */
   get running(): boolean {
     return this.selfPaced;
   }
@@ -208,7 +208,7 @@ export class AroraDevice {
   /**
    * The behavior's standing error — the message of its latest failed tick,
    * `undefined` while the behavior is healthy or none is installed. A
-   * failing tick does not stop the device or its `run()` loop; the reading
+   * failing tick does not stop the runtime or its `run()` loop; the reading
    * stays available throughout.
    */
   get behaviorError(): string | undefined {
@@ -220,29 +220,29 @@ export class AroraDevice {
    * reading: a message when a distinct failure appears, `undefined` when a
    * tick recovers. Sequential awaits share one cursor, so no change is
    * missed between them; one await may be pending at a time. Rejects when
-   * the device is gone.
+   * the runtime is gone.
    */
   behaviorErrorChanged(): Promise<string | undefined> {
     return this.inner.behaviorErrorChanged();
   }
 
   /**
-   * Call a loaded module's function through the device. The call is enqueued
-   * before this returns and dispatches inside the device's **next** step —
+   * Call a loaded module's function through the runtime. The call is enqueued
+   * before this returns and dispatches inside the runtime's **next** step —
    * the same phase a remote bridge command executes in — so the returned
    * promise resolves only after that step runs. Under `run()` just `await`
    * it; a direct driver calls `step` after issuing it.
    */
-  call(call: DeviceCall): Promise<DeviceCallResult> {
+  call(call: RuntimeCall): Promise<RuntimeCallResult> {
     const json = typeof call === "string" ? call : JSON.stringify(call);
-    return this.inner.call(json).then((result) => JSON.parse(result) as DeviceCallResult);
+    return this.inner.call(json).then((result) => JSON.parse(result) as RuntimeCallResult);
   }
 
   /**
-   * Replace the device's running graph **in place**: the spec reaches the
+   * Replace the runtime's running graph **in place**: the spec reaches the
    * interpreter as the engine's LOAD call, so the store, the loaded modules,
-   * and the device itself all survive the swap. Resolves once the new graph
-   * is installed; on a device not under `run()` a zero-dt step is taken so
+   * and the runtime itself all survive the swap. Resolves once the new graph
+   * is installed; on a runtime not under `run()` a zero-dt step is taken so
    * the swap lands without an external driver.
    */
   loadGraph(graph: GraphSpecInput): Promise<void> {
@@ -287,35 +287,35 @@ export class AroraDevice {
     return this.inner.drainChanges();
   }
 
-  /** Release the wasm-side device. The instance is unusable afterwards. */
+  /** Release the wasm-side runtime. The instance is unusable afterwards. */
   dispose(): void {
     this.inner.free();
   }
 }
 
 /**
- * Boot the device in the browser, with `graph` (a Vizij graph spec, in any
+ * Boot the runtime in the browser, with `graph` (a Vizij graph spec, in any
  * form the spec normalizer accepts) installed as its behavior. The graph's
  * `input` nodes' paths become the store keys it reads each tick. Omit `graph`
  * to get the built-in passthrough proof graph (`sensor/x` → `actuator/y`).
  *
- * `modules` optionally loads Arora wasm modules into the device's engine;
- * their functions are then reachable with `AroraDevice.call` and from the
+ * `modules` optionally loads Arora wasm modules into the runtime's engine;
+ * their functions are then reachable with `Runtime.call` and from the
  * graph's `ExternalFunction` nodes.
  *
  * Calls `init()` if it has not run yet.
  */
-export async function startDevice(
+export async function startRuntime(
   graph?: GraphSpecInput,
   input?: InitInput,
-  modules?: DeviceModule[],
-): Promise<AroraDevice> {
+  modules?: RuntimeModule[],
+): Promise<Runtime> {
   await init(input);
   const bindings = bindingCache.current!;
   const graphJson =
     graph === undefined ? undefined : typeof graph === "string" ? graph : JSON.stringify(graph);
   const inner = await bindings.VizijArora.start(graphJson, modules);
-  return new AroraDevice(inner);
+  return new Runtime(inner);
 }
 
 export { toValueJSON } from "@vizij/value-json";

--- a/npm/@vizij/runtime/tests/animation-module.mjs
+++ b/npm/@vizij/runtime/tests/animation-module.mjs
@@ -1,13 +1,13 @@
-// The animation module runs inside the browser device (VIZ-61 Stage A):
-// the device is constructed WITH the module, JS sets up a one-track ramp
+// The animation module runs inside the browser runtime (VIZ-61 Stage A):
+// the runtime is constructed WITH the module, JS sets up a one-track ramp
 // through the call surface (load_animation / create_player / add_instance),
 // and a graph ExternalFunction node calls the module's step each tick,
-// landing the sampled outputs in the device store. Mirrors the Rust
+// landing the sampled outputs in the runtime store. Mirrors the Rust
 // host-side boundary proof (crates/interop/vizij-animation-module/tests/
 // host_ramp.rs) through the public JS surface.
 import assert from "node:assert/strict";
 import { loadAnimationModule } from "@vizij/animation-module";
-import { startDevice } from "../dist/runtime/src/index.js";
+import { startRuntime } from "../dist/runtime/src/index.js";
 
 // --- declared ids (module.yaml + the type records) ---------------------------
 const FN_LOAD = "76697a69-6a00-0000-0f00-000000000001";
@@ -110,29 +110,29 @@ const graph = {
 };
 
 // --- run ---------------------------------------------------------------------
-const device = await startDevice(graph, undefined, [await loadAnimationModule()]);
+const runtime = await startRuntime(graph, undefined, [await loadAnimationModule()]);
 
 // Setup through the call surface. Each call dispatches inside the next step.
 const pending = [
-  device.call({ id: FN_LOAD, args: [field(P_CLIP, clip)] }),
-  device.call({ id: FN_CREATE_PLAYER, args: [field(P_NAME, { str: "p" })] }),
+  runtime.call({ id: FN_LOAD, args: [field(P_CLIP, clip)] }),
+  runtime.call({ id: FN_CREATE_PLAYER, args: [field(P_NAME, { str: "p" })] }),
 ];
-device.step(0);
+runtime.step(0);
 const [anim, player] = await Promise.all(pending);
 assert.ok("u32" in anim.ret, "load_animation returns an animation id");
 assert.ok("u32" in player.ret, "create_player returns a player id");
 
-const pInstance = device.call({
+const pInstance = runtime.call({
   id: FN_ADD_INSTANCE,
   args: [field(P_PLAYER, player.ret), field(P_ANIM, anim.ret)],
 });
-device.step(0);
+runtime.step(0);
 assert.ok("u32" in (await pInstance).ret, "add_instance returns an instance id");
 
 // Two 0.25 s steps: each tick the graph feeds the golden dt into the module's
 // step and lands the sampled [TrackOutput] in the store.
 const firstTrack = () => {
-  const out = device.readValues(["anim/out"])["anim/out"];
+  const out = runtime.readValues(["anim/out"])["anim/out"];
   assert.ok(out && out.structs, "anim/out carries the step's [TrackOutput]");
   const track = Object.fromEntries(out.structs.elements[0].fields.map((f) => [f.id, f.value]));
   return {
@@ -142,12 +142,12 @@ const firstTrack = () => {
   };
 };
 
-device.step(250);
+runtime.step(250);
 const first = firstTrack();
 assert.equal(first.trackId, "t0");
 assert.equal(first.key, "node/x", "the track carries its authored key");
 
-device.step(250);
+runtime.step(250);
 const second = firstTrack();
 assert.ok(
   first.value > 0 && second.value > first.value,
@@ -158,5 +158,5 @@ assert.ok(
   `expected ~0.5 at the 0.5 s midpoint, got ${second.value}`,
 );
 
-device.dispose();
+runtime.dispose();
 console.log("@vizij/runtime animation-module: ok");

--- a/npm/@vizij/runtime/tests/smoke.mjs
+++ b/npm/@vizij/runtime/tests/smoke.mjs
@@ -1,61 +1,61 @@
-// Values flow JS → device store → arora tick → store → JS, through the
+// Values flow JS → runtime store → arora tick → store → JS, through the
 // published wrapper surface (dist/), exactly as a browser consumer uses it.
 import assert from "node:assert/strict";
-import { startDevice } from "../dist/runtime/src/index.js";
+import { startRuntime } from "../dist/runtime/src/index.js";
 
-const device = await startDevice(); // built-in passthrough graph: sensor/x -> actuator/y
+const runtime = await startRuntime(); // built-in passthrough graph: sensor/x -> actuator/y
 
 // The first drain is the store's whole current state (empty at boot).
-assert.deepEqual(device.drainChanges(), {}, "opening state of an empty store");
+assert.deepEqual(runtime.drainChanges(), {}, "opening state of an empty store");
 
-device.setValue("sensor/x", { f32: 0.5 });
-device.step(16);
-assert.deepEqual(device.readValues(["actuator/y"]), { "actuator/y": { f32: 0.5 } });
+runtime.setValue("sensor/x", { f32: 0.5 });
+runtime.step(16);
+assert.deepEqual(runtime.readValues(["actuator/y"]), { "actuator/y": { f32: 0.5 } });
 
-device.writeValues({ "sensor/x": { f32: 0.25 } });
-device.step(16);
-assert.deepEqual(device.readValues(["actuator/y"]), { "actuator/y": { f32: 0.25 } });
+runtime.writeValues({ "sensor/x": { f32: 0.25 } });
+runtime.step(16);
+assert.deepEqual(runtime.readValues(["actuator/y"]), { "actuator/y": { f32: 0.25 } });
 
-const changes = device.drainChanges();
+const changes = runtime.drainChanges();
 assert.deepEqual(changes["actuator/y"], { f32: 0.25 }, "change feed saw the graph write");
 
-const snapshot = device.snapshot();
+const snapshot = runtime.snapshot();
 assert.deepEqual(snapshot["sensor/x"], { f32: 0.25 });
 
-// In-place graph swap (VIZ-57): the device and its store survive.
-await device.loadGraph({
+// In-place graph swap (VIZ-57): the runtime and its store survive.
+await runtime.loadGraph({
   nodes: [
     { id: "in", type: "input", params: { path: "sensor/b", value: { float: 0 } } },
     { id: "out", type: "output", params: { path: "actuator/b" } },
   ],
   edges: [{ from: { node_id: "in" }, to: { node_id: "out", input: "in" } }],
 });
-device.setValue("sensor/b", { f32: 0.75 });
-device.step(16);
-assert.deepEqual(device.readValues(["actuator/b"]), { "actuator/b": { f32: 0.75 } });
+runtime.setValue("sensor/b", { f32: 0.75 });
+runtime.step(16);
+assert.deepEqual(runtime.readValues(["actuator/b"]), { "actuator/b": { f32: 0.75 } });
 assert.deepEqual(
-  device.readValues(["sensor/x"]),
+  runtime.readValues(["sensor/x"]),
   { "sensor/x": { f32: 0.25 } },
   "the store carried across the swap",
 );
 
-// run(): the device paces itself; the store surface stays live.
-assert.equal(device.running, false);
+// run(): the runtime paces itself; the store surface stays live.
+assert.equal(runtime.running, false);
 const rejected = new Promise((resolve) => {
-  device.run(5).catch(resolve);
+  runtime.run(5).catch(resolve);
 });
-assert.equal(device.running, true);
+assert.equal(runtime.running, true);
 let stepError = null;
 try {
-  device.step(16);
+  runtime.step(16);
 } catch (err) {
   stepError = err;
 }
 assert.match(String(stepError), /run\(\) drives the device/, "step is gone under run()");
-device.setValue("sensor/b", { f32: 0.5 });
+runtime.setValue("sensor/b", { f32: 0.5 });
 await new Promise((resolve) => setTimeout(resolve, 50));
 assert.deepEqual(
-  device.readValues(["actuator/b"]),
+  runtime.readValues(["actuator/b"]),
   { "actuator/b": { f32: 0.5 } },
   "the self-paced loop ticked the graph",
 );
@@ -63,10 +63,10 @@ void rejected; // rejects only if the runtime itself fails, which this test neve
 
 // Behavior errors stand, they don't stop the loop (arora 9.1): swap in a
 // graph whose input has no default and no staged value — ticks fail, the
-// error is observable, and the device keeps running.
-assert.equal(device.behaviorError, undefined, "healthy behavior reads undefined");
-const failed = device.behaviorErrorChanged();
-await device.loadGraph({
+// error is observable, and the runtime keeps running.
+assert.equal(runtime.behaviorError, undefined, "healthy behavior reads undefined");
+const failed = runtime.behaviorErrorChanged();
+await runtime.loadGraph({
   nodes: [
     { id: "in", type: "input", params: { path: "sensor/missing" } },
     { id: "out", type: "output", params: { path: "actuator/c" } },
@@ -78,16 +78,16 @@ assert.match(
   /missing staged value/,
   "the failing tick's message stands as the behavior error",
 );
-const recovered = device.behaviorErrorChanged();
-device.setValue("sensor/missing", { f32: 0.125 });
+const recovered = runtime.behaviorErrorChanged();
+runtime.setValue("sensor/missing", { f32: 0.125 });
 assert.equal(await recovered, undefined, "a recovering tick clears the error");
 await new Promise((resolve) => setTimeout(resolve, 30));
 assert.deepEqual(
-  device.readValues(["actuator/c"]),
+  runtime.readValues(["actuator/c"]),
   { "actuator/c": { f32: 0.125 } },
   "the run loop kept ticking through the failure",
 );
 
-device.dispose();
+runtime.dispose();
 console.log("@vizij/runtime smoke: ok");
 process.exit(0); // the run() loop never returns; don't wait on its timers


### PR DESCRIPTION
The client-facing surface of `@vizij/runtime` drops the "device"/"Arora" leak for **runtime** vocabulary (the naming principle behind the `arora-web-wasm → runtime` rename). TS-only — no Rust change, no package rename.

## Renames (in `npm/@vizij/runtime/src/index.ts` + README)
| before | after |
|---|---|
| `startDevice(...)` | `startRuntime(...)` |
| `AroraDevice` (class) | `Runtime` |
| `DeviceModule` | `RuntimeModule` |
| `DeviceCall` | `RuntimeCall` |
| `DeviceCallResult` | `RuntimeCallResult` |

Behavior is unchanged. The **internal** wasm-bindgen names (`VizijArora`, `WasmVizijArora`) and the Rust `vizij-arora-web` crate keep their names — only the client surface changes. JSDoc/README reworded to "runtime" (keeping honest "arora device" where it describes the underlying engine).

## Version
Breaking rename → `@vizij/runtime` **1.1.0 → 2.0.0** (+ `### Breaking` changelog).

## Verified
`pnpm --filter @vizij/runtime build` (tsc + copy-wasm) clean; pre-commit fmt/clippy green.

**Merge/publish order:** merge this, publish `@vizij/runtime@2.0.0` (normal `ci:publish`, same package name), then merge the paired vizij-web consumer PR (its CI can install `@vizij/runtime@2.0.0` once published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)