### PR TITLE
feat(vizij): program autoplay + neutral staging on a shared host crate (VIZ-81)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7927,6 +7927,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arora",
+ "arora-types",
  "bevy",
  "clap 4.5.53",
  "crossterm",
@@ -7943,6 +7944,7 @@ dependencies = [
  "vizij-arora",
  "vizij-arora-behavior",
  "vizij-arora-hal",
+ "vizij-arora-host",
  "vizij-arora-store",
  "vizij-graph-core",
 ]
@@ -8052,6 +8054,16 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "tokio",
+ "vizij-api-core",
+]
+
+[[package]]
+name = "vizij-arora-host"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "log",
+ "serde_json",
  "vizij-api-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "crates/interop/vizij-arora-store",
   "crates/interop/vizij-arora-hal",
   "crates/interop/vizij-arora-behavior",
+  "crates/interop/vizij-arora-host",
   "crates/tools/vizij-glb-migrate",
   "crates/vizij",
 ]

--- a/crates/interop/vizij-arora-host/Cargo.toml
+++ b/crates/interop/vizij-arora-host/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "vizij-arora-host"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+description = "Portable Vizij host glue: compose the device behavior from graph sources, read the face bundle, pick the program to autoplay, and stage the neutral pose. Shared by the native app and vizij-arora-web (the browser runtime)."
+
+[dependencies]
+vizij-api-core = { path = "../../api/vizij-api-core" }
+anyhow = { workspace = true }
+serde_json = { workspace = true }
+log = "0.4"

