### PR TITLE
feat(vizij): TUI controls (load GLB, background) + window fit policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "arora"
-version = "9.4.0"
+version = "9.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c6a2746d742f73e4411e8f29cf7773a1b501c9a46bbef6efab725b02b2ff96"
+checksum = "8fbeb2854d9319c4e3dfae57964b26a4d183ba9688ab46b72c1a43f8f76bb8ad"
 dependencies = [
  "anyhow",
  "arora-behavior",
@@ -7931,6 +7931,7 @@ dependencies = [
  "clap 4.5.53",
  "crossterm",
  "env_logger",
+ "futures",
  "image",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,3 @@ serde-wasm-bindgen = "0.6"
 opt-level = "s"
 lto = true
 codegen-units = 1
-

--- a/crates/vizij/Cargo.toml
+++ b/crates/vizij/Cargo.toml
@@ -23,10 +23,14 @@ bevy = "0.19"
 
 # The device: an arora over the Vizij interop seams, run through the standard
 # operator flow (terminal UI on an interactive terminal, the open local bridge
-# auto-attached). 9.4 is where the composed-device entry stops reading argv,
-# which the vizij CLI (`--glb`) needs.
-arora = "9.4"
+# auto-attached). 9.5 is where the terminal UI takes application commands and
+# a run takes a shutdown — the seams behind the g/b controls and the GLB
+# reload's device rebuild.
+arora = "9.5"
 tokio = { version = "1", features = ["rt-multi-thread"] }
+# The command pump's async plumbing: the TUI command stream and the per-run
+# stop signal.
+futures = "0.3"
 # Restores the terminal on the window-close exit path, where the device's
 # terminal UI (worker thread) never gets to unwind.
 crossterm = "0.28"

--- a/crates/vizij/src/device.rs
+++ b/crates/vizij/src/device.rs
@@ -1,14 +1,20 @@
 //! The arora device behind the view: `RigHal` + `BlackboardStore` + the
 //! face's composed graph as the behavior, run on a worker thread.
 
+use std::path::Path;
+use std::sync::mpsc::{Receiver, Sender};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
+use arora::tui::{commands_frontend, TuiCommand, TuiCommandEvent};
+use futures::StreamExt;
 use serde_json::{json, Value as Json};
 use vizij_arora_behavior::{parse_spec, ProcessingGraph};
 use vizij_arora_hal::RigHal;
 use vizij_arora_store::BlackboardStore;
+
+use crate::meta::FaceMeta;
 
 /// A running face device. Both handles share storage with the device's own
 /// (they are sibling clones), so the view reads the rig and the store live.
@@ -17,15 +23,35 @@ pub struct Device {
     /// Sibling store handle; unused until input staging/UI lands (VIZ-47 UI stage).
     #[allow(dead_code)]
     pub store: BlackboardStore,
+    /// The face the device booted on.
+    pub meta: FaceMeta,
+    /// Its GLB, canonicalized — what the view loads.
+    pub glb_path: String,
+    /// Runtime changes the operator makes through the terminal UI; the view
+    /// applies them.
+    pub events: Receiver<DeviceEvent>,
     _thread: thread::JoinHandle<()>,
+}
+
+/// A runtime change the operator made through the terminal UI.
+pub enum DeviceEvent {
+    /// A different face was loaded (`g`): the device restarted on its graphs;
+    /// the view swaps over to the new meta and rig feed.
+    FaceLoaded {
+        glb_path: String,
+        meta: Box<FaceMeta>,
+        rig: RigHal,
+    },
+    /// A new background color (`b`), as sRGB bytes.
+    Background([u8; 3]),
 }
 
 /// How the device fronts the operator.
 pub enum Mode {
     /// The standard arora operator flow (`AroraBuilder::run`): the terminal UI
-    /// on an interactive terminal (headless front end otherwise), the open
-    /// local bridge auto-attached (`ws://127.0.0.1:9000`), logging owned by
-    /// the front end's sink.
+    /// on an interactive terminal (headless front end otherwise) with the
+    /// vizij commands installed, the open local bridge auto-attached
+    /// (`ws://127.0.0.1:9000`), logging owned by the front end's sink.
     Operator,
     /// Build and step quietly: no bridge, no front end — the snapshot
     /// harness, where the process' own logger stays in charge and a
@@ -82,68 +108,229 @@ pub fn compose(graphs: &[(String, Json)]) -> Result<Json> {
     Ok(json!({ "nodes": nodes, "edges": edges }))
 }
 
-/// Builds the arora (RigHal + BlackboardStore + ProcessingGraph over the
-/// composed spec) and runs it on a worker thread.
+/// Load a face for the device: parse the GLB's metadata, compose the bundle
+/// graphs whose kind is in `wanted` into the device's one behavior graph, and
+/// validate it. Returns the canonicalized GLB path (what the view loads), the
+/// metadata, and the composed spec.
+pub fn load_face(glb: &Path, wanted: &[String]) -> Result<(String, FaceMeta, String)> {
+    let canonical = glb
+        .canonicalize()
+        .with_context(|| format!("cannot resolve {}", glb.display()))?;
+    let meta = FaceMeta::from_glb_file(&canonical)?;
+    let graphs: Vec<(String, Json)> = meta
+        .bundle_graphs
+        .iter()
+        .filter(|(kind, _)| wanted.iter().any(|w| w == kind))
+        .cloned()
+        .collect();
+    if graphs.is_empty() {
+        log::warn!(
+            "no bundle graphs matched {wanted:?} in {}; the face will hold its authored pose",
+            glb.display()
+        );
+    }
+    let spec = compose(&graphs)?.to_string();
+    parse_spec(&spec).map_err(|e| anyhow!("composed spec does not parse: {e}"))?;
+    Ok((canonical.to_string_lossy().into_owned(), meta, spec))
+}
+
+/// `RRGGBB` hex (leading `#` allowed) to sRGB bytes.
+pub fn parse_rgb(hex: &str) -> Result<[u8; 3]> {
+    let hex = hex.trim().trim_start_matches('#');
+    if hex.len() != 6 {
+        return Err(anyhow!("expected RRGGBB, got {hex:?}"));
+    }
+    Ok([
+        u8::from_str_radix(&hex[0..2], 16)?,
+        u8::from_str_radix(&hex[2..4], 16)?,
+        u8::from_str_radix(&hex[4..6], 16)?,
+    ])
+}
+
+/// Load the face at `glb` (its graph kinds filtered by `wanted`) and run its
+/// device on a worker thread.
 ///
 /// The `Arora` is constructed **inside** the worker thread — it is not `Send`
 /// (single-owner by design); only the spec JSON and the sibling rig/store
-/// handles cross the thread boundary. The spec is validated here first so
+/// handles cross the thread boundary. The face is loaded here first so
 /// composition errors surface to the caller, not in a log.
-pub fn start(composed_spec: &Json, mode: Mode) -> Result<Device> {
-    let spec_json = composed_spec.to_string();
-    parse_spec(&spec_json).map_err(|e| anyhow!("composed spec does not parse: {e}"))?;
-
+pub fn start(glb: &Path, wanted: Vec<String>, mode: Mode) -> Result<Device> {
+    let (glb_path, meta, spec) = load_face(glb, &wanted)?;
     let rig = RigHal::new();
     let store = BlackboardStore::new();
+    let (events_tx, events_rx) = std::sync::mpsc::channel();
 
     let thread = {
         let rig = rig.clone();
         let store = store.clone();
-        thread::Builder::new().name("arora".into()).spawn(move || {
-            let spec = match parse_spec(&spec_json) {
-                Ok(spec) => spec,
-                Err(e) => return log::error!("spec re-parse failed: {e}"),
-            };
-            let graph = match ProcessingGraph::from_spec(spec) {
-                Ok(graph) => graph,
-                Err(e) => return log::error!("graph encode failed: {e}"),
-            };
-            let builder = arora::Arora::builder()
-                .with_hal(Box::new(rig))
-                .with_data_store(Box::new(store))
-                .with_behavior_interpreter(Box::new(graph));
-
-            match mode {
-                Mode::Operator => {
-                    // `run` is async (bridge construction, the operator
-                    // flow); this thread hosts the runtime that drives it.
-                    let tokio_rt = match tokio::runtime::Builder::new_multi_thread()
-                        .enable_all()
-                        .build()
-                    {
-                        Ok(rt) => rt,
-                        Err(e) => return log::error!("tokio runtime: {e}"),
+        thread::Builder::new()
+            .name("arora".into())
+            .spawn(move || match mode {
+                Mode::Operator => supervise(spec, wanted, rig, store, events_tx),
+                Mode::Quiet => {
+                    let Some(builder) = builder_for(&spec, rig, store) else {
+                        return;
                     };
-                    if let Err(e) = tokio_rt.block_on(builder.run()) {
-                        log::error!("arora device stopped: {e:?}");
+                    match builder.build() {
+                        Ok(mut arora) => step_forever(&mut arora),
+                        Err(e) => log::error!("building the arora device: {e:?}"),
                     }
                 }
-                Mode::Quiet => {
-                    let mut arora = match builder.build() {
-                        Ok(arora) => arora,
-                        Err(e) => return log::error!("building the arora device: {e:?}"),
-                    };
-                    step_forever(&mut arora);
-                }
-            }
-        })?
+            })?
     };
 
     Ok(Device {
         rig,
         store,
+        meta,
+        glb_path,
+        events: events_rx,
         _thread: thread,
     })
+}
+
+/// The device builder over the Vizij seams; `None` (logged) when the spec
+/// does not encode.
+fn builder_for(spec: &str, rig: RigHal, store: BlackboardStore) -> Option<arora::AroraBuilder> {
+    let spec = match parse_spec(spec) {
+        Ok(spec) => spec,
+        Err(e) => {
+            log::error!("spec re-parse failed: {e}");
+            return None;
+        }
+    };
+    let graph = match ProcessingGraph::from_spec(spec) {
+        Ok(graph) => graph,
+        Err(e) => {
+            log::error!("graph encode failed: {e}");
+            return None;
+        }
+    };
+    Some(
+        arora::Arora::builder()
+            .with_hal(Box::new(rig))
+            .with_data_store(Box::new(store))
+            .with_behavior_interpreter(Box::new(graph)),
+    )
+}
+
+/// The operator flow, generation by generation: each `g` (load GLB) stops the
+/// running device and rebuilds it — graphs, rig, store — on the new face, and
+/// the view follows through [`DeviceEvent::FaceLoaded`]. Runs until a
+/// generation ends without a reload (a device error; the terminal UI's quit
+/// exits the process).
+fn supervise(
+    mut spec: String,
+    wanted: Vec<String>,
+    rig: RigHal,
+    store: BlackboardStore,
+    events: Sender<DeviceEvent>,
+) {
+    let tokio_rt = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => return log::error!("tokio runtime: {e}"),
+    };
+    // The first generation runs on the handles the view already holds; a
+    // reload's face swap is announced only after the new front end is up, so
+    // the view's swap (and everything it logs) lands in the live pane.
+    let mut fresh = Some((rig, store));
+    let mut pending_face: Option<(String, FaceMeta)> = None;
+    loop {
+        let (rig, store) = fresh
+            .take()
+            .unwrap_or_else(|| (RigHal::new(), BlackboardStore::new()));
+        let (frontend, commands) = commands_frontend(vec![
+            TuiCommand {
+                key: 'g',
+                label: "load GLB".into(),
+                prompt: Some("GLB path".into()),
+            },
+            TuiCommand {
+                key: 'b',
+                label: "background".into(),
+                prompt: Some("background RRGGBB".into()),
+            },
+        ]);
+        if let Some((glb_path, meta)) = pending_face.take() {
+            let _ = events.send(DeviceEvent::FaceLoaded {
+                glb_path,
+                meta: Box::new(meta),
+                rig: rig.clone(),
+            });
+        }
+        let Some(builder) = builder_for(&spec, rig, store) else {
+            return;
+        };
+        let (stop_tx, stop_rx) = futures::channel::oneshot::channel();
+        let (reload_tx, reload_rx) = std::sync::mpsc::channel();
+        tokio_rt.block_on(async {
+            tokio::spawn(pump(
+                commands,
+                wanted.clone(),
+                events.clone(),
+                reload_tx,
+                stop_tx,
+            ));
+            // A fired stop drops the run future — arora's stop story: the
+            // teardown is complete and synchronous (front end released, local
+            // bridge's port freed) before the next generation starts. The
+            // pump merely ending (headless: no commands will ever come) must
+            // not stop a healthy run.
+            let stop = async move {
+                if stop_rx.await.is_err() {
+                    futures::future::pending::<()>().await
+                }
+            };
+            tokio::select! {
+                result = builder.with_frontend(frontend).run() => {
+                    if let Err(e) = result {
+                        log::error!("arora device stopped: {e:?}");
+                    }
+                }
+                _ = stop => {}
+            }
+        });
+        let Ok((glb_path, meta, new_spec)) = reload_rx.try_recv() else {
+            break;
+        };
+        spec = new_spec;
+        pending_face = Some((glb_path, meta));
+    }
+}
+
+/// Serve the terminal UI's command events for one device generation: `b`
+/// forwards a parsed background to the view; `g` validates the new face first
+/// and only then asks the run to stop, handing the supervisor what it needs to
+/// rebuild — a bad path is an error in the log pane, not a dead device.
+async fn pump(
+    mut commands: futures::channel::mpsc::UnboundedReceiver<TuiCommandEvent>,
+    wanted: Vec<String>,
+    events: Sender<DeviceEvent>,
+    reload: Sender<(String, FaceMeta, String)>,
+    stop: futures::channel::oneshot::Sender<()>,
+) {
+    while let Some(event) = commands.next().await {
+        match (event.key, event.input) {
+            ('g', Some(path)) => match load_face(Path::new(&path), &wanted) {
+                Ok(loaded) => {
+                    let _ = reload.send(loaded);
+                    let _ = stop.send(());
+                    return;
+                }
+                Err(e) => log::error!("cannot load {path}: {e:#}"),
+            },
+            ('b', Some(hex)) => match parse_rgb(&hex) {
+                Ok(rgb) => {
+                    let _ = events.send(DeviceEvent::Background(rgb));
+                }
+                Err(e) => log::error!("background: {e}"),
+            },
+            _ => {}
+        }
+    }
 }
 
 /// The ~100 Hz step loop with measured dt — the quiet mode's drive; the

--- a/crates/vizij/src/main.rs
+++ b/crates/vizij/src/main.rs
@@ -6,7 +6,7 @@
 //! offscreen (no window) and writes a PNG instead — the comparison harness
 //! against the web renderer.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use bevy::prelude::*;
 use clap::Parser;
 
@@ -43,6 +43,11 @@ struct Cli {
     #[arg(long)]
     unlit: bool,
 
+    /// How the face fits the window: contain letterboxes (the web renderer's
+    /// behavior), cover fills the window and crops the excess axis.
+    #[arg(long, value_enum, default_value_t = view::Fit::Contain)]
+    fit: view::Fit,
+
     /// Compose only these bundle graph kinds (comma-separated), e.g. "rig" or
     /// "rig,pose-driver". Default: rig + pose-driver.
     #[arg(long, default_value = "rig,pose-driver,pose")]
@@ -58,74 +63,72 @@ fn main() -> Result<()> {
         env_logger::init();
     }
 
-    let face_meta = meta::FaceMeta::from_glb_file(&cli.glb)?;
-    println!(
-        "vizij: {} — {} elements, {} animatables, {} bundle graphs",
-        cli.glb.display(),
-        face_meta.elements.len(),
-        face_meta.animatables.len(),
-        face_meta.bundle_graphs.len(),
-    );
-
-    // Compose the selected bundle graphs into the device's one behavior graph.
-    let wanted: Vec<&str> = cli.graphs.split(',').map(str::trim).collect();
-    let graphs: Vec<(String, serde_json::Value)> = face_meta
-        .bundle_graphs
-        .iter()
-        .filter(|(kind, _)| wanted.contains(&kind.as_str()))
-        .cloned()
+    let wanted: Vec<String> = cli
+        .graphs
+        .split(',')
+        .map(|kind| kind.trim().to_string())
         .collect();
-    if graphs.is_empty() {
-        log::warn!(
-            "no bundle graphs matched {:?}; the face will hold its authored pose",
-            wanted
-        );
-    }
-    let composed = device::compose(&graphs)?;
     let mode = if cli.snapshot.is_some() {
         device::Mode::Quiet
     } else {
         device::Mode::Operator
     };
-    let dev = device::start(&composed, mode)?;
+    let dev = device::start(&cli.glb, wanted, mode)?;
+    println!(
+        "vizij: {} — {} elements, {} animatables, {} bundle graphs",
+        dev.glb_path,
+        dev.meta.elements.len(),
+        dev.meta.animatables.len(),
+        dev.meta.bundle_graphs.len(),
+    );
 
-    let glb_path = cli
-        .glb
-        .canonicalize()
-        .with_context(|| format!("cannot resolve {}", cli.glb.display()))?
-        .to_string_lossy()
-        .into_owned();
-
+    let [r, g, b] = device::parse_rgb(&cli.background)?;
     let options = view::ViewOptions {
-        background: parse_hex_color(&cli.background)?,
+        background: Color::srgb_u8(r, g, b),
+        fit: cli.fit,
         ambient: cli.ambient,
         unlit: cli.unlit,
     };
-    let face = view::Face {
-        meta: face_meta,
+    let device::Device {
+        rig,
+        meta,
         glb_path,
-    };
-    let device_res = view::DeviceRes {
-        rig: dev.rig.clone(),
-    };
+        events,
+        ..
+    } = dev;
+    let face = view::Face { meta, glb_path };
+    let device_res = view::DeviceRes { rig };
 
     match &cli.snapshot {
         Some(out) => run_snapshot(&cli, face, device_res, options, out),
-        None => run_window(face, device_res, options),
+        None => run_window(face, device_res, options, events),
     }
+}
+
+/// The window size the app opens at: the face's authored aspect at a 720px
+/// height, so it starts letterbox-free (resizes and full screen then follow
+/// the `--fit` policy).
+fn window_resolution(face: &view::Face) -> (u32, u32) {
+    let (_, _, bw, bh) = face.meta.root_bounds.unwrap_or((0.0, 0.0, 5.0, 4.0));
+    let height = 720.0_f32;
+    let width = (height * bw / bh).clamp(320.0, 1600.0);
+    (width.round() as u32, height as u32)
 }
 
 fn run_window(
     face: view::Face,
     device_res: view::DeviceRes,
     options: view::ViewOptions,
+    events: std::sync::mpsc::Receiver<device::DeviceEvent>,
 ) -> Result<()> {
+    let (width, height) = window_resolution(&face);
     App::new()
         .add_plugins(
             DefaultPlugins
                 .set(WindowPlugin {
                     primary_window: Some(Window {
                         title: "Vizij".to_string(),
+                        resolution: (width, height).into(),
                         ..default()
                     }),
                     ..default()
@@ -139,6 +142,7 @@ fn run_window(
         .insert_resource(face)
         .insert_resource(device_res)
         .insert_resource(options)
+        .insert_resource(view::DeviceEvents(std::sync::Mutex::new(events)))
         .add_plugins(view::ViewPlugin)
         .run();
     // The device's terminal UI runs on the worker thread; returning from here
@@ -187,15 +191,4 @@ fn parse_size(size: &str) -> Result<(u32, u32)> {
         .split_once('x')
         .ok_or_else(|| anyhow!("--size must be WIDTHxHEIGHT"))?;
     Ok((w.parse()?, h.parse()?))
-}
-
-fn parse_hex_color(hex: &str) -> Result<Color> {
-    let hex = hex.trim_start_matches('#');
-    if hex.len() != 6 {
-        return Err(anyhow!("--background must be RRGGBB"));
-    }
-    let r = u8::from_str_radix(&hex[0..2], 16)?;
-    let g = u8::from_str_radix(&hex[2..4], 16)?;
-    let b = u8::from_str_radix(&hex[4..6], 16)?;
-    Ok(Color::srgb_u8(r, g, b))
 }

--- a/crates/vizij/src/main.rs
+++ b/crates/vizij/src/main.rs
@@ -31,8 +31,9 @@ struct Cli {
     #[arg(long, default_value = "763x486")]
     size: String,
 
-    /// Background clear color, hex RRGGBB.
-    #[arg(long, default_value = "101114")]
+    /// Background clear color, hex RRGGBB. (The web comparison harness passes
+    /// 101114, the web page's own background.)
+    #[arg(long, default_value = "000000")]
     background: String,
 
     /// three.js-style ambient intensity (the web renderer uses π/2).

--- a/crates/vizij/src/view.rs
+++ b/crates/vizij/src/view.rs
@@ -6,6 +6,8 @@
 //! double-sided materials, opacity-driven alpha blending.
 
 use std::collections::HashMap;
+use std::sync::mpsc::Receiver;
+use std::sync::Mutex;
 
 use bevy::camera::{Projection, RenderTarget, ScalingMode};
 use bevy::core_pipeline::tonemapping::{DebandDither, Tonemapping};
@@ -15,6 +17,7 @@ use bevy::prelude::*;
 use vizij_api_core::value::{as_bool, as_color_rgba, as_float, as_vec3, as_vector};
 use vizij_api_core::Value;
 
+use crate::device::DeviceEvent;
 use crate::meta::{Binding, FaceMeta, FeatureKind};
 
 /// The face metadata, as a Bevy resource.
@@ -24,10 +27,26 @@ pub struct Face {
     pub glb_path: String,
 }
 
+/// The operator's runtime changes, drained each frame ([`DeviceEvent`]).
+/// Absent in snapshot mode.
+#[derive(Resource)]
+pub struct DeviceEvents(pub Mutex<Receiver<DeviceEvent>>);
+
 /// The device handles the view reads each frame.
 #[derive(Resource)]
 pub struct DeviceRes {
     pub rig: vizij_arora_hal::RigHal,
+}
+
+/// How the camera fits the face's authored rootBounds into the viewport.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, clap::ValueEnum)]
+pub enum Fit {
+    /// The whole bounds stay visible; the window's excess axis shows
+    /// background — the web renderer's behavior.
+    Contain,
+    /// The bounds fill the window; the excess axis is cropped — for a full
+    /// screen whose aspect ratio the face does not control.
+    Cover,
 }
 
 /// View options (CLI knobs while calibrating against the web renderer).
@@ -35,6 +54,8 @@ pub struct DeviceRes {
 pub struct ViewOptions {
     /// Background clear color.
     pub background: Color,
+    /// How the face fits the window.
+    pub fit: Fit,
     /// three.js-style ambient light intensity (the web uses π/2). Materials
     /// render unlit with their albedo scaled by `intensity/π` in linear space
     /// — exactly the web's ambient-Lambert pipeline (verified pixel-exact
@@ -90,7 +111,10 @@ impl Plugin for ViewPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<BindingIndex>()
             .add_systems(Startup, (setup_scene, setup_camera))
-            .add_systems(Update, (index_scene, apply_pose).chain());
+            .add_systems(
+                Update,
+                (apply_device_events, index_scene, apply_pose).chain(),
+            );
     }
 }
 
@@ -98,6 +122,88 @@ fn setup_scene(mut commands: Commands, face: Res<Face>, asset_server: Res<AssetS
     commands.spawn(WorldAssetRoot(
         asset_server.load(GltfAssetLabel::Scene(0).from_asset(face.glb_path.clone())),
     ));
+}
+
+/// Apply the operator's runtime changes: recolor the background, or swap the
+/// whole face — despawn the scene, load the new GLB, refit the camera, hand
+/// the pose feed over to the new device generation's rig, and let
+/// `index_scene` rebuild the joins once the new scene has spawned.
+#[allow(clippy::too_many_arguments)]
+fn apply_device_events(
+    events: Option<Res<DeviceEvents>>,
+    mut face: ResMut<Face>,
+    mut device: ResMut<DeviceRes>,
+    mut options: ResMut<ViewOptions>,
+    mut index: ResMut<BindingIndex>,
+    mut commands: Commands,
+    roots: Query<Entity, With<WorldAssetRoot>>,
+    mut cameras: Query<(&mut Camera, &mut Projection, &mut Transform), With<ViewCamera>>,
+    asset_server: Res<AssetServer>,
+) {
+    let Some(events) = events else { return };
+    let Ok(receiver) = events.0.lock() else {
+        return;
+    };
+    while let Ok(event) = receiver.try_recv() {
+        match event {
+            DeviceEvent::Background([r, g, b]) => {
+                options.background = Color::srgb_u8(r, g, b);
+                for (mut camera, _, _) in &mut cameras {
+                    camera.clear_color = ClearColorConfig::Custom(options.background);
+                }
+            }
+            DeviceEvent::FaceLoaded {
+                glb_path,
+                meta,
+                rig,
+            } => {
+                log::info!(
+                    "face swapped to {glb_path} ({} elements); reloading the scene",
+                    meta.elements.len()
+                );
+                for root in &roots {
+                    commands.entity(root).despawn();
+                }
+                commands.spawn(WorldAssetRoot(
+                    asset_server.load(GltfAssetLabel::Scene(0).from_asset(glb_path.clone())),
+                ));
+                let (scaling, transform) = camera_fit(&meta, options.fit);
+                for (_, mut projection, mut camera_transform) in &mut cameras {
+                    if let Projection::Orthographic(orthographic) = &mut *projection {
+                        orthographic.scaling_mode = scaling;
+                    }
+                    *camera_transform = transform;
+                }
+                *face = Face {
+                    meta: *meta,
+                    glb_path,
+                };
+                device.rig = rig;
+                *index = BindingIndex::default();
+            }
+        }
+    }
+}
+
+/// The camera placement for a face: orthographic fit to the authored
+/// rootBounds, centered on them. Contain keeps at least the bounds visible
+/// (the web computes zoom = min(w/bw, h/bh)); cover keeps at most.
+fn camera_fit(meta: &FaceMeta, fit: Fit) -> (ScalingMode, Transform) {
+    let (cx, cy, bw, bh) = meta.root_bounds.unwrap_or((0.0, 0.0, 5.0, 4.0));
+    let scaling = match fit {
+        Fit::Contain => ScalingMode::AutoMin {
+            min_width: bw,
+            min_height: bh,
+        },
+        Fit::Cover => ScalingMode::AutoMax {
+            max_width: bw,
+            max_height: bh,
+        },
+    };
+    (
+        scaling,
+        Transform::from_xyz(cx, cy, 100.0).looking_at(Vec3::new(cx, cy, 0.0), Vec3::Y),
+    )
 }
 
 fn setup_camera(
@@ -109,14 +215,9 @@ fn setup_camera(
     // Lighting is baked into the materials (see `ViewOptions::albedo_factor`);
     // no scene light is spawned.
 
-    // Orthographic fit to the authored rootBounds: keep at least the bounds
-    // visible (the web computes zoom = min(w/bw, h/bh)), centered on them.
-    let (cx, cy, bw, bh) = face.meta.root_bounds.unwrap_or((0.0, 0.0, 5.0, 4.0));
+    let (scaling, transform) = camera_fit(&face.meta, options.fit);
     let mut projection = OrthographicProjection::default_3d();
-    projection.scaling_mode = ScalingMode::AutoMin {
-        min_width: bw,
-        min_height: bh,
-    };
+    projection.scaling_mode = scaling;
 
     let mut camera = commands.spawn((
         Camera3d::default(),
@@ -125,7 +226,7 @@ fn setup_camera(
             ..default()
         },
         Projection::Orthographic(projection),
-        Transform::from_xyz(cx, cy, 100.0).looking_at(Vec3::new(cx, cy, 0.0), Vec3::Y),
+        transform,
         Tonemapping::None,
         DebandDither::Disabled,
         Msaa::Sample4,


### PR DESCRIPTION
Stacked on [#75](https://github.com/vizij-ai/vizij-rs/pull/75) (base: `feat/viz-47-vizij-app`), riding the released **arora 9.5.0** ([arora-sdk#183](https://github.com/semio-ai/arora-sdk/pull/183)). [VIZ-47](https://linear.app/semio-ai/issue/VIZ-47/vizij-crate-the-single-entry-point-cargo-run-shows-vizij-running-an).

## Operator controls in the terminal UI

The TUI now carries vizij's own commands (9.5's command seam), advertised in the footer:

- **`g` — load GLB**: prompts for a path and reloads the whole face. The supervisor validates the new face **before** stopping the running device (a bad path is an error in the log pane, not a dead device), then drops the run future — arora's stop story: teardown is complete and synchronous (front end released, `ws://127.0.0.1:9000` freed) — rebuilds graphs/rig/store on the new face, and the view swaps scene, camera fit, and pose feed.
- **`b` — background**: prompts for `RRGGBB` and recolors live.

`device::start` now owns face loading (`load_face`: canonicalize, parse meta, compose + validate); the face swap is announced only after the new generation's front end is up, so everything it logs lands in the live pane.

## Window fit

- The window opens at the **face's authored aspect** (720p height) — letterbox-free from the first frame.
- **`--fit contain|cover`**: contain letterboxes (the web renderer's behavior, default); cover fills the window and crops the excess axis — for a full screen whose aspect ratio the face doesn't control. Applied on reload refits too.

(The third fit item from the discussion — Toasty's 21:1 `rootBounds`, a Y/Z export swap that made wide viewports crop the face vertically — landed as [vizij-web#97](https://github.com/vizij-ai/vizij-web/pull/97).)

## Validation

Pty-driven end to end: footer advertises both commands; reload Quori→Toasty re-indexes the scene (95 bindings/18 elements → 242/49, on the fixed asset) with the local bridge re-bound; `q` quits with the terminal restored. Snapshot parity vs the web renderer holds at **0.49%** (contain default); cover verified by content extents in a tall frame (fills the height where contain letterboxed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
