### PR TITLE
refactor(interop): adopt arora-behavior 6's golden→built_in rename (ARORA-59)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,9 +144,9 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "arora"
-version = "9.1.0"
+version = "9.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e4c79483b039c338ca97bd6be293855c5f1f498777c33cf78a15d9292abb2e"
+checksum = "e0f3c470df674d53e640a2d2a0f7df0b92795b630fbc0363e8a04b7582b7ce4c"
 dependencies = [
  "anyhow",
  "arora-behavior",
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "arora-behavior"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb04bb2692f56bdf70c7382cbec4206af8cd68cde47e8e41da04d0356045e95"
+checksum = "d2f5fd16c9440dc39b8a5f8011b716ad2e2c9ae9862795f225fb68bc5a02d3f0"
 dependencies = [
  "arora-types",
  "serde",
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "arora-behavior-tree"
-version = "6.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4848d0c9c96d0c7f453f1b0721a6afb237720bbb48513484e58405b9c05314"
+checksum = "0722c804aa532fff5fa8d159ddb4d2eec77a2e59cebf90196901a9047298e6f3"
 dependencies = [
  "anyhow",
  "arora-behavior",
@@ -1158,7 +1158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1742,7 +1742,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2263,7 +2263,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2532,7 +2532,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3676,7 +3676,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3714,7 +3714,7 @@ dependencies = [
  "windows-interface",
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3741,12 +3741,6 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
@@ -3757,7 +3751,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3767,7 +3761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3776,16 +3770,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3794,7 +3779,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3803,31 +3788,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
-dependencies = [
- "windows-link 0.1.3",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3837,22 +3805,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3861,22 +3817,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3885,22 +3829,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3909,22 +3841,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/crates/interop/vizij-animation-module/readme.md
+++ b/crates/interop/vizij-animation-module/readme.md
@@ -37,7 +37,7 @@ per-composite type is declared here; the runtime `Value` carries the identity.
 - `load_animation(clip: AnimationClip) -> u32` — load a clip, return its `AnimId`.
 - `create_player(name: str) -> u32` — return a `PlayerId`.
 - `add_instance(player: u32, anim: u32) -> u32` — return an `InstId`.
-- `step(dt_ns: u64) -> [TrackOutput]` — advance by the `arora/dt` golden-key
+- `step(dt_ns: u64) -> [TrackOutput]` — advance by the `arora/dt` built-in key
   nanoseconds and return **per-track outputs keyed by track identity**, each
   carrying the track's **default authored key** (`animatable_id`) plus its
   sampled value. The consumer decides the final store key: default = the

--- a/crates/interop/vizij-animation-module/src/lib.rs
+++ b/crates/interop/vizij-animation-module/src/lib.rs
@@ -340,7 +340,7 @@ fn bake_with_derivatives(
 
 /// Advance the engine by `dt_ns` nanoseconds and return per-track outputs.
 ///
-/// `dt_ns` is the runtime's `arora/dt` golden key. The transport commands
+/// `dt_ns` is the runtime's `arora/dt` built-in key. The transport commands
 /// buffered since the previous step apply first, in issue order. Each output
 /// carries the track's authored key as `default_key` and its stable id as
 /// `track_id`; the value uses the vizij-arora `Value` encoding.

--- a/crates/interop/vizij-arora-behavior/Cargo.toml
+++ b/crates/interop/vizij-arora-behavior/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 description = "Vizij node graph / orchestrator driven as Arora behavior interpreters (ProcessingGraph, OrchestratorBehavior)."
 
 [dependencies]
-arora-behavior = "5"
+arora-behavior = "6"
 arora-types = "2"
 serde_json = { workspace = true }
 uuid = "1"

--- a/crates/interop/vizij-arora-behavior/docs/node-graph.md
+++ b/crates/interop/vizij-arora-behavior/docs/node-graph.md
@@ -1,6 +1,6 @@
 # Vizij's node graph as an Arora behavior interpreter
 
-Vizij's node graph is a **behavior interpreter** in the Arora sense. Read Arora's **[how a behavior interpreter works](https://github.com/semio-ai/arora-sdk/blob/main/crates/arora-behavior/docs/interpreter-workflow.md)** first — it defines the `BehaviorInterpreter` contract (the `tick` / `apply` / `load` lifecycle, the `BehaviorContext` store, timing as golden store keys) that this page assumes. Here we cover what is *specific* to the node graph, and draw the parallel with the other reference interpreter, [`arora-behavior-tree`](https://github.com/semio-ai/arora-sdk/blob/main/crates/arora-behavior-tree/docs/nodes.md).
+Vizij's node graph is a **behavior interpreter** in the Arora sense. Read Arora's **[how a behavior interpreter works](https://github.com/semio-ai/arora-sdk/blob/main/crates/arora-behavior/docs/interpreter-workflow.md)** first — it defines the `BehaviorInterpreter` contract (the `tick` / `apply` / `load` lifecycle, the `BehaviorContext` store, timing as built-in store keys) that this page assumes. Here we cover what is *specific* to the node graph, and draw the parallel with the other reference interpreter, [`arora-behavior-tree`](https://github.com/semio-ai/arora-sdk/blob/main/crates/arora-behavior-tree/docs/nodes.md).
 
 The interpreter type is [`ProcessingGraph`](../src/lib.rs#L79), which implements `arora_behavior::BehaviorInterpreter` ([`lib.rs:180`](../src/lib.rs#L180)). The evaluation engine underneath it is the separate, host-agnostic [`vizij-graph-core`](../../../node-graph/vizij-graph-core/) crate. Vizij and Arora share **one runtime value type** (`vizij_api_core::Value` *is* `arora_types::value::Value`), so values cross the store and call boundaries with no conversion ([`vizij-arora/src/lib.rs:1-13`](../../vizij-arora/src/lib.rs#L1-L13)).
 
@@ -11,7 +11,7 @@ The interpreter's spine is `tick_store` ([`lib.rs:135-177`](../src/lib.rs#L135-L
 | Interpreter lifecycle | Vizij node graph |
 |---|---|
 | load | `load` decodes the spec and installs it with a fresh `GraphRuntime`; a recompose never rebuilds the device ([`lib.rs:198-205`](../src/lib.rs#L198-L205)) |
-| time update | `dt` is read from the golden `arora/dt` store key and advances the graph clock (`rt.t += dt`) ([`golden_dt_seconds`, `lib.rs:211-221`](../src/lib.rs#L211-L221)) |
+| time update | `dt` is read from the built-in `arora/dt` store key and advances the graph clock (`rt.t += dt`) ([`built_in_dt_seconds`, `lib.rs:211-221`](../src/lib.rs#L211-L221)) |
 | tick | stage subscribed inputs → `evaluate_all` → flush outputs; **always returns `BehaviorStatus::Running`** ([`lib.rs:181-186`](../src/lib.rs#L181-L186)) |
 | graph update | **not** incremental — `apply(GraphDiff)` is rejected; every edit is a whole-spec `load` (see [Editing](#editing-whole-spec-load-only)) |
 

--- a/crates/interop/vizij-arora-behavior/src/lib.rs
+++ b/crates/interop/vizij-arora-behavior/src/lib.rs
@@ -7,7 +7,7 @@
 //! `arora_types::value::Value`), so values cross the store boundary directly.
 //! The tick always reports [`BehaviorStatus::Running`] — a node graph runs
 //! every frame, unlike a tree that runs to a terminal status. `dt` comes from
-//! the runtime's golden store key ([`arora_behavior::golden::DT`], nanoseconds
+//! the runtime's built-in store key ([`arora_behavior::built_in::DT`], nanoseconds
 //! since the previous step), published before each tick.
 //!
 //! Inject one into an Arora device with
@@ -27,7 +27,7 @@ pub mod spec_graph;
 use std::collections::HashMap;
 
 use arora_behavior::{
-    golden, BehaviorContext, BehaviorError, BehaviorInterpreter, BehaviorStatus, Graph,
+    built_in, BehaviorContext, BehaviorError, BehaviorInterpreter, BehaviorStatus, Graph,
 };
 use arora_types::call::{Call, CallBridge};
 use arora_types::data::{DataStore, Key, StateChange};
@@ -179,7 +179,7 @@ impl ProcessingGraph {
 
 impl BehaviorInterpreter for ProcessingGraph {
     fn tick(&mut self, ctx: &mut BehaviorContext) -> Result<BehaviorStatus, BehaviorError> {
-        let dt = golden_dt_seconds(ctx.store);
+        let dt = built_in_dt_seconds(ctx.store);
         self.tick_store(ctx.store, &mut *ctx.call_bridge, dt)?;
         // A node graph is continuous: tick it again next step.
         Ok(BehaviorStatus::Running)
@@ -206,11 +206,11 @@ impl BehaviorInterpreter for ProcessingGraph {
 }
 
 /// The current step's `dt` in seconds, read from the runtime-maintained
-/// golden key ([`golden::DT`], integer nanoseconds). `0.0` when the key is
+/// built-in key ([`built_in::DT`], integer nanoseconds). `0.0` when the key is
 /// absent or not the `U64` the runtime publishes.
-pub(crate) fn golden_dt_seconds(store: &dyn DataStore) -> f32 {
+pub(crate) fn built_in_dt_seconds(store: &dyn DataStore) -> f32 {
     match store
-        .read(&[Key::from(golden::DT)])
+        .read(&[Key::from(built_in::DT)])
         .into_iter()
         .next()
         .flatten()
@@ -348,13 +348,13 @@ mod tests {
     }
 
     #[test]
-    fn golden_dt_reads_the_runtime_clock() {
+    fn built_in_dt_reads_the_runtime_clock() {
         let store = SimpleDataStore::new();
-        assert_eq!(golden_dt_seconds(&store), 0.0);
+        assert_eq!(built_in_dt_seconds(&store), 0.0);
         store
-            .write(StateChange::set(golden::DT, Value::U64(16_000_000)))
+            .write(StateChange::set(built_in::DT, Value::U64(16_000_000)))
             .unwrap();
-        assert!((golden_dt_seconds(&store) - 0.016).abs() < 1e-6);
+        assert!((built_in_dt_seconds(&store) - 0.016).abs() < 1e-6);
     }
 
     /// A path-less `output` applies a keyed record batch — the shape a module

--- a/crates/interop/vizij-arora-behavior/src/orchestrator.rs
+++ b/crates/interop/vizij-arora-behavior/src/orchestrator.rs
@@ -17,7 +17,7 @@ use arora_types::data::{DataStore, Key, StateChange};
 use vizij_api_core::TypedPath;
 use vizij_orchestrator::Orchestrator;
 
-use crate::golden_dt_seconds;
+use crate::built_in_dt_seconds;
 
 /// A Vizij orchestrator as an Arora behavior interpreter.
 pub struct OrchestratorBehavior {
@@ -86,7 +86,7 @@ impl OrchestratorBehavior {
 
 impl BehaviorInterpreter for OrchestratorBehavior {
     fn tick(&mut self, ctx: &mut BehaviorContext) -> Result<BehaviorStatus, BehaviorError> {
-        let dt = golden_dt_seconds(ctx.store);
+        let dt = built_in_dt_seconds(ctx.store);
         self.tick_store(ctx.store, dt)?;
         // An orchestrator runs every frame.
         Ok(BehaviorStatus::Running)

--- a/npm/@vizij/runtime/tests/animation-module.mjs
+++ b/npm/@vizij/runtime/tests/animation-module.mjs
@@ -89,7 +89,7 @@ const clip = {
 };
 
 // --- the behavior: a graph whose ExternalFunction node steps the module ------
-// Each tick: read the runtime's golden dt (arora/dt, nanoseconds) from the
+// Each tick: read the runtime's built-in dt (arora/dt, nanoseconds) from the
 // store, call the module's step(dt) through the engine, and write the returned
 // [TrackOutput] to anim/out — the Stage-B shape (the graph drives the
 // animation module; no JS clip pipeline).
@@ -129,7 +129,7 @@ const pInstance = runtime.call({
 runtime.step(0);
 assert.ok("u32" in (await pInstance).ret, "add_instance returns an instance id");
 
-// Two 0.25 s steps: each tick the graph feeds the golden dt into the module's
+// Two 0.25 s steps: each tick the graph feeds the built-in dt into the module's
 // step and lands the sampled [TrackOutput] in the store.
 const firstTrack = () => {
   const out = runtime.readValues(["anim/out"])["anim/out"];


### PR DESCRIPTION
Downstream of [arora-sdk #175](https://github.com/semio-ai/arora-sdk/pull/175) (ARORA-59: arora renamed its "golden" keys concept → "built-in").

- **`vizij-arora-behavior`:** bump `arora-behavior` dep `"5"`→`"6"` and adopt the rename — `golden::DT`→`built_in::DT`, `golden_dt_seconds`→`built_in_dt_seconds` (a `pub(crate)` helper — no public API change), in both `lib.rs` and `orchestrator.rs`, plus doc/prose.
- `vizij-animation-module`: doc/prose for the runtime's built-in `arora/*` keys.
- `Cargo.lock` unified on `arora 9.2.0` / `arora-behavior-tree 6.1.0` / `arora-behavior 6.0.0` (single version — the old tree 6.0.0 was still dragging in arora-behavior 5).

**No npm republish needed:** internal Rust rename, identical wasm behavior (the `arora/time`/`arora/dt` wire keys are unchanged).

**Left untouched:** the perf-baseline `goldens.json` / `evaluateAgainstGolden` snapshot-testing script — unrelated "golden".

Verified: `cargo check --workspace` clean, `cargo test -p vizij-arora-behavior` green (incl. the renamed `built_in_dt_reads_the_runtime_clock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)