--- a/crates/interop/vizij-arora-host/src/lib.rs
+++ b/crates/interop/vizij-arora-host/src/lib.rs
@@ -1,0 +1,403 @@
+//! Portable Vizij host glue — the spec/data transforms that sit *above* the
+//! device, shared by the native app (`vizij`) and the browser runtime
+//! (`vizij-arora-web`, driven by `@vizij/runtime-react`):
+//!
+//! - [`compose_sources`] unions several graph sources into the one graph a
+//!   device runs (the rig, the pose-driver, a playing program, …).
+//! - [`Bundle`] reads the face's `VIZIJ_bundle`: its graphs, its motiongraph
+//!   programs, the program to autoplay, and the neutral-pose config.
+//! - [`ProgramSelect`] picks which program plays; [`Bundle::compose`] composes
+//!   the base graphs plus that program.
+//! - [`Bundle::neutral_stage_writes`] resolves the neutral inputs to the store
+//!   writes that stage the face's resting pose.
+//!
+//! There is no renderer and no device lifecycle here — those stay in each host
+//! (Bevy + a worker thread natively; three.js + a Web Worker in the browser).
+//! This is only the logic both hosts would otherwise write twice, once in Rust
+//! and once in TypeScript.
+
+use std::collections::HashMap;
+
+use anyhow::{anyhow, Result};
+use serde_json::{json, Value as Json};
+use vizij_api_core::json::normalize_graph_spec_value;
+
+/// Which of a bundle's motiongraph programs the face boots playing.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ProgramSelect {
+    /// The bundle's own `activeMotionGraphId`.
+    Auto,
+    /// A specific program id.
+    Id(String),
+    /// No program — hold the rig's authored/neutral pose.
+    None,
+}
+
+/// A face's `VIZIJ_bundle`, reduced to what a host drives the device with.
+#[derive(Debug, Clone, Default)]
+pub struct Bundle {
+    /// Graph entries, `(kind, spec)` — `rig`, `pose-driver`, `motiongraph`, ….
+    pub graphs: Vec<(String, Json)>,
+    /// The motiongraph programs, `(id, spec)` — the graphs the face can play on
+    /// top of its rig (e.g. Quori's "Speaks").
+    pub programs: Vec<(String, Json)>,
+    /// `metadata.activeMotionGraphId` (or the first `activeMotionGraphIds`).
+    pub active_program_id: Option<String>,
+    /// `poses.config.neutralInputs` — input name → neutral value.
+    pub neutral_inputs: HashMap<String, f64>,
+}
+
+impl Bundle {
+    /// Read the bundle from a glTF JSON document: the `VIZIJ_bundle` extension
+    /// on a node, or (as the web loader also accepts) on the document root.
+    /// `None` when the document carries no bundle.
+    pub fn from_gltf_json(gltf: &Json) -> Option<Bundle> {
+        let bundle = gltf
+            .get("nodes")
+            .and_then(Json::as_array)
+            .into_iter()
+            .flatten()
+            .find_map(|node| node.get("extensions").and_then(|e| e.get("VIZIJ_bundle")))
+            .or_else(|| gltf.get("extensions").and_then(|e| e.get("VIZIJ_bundle")))?;
+        Some(Bundle::from_bundle_json(bundle))
+    }
+
+    /// Read the bundle from the `VIZIJ_bundle` object directly.
+    pub fn from_bundle_json(bundle: &Json) -> Bundle {
+        // The program the face boots playing: `activeMotionGraphId`, or the
+        // first of `activeMotionGraphIds` (the web reads the same two).
+        let metadata = bundle.get("metadata");
+        let active_program_id = metadata
+            .and_then(|m| m.get("activeMotionGraphId"))
+            .and_then(Json::as_str)
+            .or_else(|| {
+                metadata
+                    .and_then(|m| m.get("activeMotionGraphIds"))
+                    .and_then(Json::as_array)
+                    .and_then(|ids| ids.first())
+                    .and_then(Json::as_str)
+            })
+            .map(str::to_string);
+
+        let mut graphs = Vec::new();
+        let mut programs = Vec::new();
+        for entry in bundle
+            .get("graphs")
+            .and_then(Json::as_array)
+            .into_iter()
+            .flatten()
+        {
+            let kind = entry
+                .get("kind")
+                .and_then(Json::as_str)
+                .unwrap_or("unknown")
+                .to_string();
+            let Some(spec) = entry.get("spec") else {
+                continue;
+            };
+            // Motiongraphs are the playable programs, addressed by id; the base
+            // graphs (rig, pose-driver) compose by kind.
+            if kind == "motiongraph" {
+                if let Some(id) = entry.get("id").and_then(Json::as_str) {
+                    programs.push((id.to_string(), spec.clone()));
+                }
+            }
+            graphs.push((kind, spec.clone()));
+        }
+
+        let mut neutral_inputs = HashMap::new();
+        if let Some(neutral) = bundle
+            .pointer("/poses/config/neutralInputs")
+            .and_then(Json::as_object)
+        {
+            for (name, value) in neutral {
+                if let Some(n) = value.as_f64() {
+                    neutral_inputs.insert(name.clone(), n);
+                }
+            }
+        }
+
+        Bundle {
+            graphs,
+            programs,
+            active_program_id,
+            neutral_inputs,
+        }
+    }
+
+    /// The `(id, spec)` of the program `select` names, if any.
+    pub fn program(&self, select: &ProgramSelect) -> Option<&(String, Json)> {
+        let id = match select {
+            ProgramSelect::None => return None,
+            ProgramSelect::Auto => self.active_program_id.as_deref()?,
+            ProgramSelect::Id(id) => id.as_str(),
+        };
+        self.programs.iter().find(|(pid, _)| pid == id)
+    }
+
+    /// Compose the device's behavior: the base graphs whose kind is in `wanted`,
+    /// then the chosen program **last** — so it wins over the base graphs on any
+    /// store path they share (the web composes a playing program after the rig
+    /// for the same last-writer-wins reason). Returns the composed graph spec.
+    pub fn compose(&self, wanted: &[&str], select: &ProgramSelect) -> Result<Json> {
+        let mut sources: Vec<(String, Json)> = self
+            .graphs
+            .iter()
+            .filter(|(kind, _)| wanted.contains(&kind.as_str()))
+            .map(|(kind, spec)| (kind.clone(), spec.clone()))
+            .collect();
+        if let Some((id, spec)) = self.program(select) {
+            log::info!("autoplaying program {id}");
+            sources.push((format!("program::{id}"), spec.clone()));
+        }
+        compose_sources(&sources)
+    }
+
+    /// The store writes that stage the face's neutral pose: each `neutralInputs`
+    /// entry resolved to its rig input node's store path, as `(path, value)`.
+    /// Names that don't resolve to a rig input are skipped — the same tolerance
+    /// as the web's `stagePoseNeutral`. Empty when there is no neutral config.
+    pub fn neutral_stage_writes(&self) -> Vec<(String, f32)> {
+        if self.neutral_inputs.is_empty() {
+            return Vec::new();
+        }
+        let Some((_, rig)) = self.graphs.iter().find(|(kind, _)| kind == "rig") else {
+            return Vec::new();
+        };
+        let map = collect_input_path_map(rig);
+        self.neutral_inputs
+            .iter()
+            .filter_map(|(name, value)| map.get(name).map(|path| (path.clone(), *value as f32)))
+            .collect()
+    }
+}
+
+/// Union several Vizij graph specs into the one graph a device runs.
+///
+/// The device runs a single graph as its behavior, so separate sources become a
+/// union of nodes and edges. Node ids are prefixed `{source_id}::` so sources
+/// can't collide; `params.path` is deliberately **not** prefixed — path identity
+/// on the device's shared store is the cross-source contract (a pose written to
+/// a store path is read by a rig input with the same path next tick). Each spec
+/// is normalized first (legacy input-connection forms become edges) so id
+/// rewriting sees the canonical `nodes`/`edges` shape.
+///
+/// Output-path collisions across sources (two `output` nodes writing one path)
+/// are warned and resolved last-writer-wins by source order — the same tolerance
+/// as the web's `composeGraphSpecs`; current bundles don't collide.
+pub fn compose_sources(sources: &[(String, Json)]) -> Result<Json> {
+    let mut nodes = Vec::new();
+    let mut edges = Vec::new();
+    let mut output_owner: HashMap<String, String> = HashMap::new();
+    for (source_id, spec) in sources {
+        let mut normalized = spec.clone();
+        normalize_graph_spec_value(&mut normalized)
+            .map_err(|e| anyhow!("source {source_id:?} does not normalize: {e:?}"))?;
+
+        for node in nodes_of(&normalized) {
+            let Some(path) = output_path(node) else {
+                continue;
+            };
+            if let Some(owner) = output_owner.get(&path) {
+                if owner != source_id {
+                    log::warn!(
+                        "output path {path:?} is written by both {owner:?} and {source_id:?}; \
+                         last writer wins ({source_id:?})"
+                    );
+                }
+            }
+            output_owner.insert(path, source_id.clone());
+        }
+
+        let prefix = format!("{source_id}::");
+        for node in nodes_of(&normalized) {
+            let mut node = node.clone();
+            if let Some(id) = node.get("id").and_then(Json::as_str) {
+                node["id"] = json!(format!("{prefix}{id}"));
+            }
+            nodes.push(node);
+        }
+        for edge in edges_of(&normalized) {
+            let mut edge = edge.clone();
+            for end in ["from", "to"] {
+                if let Some(id) = edge
+                    .get(end)
+                    .and_then(|e| e.get("node_id"))
+                    .and_then(Json::as_str)
+                {
+                    edge[end]["node_id"] = json!(format!("{prefix}{id}"));
+                }
+            }
+            edges.push(edge);
+        }
+    }
+    Ok(json!({ "nodes": nodes, "edges": edges }))
+}
+
+fn nodes_of(spec: &Json) -> impl Iterator<Item = &Json> {
+    spec.get("nodes")
+        .and_then(Json::as_array)
+        .into_iter()
+        .flatten()
+}
+
+fn edges_of(spec: &Json) -> impl Iterator<Item = &Json> {
+    spec.get("edges")
+        .and_then(Json::as_array)
+        .into_iter()
+        .flatten()
+}
+
+/// The trimmed `params.path` of an `output` node, if this node is one.
+fn output_path(node: &Json) -> Option<String> {
+    let is_output = node
+        .get("type")
+        .and_then(Json::as_str)
+        .is_some_and(|t| t.eq_ignore_ascii_case("output"));
+    if !is_output {
+        return None;
+    }
+    node.get("params")
+        .and_then(|p| p.get("path"))
+        .and_then(Json::as_str)
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+        .map(str::to_string)
+}
+
+/// Map a graph's input nodes to their store paths, keyed the way the bundle's
+/// `neutralInputs` names them — the input node id with its `input_` prefix
+/// dropped, plus the `direct_`/`pose_control_` aliases (a port of the web host's
+/// `collectInputPathMap`). First writer wins per key, except a `direct_` alias
+/// overrides.
+pub fn collect_input_path_map(spec: &Json) -> HashMap<String, String> {
+    fn add(map: &mut HashMap<String, String>, key: &str, path: &str, force: bool) {
+        if key.is_empty() || (!force && map.contains_key(key)) {
+            return;
+        }
+        map.insert(key.to_string(), path.to_string());
+    }
+    let mut map = HashMap::new();
+    for node in nodes_of(spec) {
+        let is_input = node
+            .get("type")
+            .and_then(Json::as_str)
+            .is_some_and(|t| t.eq_ignore_ascii_case("input"));
+        if !is_input {
+            continue;
+        }
+        let Some(path) = node
+            .get("params")
+            .and_then(|p| p.get("path"))
+            .and_then(Json::as_str)
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+        else {
+            continue;
+        };
+        let id = node.get("id").and_then(Json::as_str).unwrap_or("");
+        let key = id
+            .strip_prefix("input_")
+            .unwrap_or(if id.is_empty() { path } else { id });
+        add(&mut map, key, path, false);
+        if let Some(rest) = key.strip_prefix("direct_") {
+            add(&mut map, rest, path, true);
+        }
+        if let Some(rest) = key.strip_prefix("pose_control_") {
+            add(&mut map, rest, path, false);
+        }
+    }
+    map
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn graph(nodes: Json, edges: Json) -> Json {
+        json!({ "nodes": nodes, "edges": edges })
+    }
+
+    #[test]
+    fn compose_prefixes_node_ids_but_shares_paths() {
+        let a = graph(
+            json!([{ "id": "n", "type": "output", "params": { "path": "rig/x" } }]),
+            json!([]),
+        );
+        let b = graph(
+            json!([{ "id": "n", "type": "input", "params": { "path": "rig/x" } }]),
+            json!([]),
+        );
+        let composed = compose_sources(&[("a".into(), a), ("b".into(), b)]).unwrap();
+        let ids: Vec<&str> = composed["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|n| n["id"].as_str().unwrap())
+            .collect();
+        // Ids are namespaced per source; the shared store path is untouched.
+        assert_eq!(ids, vec!["a::n", "b::n"]);
+        assert_eq!(composed["nodes"][0]["params"]["path"], "rig/x");
+        assert_eq!(composed["nodes"][1]["params"]["path"], "rig/x");
+    }
+
+    fn bundle_json() -> Json {
+        json!({
+            "metadata": { "activeMotionGraphId": "prog.speaks" },
+            "graphs": [
+                { "id": "the_rig", "kind": "rig", "spec": graph(
+                    json!([{ "id": "input_gaze_x", "type": "input", "params": { "path": "rig/gaze/x" } }]),
+                    json!([]),
+                ) },
+                { "id": "prog.speaks", "kind": "motiongraph", "spec": graph(
+                    json!([{ "id": "o", "type": "output", "params": { "path": "rig/gaze/x" } }]),
+                    json!([]),
+                ) },
+                { "id": "prog.live", "kind": "motiongraph", "spec": graph(json!([]), json!([])) }
+            ],
+            "poses": { "config": { "neutralInputs": { "gaze_x": 0.25, "missing": 1.0 } } }
+        })
+    }
+
+    #[test]
+    fn bundle_reads_programs_and_active_id() {
+        let b = Bundle::from_bundle_json(&bundle_json());
+        assert_eq!(b.active_program_id.as_deref(), Some("prog.speaks"));
+        assert_eq!(b.programs.len(), 2);
+        assert_eq!(b.program(&ProgramSelect::Auto).unwrap().0, "prog.speaks");
+        assert_eq!(
+            b.program(&ProgramSelect::Id("prog.live".into())).unwrap().0,
+            "prog.live"
+        );
+        assert!(b.program(&ProgramSelect::None).is_none());
+        assert!(b.program(&ProgramSelect::Id("nope".into())).is_none());
+    }
+
+    #[test]
+    fn compose_appends_the_active_program_last() {
+        let b = Bundle::from_bundle_json(&bundle_json());
+        let composed = b
+            .compose(&["rig", "pose-driver"], &ProgramSelect::Auto)
+            .unwrap();
+        let ids: Vec<&str> = composed["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|n| n["id"].as_str().unwrap())
+            .collect();
+        // Rig source first, program source last (last writer wins on rig/gaze/x).
+        assert_eq!(ids, vec!["rig::input_gaze_x", "program::prog.speaks::o"]);
+
+        // No autoplay → base graphs only.
+        let base = b.compose(&["rig"], &ProgramSelect::None).unwrap();
+        assert_eq!(base["nodes"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn neutral_writes_resolve_through_the_rig_input_map() {
+        let b = Bundle::from_bundle_json(&bundle_json());
+        let writes = b.neutral_stage_writes();
+        // "gaze_x" resolves via input_gaze_x → rig/gaze/x; "missing" is dropped.
+        assert_eq!(writes, vec![("rig/gaze/x".to_string(), 0.25_f32)]);
+    }
+}

--- a/crates/vizij/Cargo.toml
+++ b/crates/vizij/Cargo.toml
@@ -39,9 +39,13 @@ crossterm = "0.28"
 # through to `log` — into the terminal UI's pane or the snapshot harness's
 # env_logger.
 tracing = { version = "0.1", default-features = false, features = ["std", "log"] }
+# For staging neutral inputs into the store (`StateChange`/`Key`); the value
+# type is shared with vizij-api-core.
+arora-types = "2"
 vizij-api-core = { path = "../api/vizij-api-core" }
 vizij-graph-core = { path = "../node-graph/vizij-graph-core" }
 vizij-arora = { path = "../interop/vizij-arora" }
+vizij-arora-host = { path = "../interop/vizij-arora-host" }
 vizij-arora-store = { path = "../interop/vizij-arora-store" }
 vizij-arora-hal = { path = "../interop/vizij-arora-hal" }
 vizij-arora-behavior = { path = "../interop/vizij-arora-behavior" }

--- a/crates/vizij/src/device.rs
+++ b/crates/vizij/src/device.rs
@@ -8,10 +8,12 @@ use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Result};
 use arora::tui::{commands_frontend, TuiCommand, TuiCommandEvent};
+use arora_types::data::{DataStore, Key, StateChange};
 use futures::StreamExt;
-use serde_json::{json, Value as Json};
+use vizij_api_core::value::float;
 use vizij_arora_behavior::{parse_spec, ProcessingGraph};
 use vizij_arora_hal::RigHal;
+pub use vizij_arora_host::ProgramSelect;
 use vizij_arora_store::BlackboardStore;
 
 use crate::meta::FaceMeta;
@@ -59,79 +61,53 @@ pub enum Mode {
     Quiet,
 }
 
-/// Compose bundle graphs into the one spec the device runs — the native
-/// equivalent of the web host's `composeGraphSpecs`. Node ids are namespaced
-/// per source (`{source}::{id}`) so sources cannot collide; **store paths stay
-/// shared** — that is the cross-source contract.
-///
-/// Each graph is normalized first (legacy input-connection forms become
-/// edges), so id rewriting sees the canonical `nodes`/`edges` shape.
-pub fn compose(graphs: &[(String, Json)]) -> Result<Json> {
-    let mut nodes = Vec::new();
-    let mut edges = Vec::new();
-    for (index, (kind, spec)) in graphs.iter().enumerate() {
-        let mut normalized = spec.clone();
-        vizij_api_core::json::normalize_graph_spec_value(&mut normalized)
-            .map_err(|e| anyhow!("graph {index} ({kind}) does not normalize: {e:?}"))?;
-        let prefix = format!("{kind}{index}::");
-        for node in normalized
-            .get("nodes")
-            .and_then(Json::as_array)
-            .into_iter()
-            .flatten()
-        {
-            let mut node = node.clone();
-            if let Some(id) = node.get("id").and_then(Json::as_str) {
-                node["id"] = json!(format!("{prefix}{id}"));
-            }
-            nodes.push(node);
-        }
-        for edge in normalized
-            .get("edges")
-            .and_then(Json::as_array)
-            .into_iter()
-            .flatten()
-        {
-            let mut edge = edge.clone();
-            for end in ["from", "to"] {
-                if let Some(id) = edge
-                    .get(end)
-                    .and_then(|e| e.get("node_id"))
-                    .and_then(Json::as_str)
-                {
-                    edge[end]["node_id"] = json!(format!("{prefix}{id}"));
-                }
-            }
-            edges.push(edge);
-        }
-    }
-    Ok(json!({ "nodes": nodes, "edges": edges }))
+/// How this app composes and stages a face — carried from the CLI through the
+/// supervisor into each generation and its reloads.
+#[derive(Clone)]
+pub struct FaceConfig {
+    /// Bundle graph kinds to compose into the base behavior (rig, pose-driver).
+    pub wanted: Vec<String>,
+    /// Which program to autoplay on top of the rig.
+    pub program: ProgramSelect,
+    /// Stage the bundle's neutral inputs into the store at boot.
+    pub stage_neutral: bool,
 }
 
-/// Load a face for the device: parse the GLB's metadata, compose the bundle
-/// graphs whose kind is in `wanted` into the device's one behavior graph, and
-/// validate it. Returns the canonicalized GLB path (what the view loads), the
-/// metadata, and the composed spec.
-pub fn load_face(glb: &Path, wanted: &[String]) -> Result<(String, FaceMeta, String)> {
+/// Load a face for the device: parse the GLB's metadata, compose its bundle
+/// graphs (the base kinds plus the chosen program) into the one behavior graph,
+/// and validate it. Returns the canonicalized GLB path (what the view loads),
+/// the metadata, and the composed spec.
+pub fn load_face(glb: &Path, config: &FaceConfig) -> Result<(String, FaceMeta, String)> {
     let canonical = glb
         .canonicalize()
         .with_context(|| format!("cannot resolve {}", glb.display()))?;
     let meta = FaceMeta::from_glb_file(&canonical)?;
-    let graphs: Vec<(String, Json)> = meta
-        .bundle_graphs
-        .iter()
-        .filter(|(kind, _)| wanted.iter().any(|w| w == kind))
-        .cloned()
-        .collect();
-    if graphs.is_empty() {
-        log::warn!(
-            "no bundle graphs matched {wanted:?} in {}; the face will hold its authored pose",
-            glb.display()
-        );
-    }
-    let spec = compose(&graphs)?.to_string();
+    let wanted: Vec<&str> = config.wanted.iter().map(String::as_str).collect();
+    let spec = meta.bundle.compose(&wanted, &config.program)?.to_string();
     parse_spec(&spec).map_err(|e| anyhow!("composed spec does not parse: {e}"))?;
     Ok((canonical.to_string_lossy().into_owned(), meta, spec))
+}
+
+/// Stage a face's neutral pose into the store before the first tick: the web's
+/// `stagePoseNeutral`, ported. The rig's input nodes read these store paths, so
+/// pre-seeding them holds the face at its authored neutral even where the
+/// inputs' own defaults don't (a no-op when the bundle carries no neutral
+/// config, or every input already defaults to its neutral).
+fn stage_neutral_pose(store: &BlackboardStore, meta: &FaceMeta) {
+    let writes = meta.bundle.neutral_stage_writes();
+    if writes.is_empty() {
+        return;
+    }
+    let mut change = StateChange::new();
+    for (path, value) in &writes {
+        change
+            .set
+            .insert(Key::from(path.as_str()), Some(float(*value)));
+    }
+    match store.write(change) {
+        Ok(()) => log::info!("staged {} neutral inputs", writes.len()),
+        Err(e) => log::warn!("neutral staging failed: {e:?}"),
+    }
 }
 
 /// `RRGGBB` hex (leading `#` allowed) to sRGB bytes.
@@ -154,8 +130,8 @@ pub fn parse_rgb(hex: &str) -> Result<[u8; 3]> {
 /// (single-owner by design); only the spec JSON and the sibling rig/store
 /// handles cross the thread boundary. The face is loaded here first so
 /// composition errors surface to the caller, not in a log.
-pub fn start(glb: &Path, wanted: Vec<String>, mode: Mode) -> Result<Device> {
-    let (glb_path, meta, spec) = load_face(glb, &wanted)?;
+pub fn start(glb: &Path, config: FaceConfig, mode: Mode) -> Result<Device> {
+    let (glb_path, meta, spec) = load_face(glb, &config)?;
     let rig = RigHal::new();
     let store = BlackboardStore::new();
     let (events_tx, events_rx) = std::sync::mpsc::channel();
@@ -163,11 +139,17 @@ pub fn start(glb: &Path, wanted: Vec<String>, mode: Mode) -> Result<Device> {
     let thread = {
         let rig = rig.clone();
         let store = store.clone();
+        // The supervisor stages and announces each generation from the meta; the
+        // view keeps its own copy for the initial face.
+        let meta = meta.clone();
         thread::Builder::new()
             .name("arora".into())
             .spawn(move || match mode {
-                Mode::Operator => supervise(spec, wanted, rig, store, events_tx),
+                Mode::Operator => supervise(spec, meta, config, rig, store, events_tx),
                 Mode::Quiet => {
+                    if config.stage_neutral {
+                        stage_neutral_pose(&store, &meta);
+                    }
                     let Some(builder) = builder_for(&spec, rig, store) else {
                         return;
                     };
@@ -221,7 +203,8 @@ fn builder_for(spec: &str, rig: RigHal, store: BlackboardStore) -> Option<arora:
 /// exits the process).
 fn supervise(
     mut spec: String,
-    wanted: Vec<String>,
+    mut meta: FaceMeta,
+    config: FaceConfig,
     rig: RigHal,
     store: BlackboardStore,
     events: Sender<DeviceEvent>,
@@ -237,7 +220,8 @@ fn supervise(
     // reload's face swap is announced only after the new front end is up, so
     // the view's swap (and everything it logs) lands in the live pane.
     let mut fresh = Some((rig, store));
-    let mut pending_face: Option<(String, FaceMeta)> = None;
+    // Set on a reload so the next generation announces the new face to the view.
+    let mut pending_glb: Option<String> = None;
     loop {
         let (rig, store) = fresh
             .take()
@@ -254,12 +238,15 @@ fn supervise(
                 prompt: Some("background RRGGBB".into()),
             },
         ]);
-        if let Some((glb_path, meta)) = pending_face.take() {
+        if let Some(glb_path) = pending_glb.take() {
             let _ = events.send(DeviceEvent::FaceLoaded {
                 glb_path,
-                meta: Box::new(meta),
+                meta: Box::new(meta.clone()),
                 rig: rig.clone(),
             });
+        }
+        if config.stage_neutral {
+            stage_neutral_pose(&store, &meta);
         }
         let Some(builder) = builder_for(&spec, rig, store) else {
             return;
@@ -269,7 +256,7 @@ fn supervise(
         tokio_rt.block_on(async {
             tokio::spawn(pump(
                 commands,
-                wanted.clone(),
+                config.clone(),
                 events.clone(),
                 reload_tx,
                 stop_tx,
@@ -293,11 +280,12 @@ fn supervise(
                 _ = stop => {}
             }
         });
-        let Ok((glb_path, meta, new_spec)) = reload_rx.try_recv() else {
+        let Ok((glb_path, new_meta, new_spec)) = reload_rx.try_recv() else {
             break;
         };
         spec = new_spec;
-        pending_face = Some((glb_path, meta));
+        meta = new_meta;
+        pending_glb = Some(glb_path);
     }
 }
 
@@ -307,14 +295,14 @@ fn supervise(
 /// rebuild — a bad path is an error in the log pane, not a dead device.
 async fn pump(
     mut commands: futures::channel::mpsc::UnboundedReceiver<TuiCommandEvent>,
-    wanted: Vec<String>,
+    config: FaceConfig,
     events: Sender<DeviceEvent>,
     reload: Sender<(String, FaceMeta, String)>,
     stop: futures::channel::oneshot::Sender<()>,
 ) {
     while let Some(event) = commands.next().await {
         match (event.key, event.input) {
-            ('g', Some(path)) => match load_face(Path::new(&path), &wanted) {
+            ('g', Some(path)) => match load_face(Path::new(&path), &config) {
                 Ok(loaded) => {
                     let _ = reload.send(loaded);
                     let _ = stop.send(());

--- a/crates/vizij/src/main.rs
+++ b/crates/vizij/src/main.rs
@@ -53,6 +53,20 @@ struct Cli {
     /// "rig,pose-driver". Default: rig + pose-driver.
     #[arg(long, default_value = "rig,pose-driver,pose")]
     graphs: String,
+
+    /// Autoplay this motiongraph program id instead of the bundle's own
+    /// `activeMotionGraphId`. Window mode plays the active program by default;
+    /// `--snapshot` stays on the neutral face unless a program is named.
+    #[arg(long)]
+    program: Option<String>,
+
+    /// Don't autoplay any program — hold the rig's authored/neutral pose.
+    #[arg(long)]
+    no_autoplay: bool,
+
+    /// Don't stage the bundle's `neutralInputs` into the store at boot.
+    #[arg(long)]
+    no_stage_neutral: bool,
 }
 
 fn main() -> Result<()> {
@@ -74,13 +88,30 @@ fn main() -> Result<()> {
     } else {
         device::Mode::Operator
     };
-    let dev = device::start(&cli.glb, wanted, mode)?;
+    // Which program plays: an explicit `--program` wins; `--no-autoplay` forces
+    // none; otherwise the window autoplays the bundle's active program while the
+    // snapshot stays on the deterministic neutral face.
+    let program = if cli.no_autoplay {
+        device::ProgramSelect::None
+    } else if let Some(id) = cli.program.clone() {
+        device::ProgramSelect::Id(id)
+    } else if cli.snapshot.is_some() {
+        device::ProgramSelect::None
+    } else {
+        device::ProgramSelect::Auto
+    };
+    let config = device::FaceConfig {
+        wanted,
+        program,
+        stage_neutral: !cli.no_stage_neutral,
+    };
+    let dev = device::start(&cli.glb, config, mode)?;
     println!(
         "vizij: {} — {} elements, {} animatables, {} bundle graphs",
         dev.glb_path,
         dev.meta.elements.len(),
         dev.meta.animatables.len(),
-        dev.meta.bundle_graphs.len(),
+        dev.meta.bundle.graphs.len(),
     );
 
     let [r, g, b] = device::parse_rgb(&cli.background)?;

--- a/crates/vizij/src/meta.rs
+++ b/crates/vizij/src/meta.rs
@@ -13,6 +13,7 @@ use std::path::Path;
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use serde_json::Value as Json;
+use vizij_arora_host::Bundle;
 
 /// What one animated feature drives on a scene element.
 #[derive(Debug, Clone, PartialEq)]
@@ -53,24 +54,20 @@ pub struct Element {
     pub morph_targets: Vec<String>,
 }
 
-/// The face metadata joined from `RobotData` + `VIZIJ_bundle`.
-#[derive(Debug)]
+/// The face metadata joined from `RobotData` + `VIZIJ_bundle`. The `RobotData`
+/// half (elements, animatables, bounds) drives the Bevy renderer; the bundle is
+/// the portable host glue shared with the browser runtime.
+#[derive(Debug, Clone)]
 pub struct FaceMeta {
     pub elements: Vec<Element>,
     /// animatable UUID (string form) → what it drives.
     pub animatables: HashMap<String, Binding>,
     /// Authored view bounds on the root element: (center_x, center_y, size_x, size_y).
     pub root_bounds: Option<(f32, f32, f32, f32)>,
-    /// Graph entries from the bundle: (kind, spec JSON).
-    pub bundle_graphs: Vec<(String, Json)>,
-    /// `poses.config.neutralInputs` — input id → neutral value; staged once
-    /// input staging lands (the rig inputs all carry defaults meanwhile).
-    #[allow(dead_code)]
-    pub neutral_inputs: HashMap<String, f64>,
-    /// Bundle metadata (faceId, activeMotionGraphId, …); read once program
-    /// autoplay lands.
-    #[allow(dead_code)]
-    pub metadata: Json,
+    /// The face's `VIZIJ_bundle` — its graphs, programs, and neutral pose. The
+    /// device composition and neutral staging are its methods
+    /// ([`Bundle::compose`], [`Bundle::neutral_stage_writes`]).
+    pub bundle: Bundle,
 }
 
 /// Raw `RobotData` feature entry (only what the app needs).
@@ -134,15 +131,9 @@ impl FaceMeta {
         let mut elements = Vec::new();
         let mut animatables = HashMap::new();
         let mut root_bounds = None;
-        let mut bundle: Option<&Json> = None;
 
         for node in nodes {
             let exts = node.get("extensions");
-            if bundle.is_none() {
-                if let Some(b) = exts.and_then(|e| e.get("VIZIJ_bundle")) {
-                    bundle = Some(b);
-                }
-            }
             let Some(rd) = exts.and_then(|e| e.get("RobotData")) else {
                 continue;
             };
@@ -199,42 +190,15 @@ impl FaceMeta {
             });
         }
 
-        let mut bundle_graphs = Vec::new();
-        let mut neutral_inputs = HashMap::new();
-        let mut metadata = Json::Null;
-        if let Some(bundle) = bundle {
-            if let Some(graphs) = bundle.get("graphs").and_then(Json::as_array) {
-                for entry in graphs {
-                    let kind = entry
-                        .get("kind")
-                        .and_then(Json::as_str)
-                        .unwrap_or("unknown")
-                        .to_string();
-                    if let Some(spec) = entry.get("spec") {
-                        bundle_graphs.push((kind, spec.clone()));
-                    }
-                }
-            }
-            if let Some(neutral) = bundle
-                .pointer("/poses/config/neutralInputs")
-                .and_then(Json::as_object)
-            {
-                for (k, v) in neutral {
-                    if let Some(n) = v.as_f64() {
-                        neutral_inputs.insert(k.clone(), n);
-                    }
-                }
-            }
-            metadata = bundle.get("metadata").cloned().unwrap_or(Json::Null);
-        }
+        // The `VIZIJ_bundle` half — graphs, programs, neutral pose — is the
+        // portable host glue, read (and composed/staged) by the shared crate.
+        let bundle = Bundle::from_gltf_json(gltf).unwrap_or_default();
 
         Ok(Self {
             elements,
             animatables,
             root_bounds,
-            bundle_graphs,
-            neutral_inputs,
-            metadata,
+            bundle,
         })
     }
 }


### PR DESCRIPTION
Stage 3 of the native-app proposal ([VIZ-81](https://linear.app/semio-ai/issue/VIZ-81)). Two things:

## 1. Extract the shared host glue into `vizij-arora-host`

The device *engine* (arora + the `vizij-arora-*` interop crates) is already shared between this native app and the browser — it runs the composed graph and hosts modules the same way in both. But the layer *above* the device was being written twice: `composeGraphSpecs`, `stagePoseNeutral`/`collectInputPathMap`, and program selection all live in TypeScript in `@vizij/runtime-react`, and I'd started porting them into `crates/vizij`. Rather than grow a parallel Rust reimplementation, they now live once in a new portable crate:

- `compose_sources` — union graph sources into the one graph a device runs (id-prefix `{source}::`, shared store paths, last-writer-wins collision warning).
- `Bundle` — read the `VIZIJ_bundle` (graphs, motiongraph programs, `activeMotionGraphId`, neutral inputs).
- `ProgramSelect` + `Bundle::compose` — compose the base graphs plus the chosen program.
- `Bundle::neutral_stage_writes` / `collect_input_path_map` — resolve neutral inputs to store writes.

No renderer, no device lifecycle — just the spec/data transforms both hosts would otherwise duplicate. Unit-tested (compose, bundle parse, program selection, neutral resolution). **`vizij-arora-web` + the browser runtime migrate onto this next**, so the TS runtime collapses to a thin shell — the same direction as the structural-encoding / `apply(GraphDiff)` plan.

## 2. VIZ-81 features, on that crate

- **Program autoplay** — the window composes the bundle's `activeMotionGraphId` motiongraph on top of the rig, so Quori boots playing "Speaks" instead of sitting neutral. `--program <id>` overrides; `--no-autoplay` holds neutral. The `--snapshot` harness stays on the deterministic neutral face unless a program is named.
- **Neutral staging** — the bundle's `neutralInputs` are resolved through the rig input map and written into the store at boot (the web's `stagePoseNeutral`). On by default; `--no-stage-neutral` to skip. 182/315 of Quori's neutral keys resolve (the web drops unresolved ones too).

`FaceMeta` now carries a `vizij_arora_host::Bundle`; the `compose`/collect/stage code that lived in `device.rs`/`meta.rs` is gone.

## Verification

- `cargo test -p vizij-arora-host` (compose, bundle, program-select, neutral) + workspace clippy `-D warnings`.
- The neutral face renders **bit-identical** before/after the extraction (the shared compose matches the old inline path exactly).
- Snapshot with `--program authoring.motiongraph.program.1` renders the distinct "Speaks" pose (raised brows, gaze-up, curved mouth) vs. the flat neutral face.

## Not in scope (follow-ups, need an arora seam)

The animation **module + clip transport** (play/pause/seek on `bundle.animations`) needs a `Caller` into the device while it runs under the operator flow — `AroraBuilder::run()` owns the device and doesn't hand one back. Current faces autoplay a *program* (a motiongraph, fully compositional), not a clip, so this is deferred to a follow-up + an arora caller seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)