### PR TITLE
feat(vizij): register the animation module host-side (native, no wasm/bindep)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,16 +385,16 @@ dependencies = [
 
 [[package]]
 name = "arora"
-version = "9.6.0"
+version = "9.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40f984dc0b3582c8f70af6d475b5606aeb79b7d5ffcfe2f8accaf785ae063648"
+checksum = "465ee4cfa78a49ff8e107d57425b2afd5105987fed282dfa0676015757c76af5"
 dependencies = [
  "anyhow",
  "arora-behavior",
  "arora-behavior-tree",
  "arora-bridge",
  "arora-bridge-ws",
- "arora-engine",
+ "arora-engine 4.0.0",
  "arora-hal",
  "arora-simple-data-store",
  "arora-studio-bridge-client",
@@ -418,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "arora-behavior"
-version = "7.0.0"
+version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3034f2d7c6ed0c8910e35fa51ce09f792360a8b347cfd8a2acb173f38168a2"
+checksum = "facca7a131265b20c789bded78833b09f9925a9e9e72f7412839f99eaba0646a"
 dependencies = [
  "arora-types",
  "serde",
@@ -429,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "arora-behavior-tree"
-version = "6.2.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f1a3b46807b282f36078fa17e5d67727d389a0c9f53bafe4b5a9ae4f382aa7"
+checksum = "f001b96641fa9b941a2866125c5e0b9787cf3b865e922b54e0cf780e7d6b04d4"
 dependencies = [
  "anyhow",
  "arora-behavior",
@@ -464,15 +464,16 @@ dependencies = [
 
 [[package]]
 name = "arora-bridge"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb06e17e4b19c0655a28086bc52444906784fac5acb95d86cbf7e366c160180a"
+checksum = "d7848310653e25a84361cae07d1131f540b528f959e593e815e3e6a8a8f52859"
 dependencies = [
  "arora-types",
  "async-trait",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "serde",
 ]
 
 [[package]]
@@ -514,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "arora-buffers"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d17ec0a4456ddc613cdcc83e500f569c44519579a36d32e31a8d114709a1977"
+checksum = "8eaa641c4ef4139cde554ca709690f05e8214b4379e8d2245a67c2159b3a8076"
 dependencies = [
  "arora-types",
  "bytes",
@@ -531,6 +532,33 @@ name = "arora-engine"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fad162f6335cc7819b85d5cce0220da70fbbc641d819ea6d0db22495b4ca23a"
+dependencies = [
+ "anyhow",
+ "arora-buffers",
+ "arora-types",
+ "async-trait",
+ "bytes",
+ "cbindgen 0.29.4",
+ "console_error_panic_hook",
+ "derive_more",
+ "getrandom 0.4.3",
+ "js-sys",
+ "lazy_static",
+ "rand 0.10.2",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "arora-engine"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d129b70d3fca9b3f4168badfafd839a24b23c4f5d74d76a3ddb81ecc897ae7c7"
 dependencies = [
  "anyhow",
  "arora-buffers",
@@ -675,10 +703,11 @@ dependencies = [
 
 [[package]]
 name = "arora-types"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e47b8c04f3e96958dcb1880736fe92ee8b69a42a363ab0011ad57941e3c22a"
+checksum = "12e17cc7d475627aa6275487e9029633fca4eee4b0ed4956667faa4c18763fe7"
 dependencies = [
+ "arora-types-derive",
  "async-trait",
  "derive_more",
  "indexmap 2.14.0",
@@ -691,10 +720,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "arora-vfs"
-version = "0.1.0"
+name = "arora-types-derive"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c684bb078ae264585b66a78586cc8064a3f1b2fe47d4604bcbb7572f7e2f926b"
+checksum = "5b31c1d60113291de5628f20a60cebd0238ea6496cb3a32d48d071c3a24c0728"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "uuid",
+]
+
+[[package]]
+name = "arora-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c007ee20c55b8c04e5cfa56fa704b29cb35f2f3bfa4d654dcb7874a74f6a5130"
 dependencies = [
  "async-recursion",
  "derive_more",
@@ -709,7 +750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54a8c392e81f09866153d837c2b93787aee955e810150126a07bbca6f839721c"
 dependencies = [
  "arora",
- "arora-engine",
+ "arora-engine 3.0.0",
  "arora-types",
  "console_error_panic_hook",
  "futures",
@@ -5338,7 +5379,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -9747,7 +9788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -10328,7 +10369,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.3",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 
@@ -10597,6 +10638,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "vizij-animation-module",
  "vizij-api-core",
  "vizij-arora",
  "vizij-arora-behavior",
@@ -10623,7 +10665,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "arora-buffers",
- "arora-engine",
+ "arora-engine 4.0.0",
  "arora-module-core",
  "arora-module-rust",
  "arora-registry",
@@ -11785,7 +11827,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/interop/vizij-animation-module/Cargo.toml
+++ b/crates/interop/vizij-animation-module/Cargo.toml
@@ -27,7 +27,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]
 anyhow = "1"
-arora-engine = "3"
+arora-engine = "4"
 arora-types = "2"
 uuid = { version = "1", features = ["v4"] }
 serde_json = "1"

--- a/crates/interop/vizij-animation-module/src/lib.rs
+++ b/crates/interop/vizij-animation-module/src/lib.rs
@@ -32,13 +32,46 @@
 #[allow(clippy::all, dead_code, unused)]
 mod arora_generated;
 
+// The typed boundary structs (ARORA-55 codegen) and their `Value` conversions,
+// re-exported so a native host can marshal calls the same way the wasm glue
+// does — decode an argument with `TryFrom<Value>`, encode a result with
+// `Into<Value>` — instead of hand-writing the field UUIDs.
+pub use arora_generated::vizij::{
+    anim_track::AnimTrack, animation_clip::AnimationClip, keypoint::Keypoint,
+    player_state::PlayerState, track_output::TrackOutput, transition_handle::TransitionHandle,
+};
+
+/// The module's id and its exported function ids (mirror `module.yaml`), so a
+/// native host can register these functions as a module under the same ids the
+/// wasm module exports — a graph `ExternalFunction` node then dispatches to
+/// either identically.
+pub mod ids {
+    use uuid::Uuid;
+    pub const MODULE: Uuid = Uuid::from_u128(0x76697a69_6a00_0000_0d00_000000000000);
+    pub const LOAD_ANIMATION: Uuid = Uuid::from_u128(0x76697a69_6a00_0000_0f00_000000000001);
+    pub const CREATE_PLAYER: Uuid = Uuid::from_u128(0x76697a69_6a00_0000_0f00_000000000002);
+    pub const ADD_INSTANCE: Uuid = Uuid::from_u128(0x76697a69_6a00_0000_0f00_000000000003);
+    pub const STEP: Uuid = Uuid::from_u128(0x76697a69_6a00_0000_0f00_000000000004);
+    pub const PLAY: Uuid = Uuid::from_u128(0x76697a69_6a00_0000_0f00_000000000005);
+    pub const PAUSE: Uuid = Uuid::from_u128(0x76697a69_6a00_0000_0f00_000000000006);
+    pub const STOP: Uuid = Uuid::from_u128(0x76697a69_6a00_0000_0f00_000000000007);
+    pub const SEEK: Uuid = Uuid::from_u128(0x76697a69_6a00_0000_0f00_000000000008);
+    pub const SET_SPEED: Uuid = Uuid::from_u128(0x76697a69_6a00_0000_0f00_000000000009);
+    pub const SET_LOOP: Uuid = Uuid::from_u128(0x76697a69_6a00_0000_0f00_00000000000a);
+    pub const SET_WEIGHT: Uuid = Uuid::from_u128(0x76697a69_6a00_0000_0f00_00000000000b);
+    pub const REMOVE_INSTANCE: Uuid = Uuid::from_u128(0x76697a69_6a00_0000_0f00_00000000000c);
+    pub const PLAYER_STATES: Uuid = Uuid::from_u128(0x76697a69_6a00_0000_0f00_00000000000d);
+    /// The `[TrackOutput]` / `[PlayerState]` element struct type ids, for the
+    /// `ArrayStructure` a step / player_states result wraps them in.
+    pub const TRACK_OUTPUT_TYPE: Uuid = Uuid::from_u128(0x76697a69_6a00_0000_0000_000000000110);
+    pub const PLAYER_STATE_TYPE: Uuid = Uuid::from_u128(0x76697a69_6a00_0000_0000_000000000111);
+}
+
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-use arora_generated::vizij::{
-    animation_clip::AnimationClip, keypoint::Keypoint as GenKeypoint, player_state::PlayerState,
-    track_output::TrackOutput,
-};
+// `AnimationClip`, `PlayerState`, `TrackOutput` come from the `pub use` above.
+use arora_generated::vizij::keypoint::Keypoint as GenKeypoint;
 
 use vizij_animation_core::{
     export_baked_json, export_baked_with_derivatives_json, AnimId, AnimationData, BakingConfig,
@@ -61,7 +94,7 @@ lazy_static::lazy_static! {
 ///
 /// The keyframe `value`s arrive as raw Arora `Value`s (vizij-arora encoding) and
 /// are converted back to Vizij values for the core model.
-fn load_animation(clip: Option<AnimationClip>) -> u32 {
+pub fn load_animation(clip: Option<AnimationClip>) -> u32 {
     let Some(clip) = clip else {
         return u32::MAX;
     };
@@ -95,7 +128,7 @@ fn load_animation(clip: Option<AnimationClip>) -> u32 {
 }
 
 /// Create a player and return its `PlayerId`.
-fn create_player(name: Option<String>) -> u32 {
+pub fn create_player(name: Option<String>) -> u32 {
     ENGINE
         .lock()
         .expect("engine")
@@ -104,7 +137,7 @@ fn create_player(name: Option<String>) -> u32 {
 }
 
 /// Attach an animation instance to a player and return its `InstId`.
-fn add_instance(player: Option<u32>, anim: Option<u32>) -> u32 {
+pub fn add_instance(player: Option<u32>, anim: Option<u32>) -> u32 {
     let (Some(player), Some(anim)) = (player, anim) else {
         return u32::MAX;
     };
@@ -126,7 +159,7 @@ fn buffer_command(player: u32, command: PlayerCommand) -> u32 {
 }
 
 /// Resume or start playback. Applied at the next `step`.
-fn play(player: Option<u32>) -> u32 {
+pub fn play(player: Option<u32>) -> u32 {
     let Some(player) = player else {
         return u32::MAX;
     };
@@ -139,7 +172,7 @@ fn play(player: Option<u32>) -> u32 {
 }
 
 /// Hold the playhead where it is. Applied at the next `step`.
-fn pause(player: Option<u32>) -> u32 {
+pub fn pause(player: Option<u32>) -> u32 {
     let Some(player) = player else {
         return u32::MAX;
     };
@@ -152,7 +185,7 @@ fn pause(player: Option<u32>) -> u32 {
 }
 
 /// Stop playback and reset to the window start. Applied at the next `step`.
-fn stop(player: Option<u32>) -> u32 {
+pub fn stop(player: Option<u32>) -> u32 {
     let Some(player) = player else {
         return u32::MAX;
     };
@@ -166,7 +199,7 @@ fn stop(player: Option<u32>) -> u32 {
 
 /// Move the playhead to `time_ns` (nanoseconds, the `dt_ns` time base).
 /// Applied at the next `step`.
-fn seek(player: Option<u32>, time_ns: Option<u64>) -> u32 {
+pub fn seek(player: Option<u32>, time_ns: Option<u64>) -> u32 {
     let (Some(player), Some(time_ns)) = (player, time_ns) else {
         return u32::MAX;
     };
@@ -180,7 +213,7 @@ fn seek(player: Option<u32>, time_ns: Option<u64>) -> u32 {
 }
 
 /// Set the playback speed multiplier. Applied at the next `step`.
-fn set_speed(player: Option<u32>, speed: Option<f32>) -> u32 {
+pub fn set_speed(player: Option<u32>, speed: Option<f32>) -> u32 {
     let (Some(player), Some(speed)) = (player, speed) else {
         return u32::MAX;
     };
@@ -195,7 +228,7 @@ fn set_speed(player: Option<u32>, speed: Option<f32>) -> u32 {
 
 /// Set how player time maps into clip time: `"once"`, `"loop"`, or
 /// `"ping_pong"`. Applied at the next `step`.
-fn set_loop(player: Option<u32>, mode: Option<String>) -> u32 {
+pub fn set_loop(player: Option<u32>, mode: Option<String>) -> u32 {
     let (Some(player), Some(mode)) = (player, mode) else {
         return u32::MAX;
     };
@@ -216,7 +249,7 @@ fn set_loop(player: Option<u32>, mode: Option<String>) -> u32 {
 
 /// Set an instance's blend weight (weights normalize across a player's
 /// instances). Applied at the next `step`. Returns the echoed instance id.
-fn set_weight(player: Option<u32>, instance: Option<u32>, weight: Option<f32>) -> u32 {
+pub fn set_weight(player: Option<u32>, instance: Option<u32>, weight: Option<f32>) -> u32 {
     let (Some(player), Some(instance), Some(weight)) = (player, instance, weight) else {
         return u32::MAX;
     };
@@ -237,7 +270,7 @@ fn set_weight(player: Option<u32>, instance: Option<u32>, weight: Option<f32>) -
 
 /// Detach an instance from its player, immediately (a structural edit, like
 /// `add_instance`). Returns 1 when the instance existed, 0 otherwise.
-fn remove_instance(player: Option<u32>, instance: Option<u32>) -> u32 {
+pub fn remove_instance(player: Option<u32>, instance: Option<u32>) -> u32 {
     let (Some(player), Some(instance)) = (player, instance) else {
         return u32::MAX;
     };
@@ -250,7 +283,7 @@ fn remove_instance(player: Option<u32>, instance: Option<u32>) -> u32 {
 /// One `PlayerState` per player: the engine's derived playback state, the
 /// playhead and full length in nanoseconds (the `dt_ns` time base), and the
 /// speed multiplier.
-fn player_states() -> Vec<PlayerState> {
+pub fn player_states() -> Vec<PlayerState> {
     let engine = ENGINE.lock().expect("engine");
     engine
         .list_players()
@@ -293,7 +326,7 @@ fn baking_config(
 /// `export_baked_json` shape). `frame_rate` (Hz) defaults to 60, `start_time`
 /// (seconds) to 0, and `end_time` (seconds) to the clip duration. Returns an
 /// empty string if `anim` is not loaded.
-fn bake(
+pub fn bake(
     anim: Option<u32>,
     frame_rate: Option<f32>,
     start_time: Option<f32>,
@@ -316,7 +349,7 @@ fn bake(
 /// Like [`bake`], but also samples per-frame derivatives; returns the combined
 /// values-and-derivatives JSON (`export_baked_with_derivatives_json` shape).
 /// Returns an empty string if `anim` is not loaded.
-fn bake_with_derivatives(
+pub fn bake_with_derivatives(
     anim: Option<u32>,
     frame_rate: Option<f32>,
     start_time: Option<f32>,
@@ -344,7 +377,7 @@ fn bake_with_derivatives(
 /// buffered since the previous step apply first, in issue order. Each output
 /// carries the track's authored key as `default_key` and its stable id as
 /// `track_id`; the value uses the vizij-arora `Value` encoding.
-fn step(dt_ns: Option<u64>) -> Vec<TrackOutput> {
+pub fn step(dt_ns: Option<u64>) -> Vec<TrackOutput> {
     let dt = dt_ns.unwrap_or(0) as f64 / 1e9;
     let inputs = std::mem::take(&mut *PENDING.lock().expect("pending inputs"));
 

--- a/crates/interop/vizij-arora-behavior/Cargo.toml
+++ b/crates/interop/vizij-arora-behavior/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 description = "A Vizij node graph driven as an Arora behavior interpreter (ProcessingGraph)."
 
 [dependencies]
-arora-behavior = "7"
+arora-behavior = "8"
 arora-types = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/interop/vizij-arora-host/src/lib.rs
+++ b/crates/interop/vizij-arora-host/src/lib.rs
@@ -136,10 +136,21 @@ impl Bundle {
     }
 
     /// Compose the device's behavior: the base graphs whose kind is in `wanted`,
-    /// then the chosen program **last** — so it wins over the base graphs on any
-    /// store path they share (the web composes a playing program after the rig
-    /// for the same last-writer-wins reason). Returns the composed graph spec.
-    pub fn compose(&self, wanted: &[&str], select: &ProgramSelect) -> Result<Json> {
+    /// then the chosen program, then (when `with_animations`) the animation
+    /// source — each **last** wins over the earlier ones on any store path they
+    /// share (the web composes the same way, for the same last-writer-wins
+    /// reason). So a playing program overrides the base rig, and a playing clip
+    /// overrides both. Returns the composed graph spec.
+    ///
+    /// Pass `with_animations` when the device has the animation module loaded;
+    /// [`animations_source`] dispatches to it, so composing it without the module
+    /// would leave an `ExternalFunction` node with nothing to call.
+    pub fn compose(
+        &self,
+        wanted: &[&str],
+        select: &ProgramSelect,
+        with_animations: bool,
+    ) -> Result<Json> {
         let mut sources: Vec<(String, Json)> = self
             .graphs
             .iter()
@@ -149,6 +160,9 @@ impl Bundle {
         if let Some((id, spec)) = self.program(select) {
             log::info!("autoplaying program {id}");
             sources.push((format!("program::{id}"), spec.clone()));
+        }
+        if with_animations {
+            sources.push(animations_source());
         }
         compose_sources(&sources)
     }
@@ -170,6 +184,70 @@ impl Bundle {
             .filter_map(|(name, value)| map.get(name).map(|path| (path.clone(), *value as f32)))
             .collect()
     }
+}
+
+/// Source id of the animation source (see [`compose_sources`] for how source
+/// ids namespace node ids).
+pub const ANIMATIONS_SOURCE_ID: &str = "animations";
+
+/// Store path the animation source writes the module's per-tick `[PlayerState]`
+/// feedback to. A plain store key (not an `arora/` built-in), so it carries
+/// over a bridge and across a device restart like any other value.
+pub const ANIMATION_PLAYERS_PATH: &str = "vizij/animations/players";
+
+// The animation module's declared ids (mirror `module.yaml` / the web host's
+// `ANIMATION_MODULE_*`). The graph carries them as opaque handles: the
+// `ExternalFunction` nodes name the module functions, the `output` node the
+// `TrackOutput` fields it fans out by.
+const FN_STEP: &str = "76697a69-6a00-0000-0f00-000000000004";
+const FN_PLAYER_STATES: &str = "76697a69-6a00-0000-0f00-00000000000d";
+const PARAM_DT_NS: &str = "76697a69-6a00-0000-0f04-000000000001";
+const FIELD_OUTPUT_DEFAULT_KEY: &str = "76697a69-6a00-0000-0110-000000000002";
+const FIELD_OUTPUT_VALUE: &str = "76697a69-6a00-0000-0110-000000000003";
+
+/// The graph source that ticks the animation module **inside the device** (the
+/// native port of the web host's `animationsGraphSource`): an `ExternalFunction`
+/// node calls the module's `step` every tick, fed the runtime's built-in
+/// `arora/dt` (nanoseconds), and a path-less `output` node fans the returned
+/// `[TrackOutput]` batch onto the store keys each record names — its
+/// `default_key`, the final rig paths decided at clip load. A second
+/// `ExternalFunction` node writes `player_states()` to [`ANIMATION_PLAYERS_PATH`].
+///
+/// The source is inert until a clip plays: with no instances the module's `step`
+/// returns nothing, so the `output` writes nothing and the rig/program pose
+/// stands. Transport (load a clip, play/pause/seek/…) is driven through the
+/// module's exported functions — over a bridge, or in-process — not from here.
+pub fn animations_source() -> (String, Json) {
+    let spec = json!({
+        "nodes": [
+            { "id": "dt", "type": "input", "params": { "path": "arora/dt" } },
+            {
+                "id": "step",
+                "type": "externalfunction",
+                "params": { "function": FN_STEP, "param_ids": [PARAM_DT_NS] },
+            },
+            {
+                "id": "apply",
+                "type": "output",
+                "params": {
+                    "key_field": FIELD_OUTPUT_DEFAULT_KEY,
+                    "value_field": FIELD_OUTPUT_VALUE,
+                },
+            },
+            {
+                "id": "states",
+                "type": "externalfunction",
+                "params": { "function": FN_PLAYER_STATES, "param_ids": [] },
+            },
+            { "id": "states-out", "type": "output", "params": { "path": ANIMATION_PLAYERS_PATH } },
+        ],
+        "edges": [
+            { "from": { "node_id": "dt" }, "to": { "node_id": "step", "input": "args_0" } },
+            { "from": { "node_id": "step" }, "to": { "node_id": "apply", "input": "in" } },
+            { "from": { "node_id": "states" }, "to": { "node_id": "states-out", "input": "in" } },
+        ],
+    });
+    (ANIMATIONS_SOURCE_ID.to_string(), spec)
 }
 
 /// Union several Vizij graph specs into the one graph a device runs.
@@ -377,7 +455,7 @@ mod tests {
     fn compose_appends_the_active_program_last() {
         let b = Bundle::from_bundle_json(&bundle_json());
         let composed = b
-            .compose(&["rig", "pose-driver"], &ProgramSelect::Auto)
+            .compose(&["rig", "pose-driver"], &ProgramSelect::Auto, false)
             .unwrap();
         let ids: Vec<&str> = composed["nodes"]
             .as_array()
@@ -389,8 +467,26 @@ mod tests {
         assert_eq!(ids, vec!["rig::input_gaze_x", "program::prog.speaks::o"]);
 
         // No autoplay → base graphs only.
-        let base = b.compose(&["rig"], &ProgramSelect::None).unwrap();
+        let base = b.compose(&["rig"], &ProgramSelect::None, false).unwrap();
         assert_eq!(base["nodes"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn compose_appends_the_animation_source_last() {
+        let b = Bundle::from_bundle_json(&bundle_json());
+        let composed = b.compose(&["rig"], &ProgramSelect::None, true).unwrap();
+        let ids: Vec<String> = composed["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|n| n["id"].as_str().unwrap().to_string())
+            .collect();
+        // The rig source, then the animation source's nodes, namespaced by its
+        // source id — its `step`/`player_states` dispatch drives the module.
+        assert!(ids.contains(&"rig::input_gaze_x".to_string()));
+        assert!(ids.contains(&"animations::step".to_string()));
+        assert!(ids.contains(&"animations::apply".to_string()));
+        assert!(ids.contains(&"animations::states-out".to_string()));
     }
 
     #[test]

--- a/crates/vizij/Cargo.toml
+++ b/crates/vizij/Cargo.toml
@@ -26,7 +26,10 @@ bevy = "0.19"
 # auto-attached). 9.5 gave the TUI application commands and drop-cancellation
 # (the g/b controls, the GLB reload's rebuild); 9.6 makes `local_ws_bridge()`
 # public so the app composes the local bridge alongside the --ros2/--studio ones.
-arora = "9.6"
+# 9.7 adds `with_host_module`, which registers the animation module natively (a
+# `HostModule` of in-process functions) — no wasm guest, no bindep, so the
+# workspace stays on stable.
+arora = "9.7"
 # The ROS 2 bridge, attached under `--ros2` (feature `ros2`). Heavy (ros2-client
 # + a DDS/Zenoh backend), so opt-in; the Studio bridge rides arora's own
 # `studio-bridge` feature instead (`--studio`).
@@ -53,6 +56,11 @@ vizij-arora-host = { path = "../interop/vizij-arora-host" }
 vizij-arora-store = { path = "../interop/vizij-arora-store" }
 vizij-arora-hal = { path = "../interop/vizij-arora-hal" }
 vizij-arora-behavior = { path = "../interop/vizij-arora-behavior" }
+
+# The animation module, linked natively: we register its functions as a host
+# module (`with_host_module`) rather than loading its wasm, so no artifact
+# dependency and no nightly. Its generated `Value` conversions marshal the calls.
+vizij-animation-module = { path = "../interop/vizij-animation-module" }
 
 [features]
 default = []

--- a/crates/vizij/src/animation.rs
+++ b/crates/vizij/src/animation.rs
@@ -1,0 +1,186 @@
+//! The animation module, registered **host-side** — no wasm, no artifact
+//! dependency, so the workspace stays on stable.
+//!
+//! Built like arora's interpreter module: a [`ModuleBuilder`] with one closure
+//! per animation function, finished into a [`HostModule`] the device registers
+//! with [`AroraBuilder::with_host_module`](arora::AroraBuilder::with_host_module).
+//! Each closure marshals the `Call` at the `Value` boundary using the module
+//! crate's own generated conversions (`TryFrom<Value>` in, `Into<Value>` out)
+//! and calls its native functions, which run the same `vizij-animation-core`
+//! engine the wasm module wraps. A graph `ExternalFunction` node then dispatches
+//! `step`/`player_states` to these exactly as it would to the loaded wasm guest.
+
+use std::collections::HashMap;
+
+use arora::{HostModule, ModuleBuilder};
+use arora_types::call::{Call, CallError, CallResult};
+use arora_types::value::{StructureWithoutId, Value};
+use uuid::Uuid;
+use vizij_animation_module::{ids, AnimationClip, PlayerState, TrackOutput};
+
+/// The animation module as a host module: its functions dispatch in-process,
+/// under the same ids the wasm module exports.
+pub fn host_module() -> HostModule {
+    ModuleBuilder::new(ids::MODULE)
+        .function(ids::LOAD_ANIMATION, |call| {
+            u32_result(vizij_animation_module::load_animation(arg_clip(&call)))
+        })
+        .function(ids::CREATE_PLAYER, |call| {
+            u32_result(vizij_animation_module::create_player(arg_string(&call, 0)))
+        })
+        .function(ids::ADD_INSTANCE, |call| {
+            u32_result(vizij_animation_module::add_instance(
+                arg_u32(&call, 0),
+                arg_u32(&call, 1),
+            ))
+        })
+        .function(ids::STEP, |call| {
+            let outputs = vizij_animation_module::step(arg_u64(&call, 0));
+            value_result(array_structure(ids::TRACK_OUTPUT_TYPE, outputs))
+        })
+        .function(ids::PLAY, |call| {
+            u32_result(vizij_animation_module::play(arg_u32(&call, 0)))
+        })
+        .function(ids::PAUSE, |call| {
+            u32_result(vizij_animation_module::pause(arg_u32(&call, 0)))
+        })
+        .function(ids::STOP, |call| {
+            u32_result(vizij_animation_module::stop(arg_u32(&call, 0)))
+        })
+        .function(ids::SEEK, |call| {
+            u32_result(vizij_animation_module::seek(
+                arg_u32(&call, 0),
+                arg_u64(&call, 1),
+            ))
+        })
+        .function(ids::SET_SPEED, |call| {
+            u32_result(vizij_animation_module::set_speed(
+                arg_u32(&call, 0),
+                arg_f32(&call, 1),
+            ))
+        })
+        .function(ids::SET_LOOP, |call| {
+            u32_result(vizij_animation_module::set_loop(
+                arg_u32(&call, 0),
+                arg_string(&call, 1),
+            ))
+        })
+        .function(ids::SET_WEIGHT, |call| {
+            u32_result(vizij_animation_module::set_weight(
+                arg_u32(&call, 0),
+                arg_u32(&call, 1),
+                arg_f32(&call, 2),
+            ))
+        })
+        .function(ids::REMOVE_INSTANCE, |call| {
+            u32_result(vizij_animation_module::remove_instance(
+                arg_u32(&call, 0),
+                arg_u32(&call, 1),
+            ))
+        })
+        .function(ids::PLAYER_STATES, |_call| {
+            let states = vizij_animation_module::player_states();
+            value_result(array_structure(ids::PLAYER_STATE_TYPE, states))
+        })
+        .build()
+}
+
+/// `function id -> module id` over the animation functions — what
+/// `ProcessingGraph::set_function_modules` needs so a bare function handle
+/// (the animation source's `step`/`player_states` nodes) routes to this module.
+pub fn function_modules() -> HashMap<Uuid, Uuid> {
+    [
+        ids::LOAD_ANIMATION,
+        ids::CREATE_PLAYER,
+        ids::ADD_INSTANCE,
+        ids::STEP,
+        ids::PLAY,
+        ids::PAUSE,
+        ids::STOP,
+        ids::SEEK,
+        ids::SET_SPEED,
+        ids::SET_LOOP,
+        ids::SET_WEIGHT,
+        ids::REMOVE_INSTANCE,
+        ids::PLAYER_STATES,
+    ]
+    .into_iter()
+    .map(|function| (function, ids::MODULE))
+    .collect()
+}
+
+// --- Call marshaling ---------------------------------------------------------
+
+fn value_result(value: Value) -> Result<CallResult, CallError> {
+    Ok(CallResult {
+        ret: value,
+        mutated: Vec::new(),
+    })
+}
+
+fn u32_result(value: u32) -> Result<CallResult, CallError> {
+    value_result(Value::U32(value))
+}
+
+fn arg(call: &Call, index: usize) -> Option<&Value> {
+    call.args.get(index).map(|field| field.value.as_ref())
+}
+
+fn arg_u32(call: &Call, index: usize) -> Option<u32> {
+    match arg(call, index) {
+        Some(Value::U32(n)) => Some(*n),
+        _ => None,
+    }
+}
+
+fn arg_u64(call: &Call, index: usize) -> Option<u64> {
+    match arg(call, index) {
+        Some(Value::U64(n)) => Some(*n),
+        _ => None,
+    }
+}
+
+fn arg_f32(call: &Call, index: usize) -> Option<f32> {
+    match arg(call, index) {
+        Some(Value::F32(f)) => Some(*f),
+        _ => None,
+    }
+}
+
+fn arg_string(call: &Call, index: usize) -> Option<String> {
+    match arg(call, index) {
+        Some(Value::String(s)) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+/// Decode the clip argument through the module's own generated conversion.
+fn arg_clip(call: &Call) -> Option<AnimationClip> {
+    arg(call, 0).and_then(|value| AnimationClip::try_from(value.clone()).ok())
+}
+
+/// Wrap a batch of records (each `Into<Value>` produces a `Value::Structure`)
+/// into the `Value::ArrayStructure` the graph's path-less `output` node reads —
+/// `type_id` names the element struct so an empty batch is still well-formed.
+fn array_structure<T: Into<Value>>(type_id: Uuid, records: Vec<T>) -> Value {
+    let elements = records
+        .into_iter()
+        .filter_map(|record| match record.into() {
+            Value::Structure(structure) => Some(StructureWithoutId {
+                fields: structure.fields,
+            }),
+            _ => None,
+        })
+        .collect();
+    Value::ArrayStructure {
+        id: type_id,
+        elements,
+    }
+}
+
+// Only the module's boundary structs satisfy `array_structure`'s bound.
+const _: fn() = || {
+    fn assert_into_value<T: Into<Value>>() {}
+    assert_into_value::<TrackOutput>();
+    assert_into_value::<PlayerState>();
+};

--- a/crates/vizij/src/device.rs
+++ b/crates/vizij/src/device.rs
@@ -16,6 +16,7 @@ use vizij_arora_hal::RigHal;
 pub use vizij_arora_host::ProgramSelect;
 use vizij_arora_store::BlackboardStore;
 
+use crate::animation;
 use crate::meta::FaceMeta;
 
 /// A running face device. Both handles share storage with the device's own
@@ -129,7 +130,13 @@ pub fn load_face(glb: &Path, config: &FaceConfig) -> Result<(String, FaceMeta, S
         .with_context(|| format!("cannot resolve {}", glb.display()))?;
     let meta = FaceMeta::from_glb_file(&canonical)?;
     let wanted: Vec<&str> = config.wanted.iter().map(String::as_str).collect();
-    let spec = meta.bundle.compose(&wanted, &config.program)?.to_string();
+    // `with_animations`: the device always loads the animation module (see
+    // `builder_for`), so the animation source it dispatches to is always
+    // composed — inert until a clip plays.
+    let spec = meta
+        .bundle
+        .compose(&wanted, &config.program, true)?
+        .to_string();
     parse_spec(&spec).map_err(|e| anyhow!("composed spec does not parse: {e}"))?;
     Ok((canonical.to_string_lossy().into_owned(), meta, spec))
 }
@@ -217,8 +224,10 @@ pub fn start(glb: &Path, config: FaceConfig, bridges: BridgeConfig, mode: Mode) 
     })
 }
 
-/// The device builder over the Vizij seams; `None` (logged) when the spec
-/// does not encode.
+/// The device builder over the Vizij seams: the composed graph as the behavior,
+/// with the animation module loaded so the composed animation source's
+/// `ExternalFunction` nodes dispatch and its transport is callable. `None`
+/// (logged) when the spec does not encode or the baked-in module does not load.
 fn builder_for(spec: &str, rig: RigHal, store: BlackboardStore) -> Option<arora::AroraBuilder> {
     let spec = match parse_spec(spec) {
         Ok(spec) => spec,
@@ -227,18 +236,22 @@ fn builder_for(spec: &str, rig: RigHal, store: BlackboardStore) -> Option<arora:
             return None;
         }
     };
-    let graph = match ProcessingGraph::from_spec(spec) {
+    let mut graph = match ProcessingGraph::from_spec(spec) {
         Ok(graph) => graph,
         Err(e) => {
             log::error!("graph encode failed: {e}");
             return None;
         }
     };
+    // Route the animation source's `step`/`player_states` handles (and any
+    // in-process transport call) to the host module registered below.
+    graph.set_function_modules(animation::function_modules());
     Some(
         arora::Arora::builder()
             .with_hal(Box::new(rig))
             .with_data_store(Box::new(store))
-            .with_behavior_interpreter(Box::new(graph)),
+            .with_behavior_interpreter(Box::new(graph))
+            .with_host_module(animation::host_module()),
     )
 }
 
@@ -383,5 +396,41 @@ fn step_forever(arora: &mut arora::Arora) {
             break;
         }
         thread::sleep(period);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vizij_arora_host::{animations_source, compose_sources, ANIMATION_PLAYERS_PATH};
+
+    /// The composed animation source ticks the loaded module: `builder_for`
+    /// loads the baked-in wasm and wires `set_function_modules`, so the source's
+    /// `player_states` `ExternalFunction` dispatches and its output lands in the
+    /// store. A dispatch failure ("no module registered") would abort the graph
+    /// tick before any write, so the key's mere presence proves the module runs.
+    #[test]
+    fn animation_source_ticks_the_loaded_module() {
+        let spec = compose_sources(&[animations_source()])
+            .expect("compose the animation source")
+            .to_string();
+        let mut arora = builder_for(&spec, RigHal::new(), BlackboardStore::new())
+            .expect("build the device over the loaded animation module")
+            .build()
+            .expect("build arora");
+        for _ in 0..3 {
+            arora.step(Duration::from_millis(16)).expect("step");
+        }
+        let key = Key::from(ANIMATION_PLAYERS_PATH);
+        let players = arora
+            .store()
+            .read(std::slice::from_ref(&key))
+            .into_iter()
+            .next()
+            .flatten();
+        assert!(
+            players.is_some(),
+            "{ANIMATION_PLAYERS_PATH} absent — the animation module did not dispatch",
+        );
     }
 }

--- a/crates/vizij/src/main.rs
+++ b/crates/vizij/src/main.rs
@@ -12,6 +12,7 @@ use anyhow::{anyhow, Result};
 use bevy::prelude::*;
 use clap::Parser;
 
+mod animation;
 mod device;
 mod frames;
 mod meta;


### PR DESCRIPTION
Implements the animation half of [VIZ-81](https://linear.app/semio-ai/issue/VIZ-81) — stage 3 of the [native-app proposal](https://github.com/vizij-ai/vizij-rs/pull/74): the device loads the animation module and an animation source, so clips staged on the store play through to the face.

Supersedes #81 (the wasm-bindep variant): instead of loading the module's cdylib as a wasm guest — which drags the whole workspace onto nightly for `-Z bindeps` — the module links natively and registers through arora 9.7's `AroraBuilder::with_host_module`. `animation::host_module()` assembles a `ModuleBuilder` with one closure per module function over the module's own generated `Value` conversions, so `load_animation`, `step`, the transport functions, and `player_states` dispatch in-process. Same call plane, same UUIDs, no wasm anywhere — **the workspace stays on stable**.

- `vizij-animation-module` exposes its functions, boundary types (`AnimationClip`, `TrackOutput`, `PlayerState`), and `ids` for host use.
- The composed animation source moves to `vizij-arora-host` (`animations_source()`, shared with the web runtime's semantics): `arora/dt → step → path-less fan-out onto the keys each `TrackOutput` names, plus `player_states → vizij/animations/players`. Composed last, inert until a clip plays.
- Pins: arora 9.7 / arora-engine 4 / arora-behavior 8 (the [#192](https://github.com/semio-ai/arora-sdk/pull/192)/[#196](https://github.com/semio-ai/arora-sdk/pull/196)/[#198](https://github.com/semio-ai/arora-sdk/pull/198) release line).

Validated on stable 1.96.0: full-workspace fmt/clippy/tests green, including `animation_source_ticks_the_loaded_module` (the source drives the module through a real device tick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)