### PR TITLE
chore(animation,node-graph): document the npm rename (0.4.1 / 0.7.1)

### DIFF
--- a/npm/@vizij/animation/CHANGELOG.md
+++ b/npm/@vizij/animation/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @vizij/animation
 
+## 0.4.1
+
+### Patch Changes
+
+- Renamed to `@vizij/animation` from `@vizij/animation-wasm`: a bare-domain npm
+  name — the `-wasm` suffix described the Rust crate, not the npm package. Same
+  package and API; update your dependency. The old name is deprecated and points
+  here.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/npm/@vizij/animation/package.json
+++ b/npm/@vizij/animation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizij/animation",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "WASM bindings for Vizij animation core.",
   "license": "MIT",
   "repository": {

--- a/npm/@vizij/node-graph/CHANGELOG.md
+++ b/npm/@vizij/node-graph/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @vizij/node-graph
 
+## 0.7.1
+
+### Patch Changes
+
+- Renamed to `@vizij/node-graph` from `@vizij/node-graph-wasm`: a bare-domain
+  npm name — the `-wasm` suffix described the Rust crate, not the npm package.
+  Same package and API; update your dependency. The old name is deprecated and
+  points here.
+
 ## 0.7.0
 
 ### Minor Changes

--- a/npm/@vizij/node-graph/package.json
+++ b/npm/@vizij/node-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizij/node-graph",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "WASM bindings for Vizij node-graph core.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
The `@vizij/animation-wasm → @vizij/animation` (#64) and
`@vizij/node-graph-wasm → @vizij/node-graph` (#65) renames shipped at 0.4.0 /
0.7.0 but never recorded the rename in the packages' changelogs — so npm
consumers landing on the new package see no lineage note.

This adds a patch release for each whose sole change is that note:

- `@vizij/animation` 0.4.0 → **0.4.1**
- `@vizij/node-graph` 0.7.0 → **0.7.1**

Leaf packages (no workspace dependents), so the lockfile is untouched.

**Publish:** after merge, trigger `publish-npm` (workflow_dispatch, `package: animation` then `package: node-graph`, or a `npm-pub-*` tag). With trusted publishing now enabled for both names, these republish **with provenance** — no local `--no-provenance` workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)