### PR TITLE
feat(vizij): official ROS4HRI support over the Vizij face standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,3 +187,7 @@ jobs:
           VIZIJ_FIXTURES: ${{ github.workspace }}/fixtures
           WGPU_BACKEND: vulkan
         run: cargo test -p vizij --test snapshot_regression -- --ignored --nocapture
+      - name: Drive the adapted Quori over the ROS4HRI mapping
+        env:
+          VIZIJ_FIXTURES: ${{ github.workspace }}/fixtures
+        run: cargo test -p vizij --bin vizij ros4hri_drives_the_adapted_quori -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10646,6 +10646,7 @@ dependencies = [
  "vizij-arora-hal",
  "vizij-arora-host",
  "vizij-arora-store",
+ "vizij-bundle",
  "vizij-graph-core",
 ]
 
@@ -10791,10 +10792,21 @@ dependencies = [
  "vizij-api-core",
  "vizij-arora-behavior",
  "vizij-arora-hal",
+ "vizij-arora-host",
  "vizij-arora-store",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
+]
+
+[[package]]
+name = "vizij-bundle"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde_json",
+ "vizij-arora-host",
+ "vizij-glb-migrate",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "crates/interop/vizij-arora-hal",
   "crates/interop/vizij-arora-behavior",
   "crates/interop/vizij-arora-host",
+  "crates/tools/vizij-bundle",
   "crates/tools/vizij-glb-migrate",
   "crates/vizij",
 ]

--- a/crates/api/vizij-api-core/src/json/mod.rs
+++ b/crates/api/vizij-api-core/src/json/mod.rs
@@ -601,6 +601,15 @@ pub fn normalize_graph_spec_value(root: &mut JsonValue) -> Result<(), JsonError>
                 );
                 let mut operand_aliases: HashMap<String, String> = HashMap::new();
                 let mut next_operand_index: usize = 1;
+                // A variadic node's FIXED ports must survive operand aliasing
+                // — only the case values are operands; `selector`/`default`
+                // keep their meaning (aliasing them would silence the node
+                // into its no-match NaN).
+                if node_type == "case" {
+                    for fixed in ["selector", "default"] {
+                        operand_aliases.insert(fixed.to_string(), fixed.to_string());
+                    }
+                }
 
                 let mut input_defaults_map =
                     if let Some(existing_defaults) = node_map.remove("input_defaults") {
@@ -1246,5 +1255,31 @@ mod tests {
         let err = normalize_graph_spec_value(&mut root)
             .expect_err("legacy links field should be rejected");
         assert!(matches!(err, JsonError::LegacyLinksField));
+    }
+
+    #[test]
+    fn case_edges_keep_their_fixed_ports() {
+        let mut root = json!({
+            "nodes": [
+                { "id": "sel", "type": "constant", "params": { "value": "x" } },
+                { "id": "v", "type": "constant", "params": { "value": 1.0 } },
+                { "id": "d", "type": "constant", "params": { "value": 0.0 } },
+                { "id": "c", "type": "case", "params": { "case_labels": ["x"] } },
+            ],
+            "edges": [
+                { "from": { "node_id": "sel" }, "to": { "node_id": "c", "input": "selector" } },
+                { "from": { "node_id": "v" }, "to": { "node_id": "c", "input": "operand_0" } },
+                { "from": { "node_id": "d" }, "to": { "node_id": "c", "input": "default" } },
+            ],
+        });
+        normalize_graph_spec_value(&mut root).expect("normalize");
+        let inputs: Vec<&str> = root["edges"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e["to"]["input"].as_str().unwrap())
+            .collect();
+        // The fixed ports survive; only genuine operands are operands.
+        assert_eq!(inputs, ["selector", "operand_0", "default"]);
     }
 }

--- a/crates/interop/vizij-arora-host/profiles/ros4hri.json
+++ b/crates/interop/vizij-arora-host/profiles/ros4hri.json
@@ -1,0 +1,13237 @@
+{
+  "nodes": [
+    {
+      "id": "in-name",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/expression/name",
+        "value": ""
+      }
+    },
+    {
+      "id": "in-valence",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/expression/valence",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in-arousal",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/expression/arousal",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "c1",
+      "type": "constant",
+      "params": {
+        "value": 0.0
+      }
+    },
+    {
+      "id": "c2",
+      "type": "constant",
+      "params": {
+        "value": 1.0
+      }
+    },
+    {
+      "id": "n3",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          ""
+        ]
+      }
+    },
+    {
+      "id": "n4",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "c5",
+      "type": "constant",
+      "params": {
+        "value": 0.36
+      }
+    },
+    {
+      "id": "c6",
+      "type": "constant",
+      "params": {
+        "value": 0.0
+      }
+    },
+    {
+      "id": "c7",
+      "type": "constant",
+      "params": {
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n8",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n9",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n10",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n11",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n12",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n13",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n14",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n15",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c16",
+      "type": "constant",
+      "params": {
+        "value": -0.7
+      }
+    },
+    {
+      "id": "c17",
+      "type": "constant",
+      "params": {
+        "value": 0.7
+      }
+    },
+    {
+      "id": "n18",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n19",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n20",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n21",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n22",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n23",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n24",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n25",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c26",
+      "type": "constant",
+      "params": {
+        "value": -0.7
+      }
+    },
+    {
+      "id": "c27",
+      "type": "constant",
+      "params": {
+        "value": -0.4
+      }
+    },
+    {
+      "id": "n28",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n29",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n30",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n31",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n32",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n33",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n34",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n35",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c36",
+      "type": "constant",
+      "params": {
+        "value": 0.8
+      }
+    },
+    {
+      "id": "c37",
+      "type": "constant",
+      "params": {
+        "value": 0.4
+      }
+    },
+    {
+      "id": "n38",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n39",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n40",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n41",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n42",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n43",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n44",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n45",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c46",
+      "type": "constant",
+      "params": {
+        "value": 0.1
+      }
+    },
+    {
+      "id": "c47",
+      "type": "constant",
+      "params": {
+        "value": 0.8
+      }
+    },
+    {
+      "id": "n48",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n49",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n50",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n51",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n52",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n53",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n54",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n55",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c56",
+      "type": "constant",
+      "params": {
+        "value": -0.7
+      }
+    },
+    {
+      "id": "c57",
+      "type": "constant",
+      "params": {
+        "value": 0.4
+      }
+    },
+    {
+      "id": "n58",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n59",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n60",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n61",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n62",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n63",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n64",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n65",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c66",
+      "type": "constant",
+      "params": {
+        "value": -0.7
+      }
+    },
+    {
+      "id": "c67",
+      "type": "constant",
+      "params": {
+        "value": 0.8
+      }
+    },
+    {
+      "id": "n68",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n69",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n70",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n71",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n72",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n73",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n74",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n75",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c76",
+      "type": "constant",
+      "params": {
+        "value": -0.3
+      }
+    },
+    {
+      "id": "c77",
+      "type": "constant",
+      "params": {
+        "value": 0.3
+      }
+    },
+    {
+      "id": "n78",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n79",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n80",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n81",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n82",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n83",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n84",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n85",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c86",
+      "type": "constant",
+      "params": {
+        "value": -0.4
+      }
+    },
+    {
+      "id": "c87",
+      "type": "constant",
+      "params": {
+        "value": -0.15
+      }
+    },
+    {
+      "id": "n88",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n89",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n90",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n91",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n92",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n93",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n94",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n95",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c96",
+      "type": "constant",
+      "params": {
+        "value": -0.8
+      }
+    },
+    {
+      "id": "c97",
+      "type": "constant",
+      "params": {
+        "value": -0.5
+      }
+    },
+    {
+      "id": "n98",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n99",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n100",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n101",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n102",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n103",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n104",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n105",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c106",
+      "type": "constant",
+      "params": {
+        "value": -0.5
+      }
+    },
+    {
+      "id": "c107",
+      "type": "constant",
+      "params": {
+        "value": -0.35
+      }
+    },
+    {
+      "id": "n108",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n109",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n110",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n111",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n112",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n113",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n114",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n115",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c116",
+      "type": "constant",
+      "params": {
+        "value": -0.5
+      }
+    },
+    {
+      "id": "c117",
+      "type": "constant",
+      "params": {
+        "value": -0.25
+      }
+    },
+    {
+      "id": "n118",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n119",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n120",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n121",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n122",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n123",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n124",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n125",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c126",
+      "type": "constant",
+      "params": {
+        "value": -0.35
+      }
+    },
+    {
+      "id": "c127",
+      "type": "constant",
+      "params": {
+        "value": 0.2
+      }
+    },
+    {
+      "id": "n128",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n129",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n130",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n131",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n132",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n133",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n134",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n135",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c136",
+      "type": "constant",
+      "params": {
+        "value": -0.8
+      }
+    },
+    {
+      "id": "c137",
+      "type": "constant",
+      "params": {
+        "value": 0.8
+      }
+    },
+    {
+      "id": "n138",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n139",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n140",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n141",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n142",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n143",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n144",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n145",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c146",
+      "type": "constant",
+      "params": {
+        "value": -0.3
+      }
+    },
+    {
+      "id": "c147",
+      "type": "constant",
+      "params": {
+        "value": 0.1
+      }
+    },
+    {
+      "id": "n148",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n149",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n150",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n151",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n152",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n153",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n154",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n155",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c156",
+      "type": "constant",
+      "params": {
+        "value": -0.5
+      }
+    },
+    {
+      "id": "c157",
+      "type": "constant",
+      "params": {
+        "value": 0.4
+      }
+    },
+    {
+      "id": "n158",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n159",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n160",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n161",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n162",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n163",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n164",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n165",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c166",
+      "type": "constant",
+      "params": {
+        "value": -0.8
+      }
+    },
+    {
+      "id": "c167",
+      "type": "constant",
+      "params": {
+        "value": 0.9
+      }
+    },
+    {
+      "id": "n168",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n169",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n170",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n171",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n172",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n173",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n174",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n175",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c176",
+      "type": "constant",
+      "params": {
+        "value": -0.4
+      }
+    },
+    {
+      "id": "c177",
+      "type": "constant",
+      "params": {
+        "value": 0.25
+      }
+    },
+    {
+      "id": "n178",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n179",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n180",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n181",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n182",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n183",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n184",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n185",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c186",
+      "type": "constant",
+      "params": {
+        "value": -0.6
+      }
+    },
+    {
+      "id": "c187",
+      "type": "constant",
+      "params": {
+        "value": -0.3
+      }
+    },
+    {
+      "id": "n188",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n189",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n190",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n191",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n192",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n193",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n194",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n195",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c196",
+      "type": "constant",
+      "params": {
+        "value": -0.35
+      }
+    },
+    {
+      "id": "c197",
+      "type": "constant",
+      "params": {
+        "value": -0.55
+      }
+    },
+    {
+      "id": "n198",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n199",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n200",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n201",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n202",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n203",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n204",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n205",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c206",
+      "type": "constant",
+      "params": {
+        "value": -0.15
+      }
+    },
+    {
+      "id": "c207",
+      "type": "constant",
+      "params": {
+        "value": -0.7
+      }
+    },
+    {
+      "id": "n208",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n209",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n210",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n211",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n212",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n213",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n214",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n215",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c216",
+      "type": "constant",
+      "params": {
+        "value": 0.0
+      }
+    },
+    {
+      "id": "c217",
+      "type": "constant",
+      "params": {
+        "value": -0.95
+      }
+    },
+    {
+      "id": "n218",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n219",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n220",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n221",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n222",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n223",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n224",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n225",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c226",
+      "type": "constant",
+      "params": {
+        "value": -0.25
+      }
+    },
+    {
+      "id": "c227",
+      "type": "constant",
+      "params": {
+        "value": 0.35
+      }
+    },
+    {
+      "id": "n228",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n229",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n230",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n231",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n232",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n233",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n234",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n235",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c236",
+      "type": "constant",
+      "params": {
+        "value": 0.5
+      }
+    },
+    {
+      "id": "c237",
+      "type": "constant",
+      "params": {
+        "value": 0.7
+      }
+    },
+    {
+      "id": "n238",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n239",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n240",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n241",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n242",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n243",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n244",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n245",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "c246",
+      "type": "constant",
+      "params": {
+        "value": 0.7
+      }
+    },
+    {
+      "id": "c247",
+      "type": "constant",
+      "params": {
+        "value": 0.8
+      }
+    },
+    {
+      "id": "n248",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n249",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n250",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n251",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n252",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n253",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n254",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n255",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "n256",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "c257",
+      "type": "constant",
+      "params": {
+        "value": 1e-6
+      }
+    },
+    {
+      "id": "n258",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "n259",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n260",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n261",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "c262",
+      "type": "constant",
+      "params": {
+        "value": 0.0225
+      }
+    },
+    {
+      "id": "n263",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "c264",
+      "type": "constant",
+      "params": {
+        "value": 0.0
+      }
+    },
+    {
+      "id": "c265",
+      "type": "constant",
+      "params": {
+        "value": 1.0
+      }
+    },
+    {
+      "id": "n266",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "n267",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n268",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "neutral"
+        ]
+      }
+    },
+    {
+      "id": "n269",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n270",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n271",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n272",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n273",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n274",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n275",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o276",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/neutral"
+      }
+    },
+    {
+      "id": "n277",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "angry"
+        ]
+      }
+    },
+    {
+      "id": "n278",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n279",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n280",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n281",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n282",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n283",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o284",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/angry"
+      }
+    },
+    {
+      "id": "n285",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "sad"
+        ]
+      }
+    },
+    {
+      "id": "n286",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n287",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n288",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n289",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n290",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n291",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o292",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/sad"
+      }
+    },
+    {
+      "id": "n293",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "happy"
+        ]
+      }
+    },
+    {
+      "id": "n294",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n295",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n296",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n297",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n298",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n299",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o300",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/happy"
+      }
+    },
+    {
+      "id": "n301",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "surprised"
+        ]
+      }
+    },
+    {
+      "id": "n302",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n303",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n304",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n305",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n306",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n307",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o308",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/surprised"
+      }
+    },
+    {
+      "id": "n309",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "disgusted"
+        ]
+      }
+    },
+    {
+      "id": "n310",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n311",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n312",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n313",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n314",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n315",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o316",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/disgusted"
+      }
+    },
+    {
+      "id": "n317",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "scared"
+        ]
+      }
+    },
+    {
+      "id": "n318",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n319",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n320",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n321",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n322",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n323",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o324",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/scared"
+      }
+    },
+    {
+      "id": "n325",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "pleading"
+        ]
+      }
+    },
+    {
+      "id": "n326",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n327",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n328",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n329",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n330",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n331",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o332",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/pleading"
+      }
+    },
+    {
+      "id": "n333",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "vulnerable"
+        ]
+      }
+    },
+    {
+      "id": "n334",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n335",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n336",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n337",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n338",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n339",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o340",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/vulnerable"
+      }
+    },
+    {
+      "id": "n341",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "despaired"
+        ]
+      }
+    },
+    {
+      "id": "n342",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n343",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n344",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n345",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n346",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n347",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o348",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/despaired"
+      }
+    },
+    {
+      "id": "n349",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "guilty"
+        ]
+      }
+    },
+    {
+      "id": "n350",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n351",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n352",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n353",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n354",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n355",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o356",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/guilty"
+      }
+    },
+    {
+      "id": "n357",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "disappointed"
+        ]
+      }
+    },
+    {
+      "id": "n358",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n359",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n360",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n361",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n362",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n363",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o364",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/disappointed"
+      }
+    },
+    {
+      "id": "n365",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "embarrassed"
+        ]
+      }
+    },
+    {
+      "id": "n366",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n367",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n368",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n369",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n370",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n371",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o372",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/embarrassed"
+      }
+    },
+    {
+      "id": "n373",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "horrified"
+        ]
+      }
+    },
+    {
+      "id": "n374",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n375",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n376",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n377",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n378",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n379",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o380",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/horrified"
+      }
+    },
+    {
+      "id": "n381",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "skeptical"
+        ]
+      }
+    },
+    {
+      "id": "n382",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n383",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n384",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n385",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n386",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n387",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o388",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/skeptical"
+      }
+    },
+    {
+      "id": "n389",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "annoyed"
+        ]
+      }
+    },
+    {
+      "id": "n390",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n391",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n392",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n393",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n394",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n395",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o396",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/annoyed"
+      }
+    },
+    {
+      "id": "n397",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "furious"
+        ]
+      }
+    },
+    {
+      "id": "n398",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n399",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n400",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n401",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n402",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n403",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o404",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/furious"
+      }
+    },
+    {
+      "id": "n405",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "suspicious"
+        ]
+      }
+    },
+    {
+      "id": "n406",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n407",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n408",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n409",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n410",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n411",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o412",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/suspicious"
+      }
+    },
+    {
+      "id": "n413",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "rejected"
+        ]
+      }
+    },
+    {
+      "id": "n414",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n415",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n416",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n417",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n418",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n419",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o420",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/rejected"
+      }
+    },
+    {
+      "id": "n421",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "bored"
+        ]
+      }
+    },
+    {
+      "id": "n422",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n423",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n424",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n425",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n426",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n427",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o428",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/bored"
+      }
+    },
+    {
+      "id": "n429",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "tired"
+        ]
+      }
+    },
+    {
+      "id": "n430",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n431",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n432",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n433",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n434",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n435",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o436",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/tired"
+      }
+    },
+    {
+      "id": "n437",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "asleep"
+        ]
+      }
+    },
+    {
+      "id": "n438",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n439",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n440",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n441",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n442",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n443",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o444",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/asleep"
+      }
+    },
+    {
+      "id": "n445",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "confused"
+        ]
+      }
+    },
+    {
+      "id": "n446",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n447",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n448",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n449",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n450",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n451",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o452",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/confused"
+      }
+    },
+    {
+      "id": "n453",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "amazed"
+        ]
+      }
+    },
+    {
+      "id": "n454",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n455",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n456",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n457",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n458",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n459",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o460",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/amazed"
+      }
+    },
+    {
+      "id": "n461",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "excited"
+        ]
+      }
+    },
+    {
+      "id": "n462",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n463",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n464",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n465",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n466",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n467",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o468",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/expression/excited"
+      }
+    },
+    {
+      "id": "in-gaze",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/gaze/target",
+        "value": {
+          "x": 10.0,
+          "y": 0.0,
+          "z": 0.0
+        }
+      }
+    },
+    {
+      "id": "c469",
+      "type": "constant",
+      "params": {
+        "value": 0.0
+      }
+    },
+    {
+      "id": "c470",
+      "type": "constant",
+      "params": {
+        "value": 1.0
+      }
+    },
+    {
+      "id": "c471",
+      "type": "constant",
+      "params": {
+        "value": 2.0
+      }
+    },
+    {
+      "id": "n472",
+      "type": "vectorindex",
+      "params": {}
+    },
+    {
+      "id": "n473",
+      "type": "vectorindex",
+      "params": {}
+    },
+    {
+      "id": "n474",
+      "type": "vectorindex",
+      "params": {}
+    },
+    {
+      "id": "c475",
+      "type": "constant",
+      "params": {
+        "value": 0.1
+      }
+    },
+    {
+      "id": "n476",
+      "type": "greaterthan",
+      "params": {}
+    },
+    {
+      "id": "c477",
+      "type": "constant",
+      "params": {
+        "value": 0.03
+      }
+    },
+    {
+      "id": "n478",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n479",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n480",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n481",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "c482",
+      "type": "constant",
+      "params": {
+        "value": 0.28
+      }
+    },
+    {
+      "id": "n483",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "c484",
+      "type": "constant",
+      "params": {
+        "value": 1.0
+      }
+    },
+    {
+      "id": "n485",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n486",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "c487",
+      "type": "constant",
+      "params": {
+        "value": 0.78
+      }
+    },
+    {
+      "id": "n488",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "c489",
+      "type": "constant",
+      "params": {
+        "value": -1.0
+      }
+    },
+    {
+      "id": "c490",
+      "type": "constant",
+      "params": {
+        "value": 1.0
+      }
+    },
+    {
+      "id": "n491",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "n492",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n493",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "c494",
+      "type": "constant",
+      "params": {
+        "value": 0.28
+      }
+    },
+    {
+      "id": "n495",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "c496",
+      "type": "constant",
+      "params": {
+        "value": 1.0
+      }
+    },
+    {
+      "id": "n497",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n498",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "c499",
+      "type": "constant",
+      "params": {
+        "value": 0.78
+      }
+    },
+    {
+      "id": "n500",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "c501",
+      "type": "constant",
+      "params": {
+        "value": -1.0
+      }
+    },
+    {
+      "id": "c502",
+      "type": "constant",
+      "params": {
+        "value": 1.0
+      }
+    },
+    {
+      "id": "n503",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "n504",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n505",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "c506",
+      "type": "constant",
+      "params": {
+        "value": 0.28
+      }
+    },
+    {
+      "id": "n507",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "c508",
+      "type": "constant",
+      "params": {
+        "value": 1.0
+      }
+    },
+    {
+      "id": "n509",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n510",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "c511",
+      "type": "constant",
+      "params": {
+        "value": 0.78
+      }
+    },
+    {
+      "id": "n512",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "c513",
+      "type": "constant",
+      "params": {
+        "value": -1.0
+      }
+    },
+    {
+      "id": "c514",
+      "type": "constant",
+      "params": {
+        "value": 1.0
+      }
+    },
+    {
+      "id": "n515",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "n516",
+      "type": "if",
+      "params": {}
+    },
+    {
+      "id": "n517",
+      "type": "if",
+      "params": {}
+    },
+    {
+      "id": "n518",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "n519",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o520",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/left_eye/pos/x"
+      }
+    },
+    {
+      "id": "o521",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/left_eye/pos/y"
+      }
+    },
+    {
+      "id": "n522",
+      "type": "if",
+      "params": {}
+    },
+    {
+      "id": "n523",
+      "type": "if",
+      "params": {}
+    },
+    {
+      "id": "n524",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "n525",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o526",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/right_eye/pos/x"
+      }
+    },
+    {
+      "id": "o527",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/right_eye/pos/y"
+      }
+    },
+    {
+      "id": "in-au-1",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/au/1",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n528",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o529",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/brow_inner_up"
+      }
+    },
+    {
+      "id": "in-au-2",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/au/2",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n530",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o531",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/brow_outer_up_left"
+      }
+    },
+    {
+      "id": "o532",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/brow_outer_up_right"
+      }
+    },
+    {
+      "id": "in-au-4",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/au/4",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n533",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o534",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/brow_down_left"
+      }
+    },
+    {
+      "id": "o535",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/brow_down_right"
+      }
+    },
+    {
+      "id": "in-au-5",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/au/5",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n536",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o537",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/eye_wide_left"
+      }
+    },
+    {
+      "id": "o538",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/eye_wide_right"
+      }
+    },
+    {
+      "id": "in-au-6",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/au/6",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n539",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o540",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/cheek_raise_left"
+      }
+    },
+    {
+      "id": "o541",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/cheek_raise_right"
+      }
+    },
+    {
+      "id": "in-au-7",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/au/7",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n542",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o543",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/eye_squint_left"
+      }
+    },
+    {
+      "id": "o544",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/eye_squint_right"
+      }
+    },
+    {
+      "id": "in-au-9",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/au/9",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n545",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o546",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/nose_sneer_left"
+      }
+    },
+    {
+      "id": "o547",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/nose_sneer_right"
+      }
+    },
+    {
+      "id": "in-au-10",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/au/10",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n548",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o549",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/mouth_upper_up_left"
+      }
+    },
+    {
+      "id": "o550",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/mouth_upper_up_right"
+      }
+    },
+    {
+      "id": "in-au-12",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/au/12",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n551",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o552",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/mouth_smile_left"
+      }
+    },
+    {
+      "id": "o553",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/mouth_smile_right"
+      }
+    },
+    {
+      "id": "in-au-15",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/au/15",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n554",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o555",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/mouth_frown_left"
+      }
+    },
+    {
+      "id": "o556",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/mouth_frown_right"
+      }
+    },
+    {
+      "id": "in-au-16",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/au/16",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n557",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o558",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/mouth_lower_down_left"
+      }
+    },
+    {
+      "id": "o559",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/mouth_lower_down_right"
+      }
+    },
+    {
+      "id": "in-au-18",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/au/18",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n560",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o561",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/mouth_pucker"
+      }
+    },
+    {
+      "id": "in-au-19",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/au/19",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n562",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o563",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/tongue_out"
+      }
+    },
+    {
+      "id": "in-au-20",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/au/20",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n564",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o565",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/mouth_stretch_left"
+      }
+    },
+    {
+      "id": "o566",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/mouth_stretch_right"
+      }
+    },
+    {
+      "id": "in-au-22",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/au/22",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n567",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o568",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/mouth_funnel"
+      }
+    },
+    {
+      "id": "in-au-24",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/au/24",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n569",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o570",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/mouth_press_left"
+      }
+    },
+    {
+      "id": "o571",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/mouth_press_right"
+      }
+    },
+    {
+      "id": "in-au-26",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/au/26",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n572",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o573",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/jaw_open"
+      }
+    },
+    {
+      "id": "o574",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/mouth/morph/jaw_open"
+      }
+    },
+    {
+      "id": "in-au-29",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/au/29",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n575",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o576",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/jaw_forward"
+      }
+    },
+    {
+      "id": "in-au-34",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/au/34",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n577",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o578",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/cheek_puff"
+      }
+    },
+    {
+      "id": "in-au-43",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/au/43",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n579",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o580",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/eye_closed_left"
+      }
+    },
+    {
+      "id": "o581",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/face/eye_closed_right"
+      }
+    },
+    {
+      "id": "in-vis-sil",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/viseme/sil",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n582",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o583",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/viseme/sil"
+      }
+    },
+    {
+      "id": "in-vis-PP",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/viseme/PP",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n584",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o585",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/viseme/PP"
+      }
+    },
+    {
+      "id": "in-vis-FF",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/viseme/FF",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n586",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o587",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/viseme/FF"
+      }
+    },
+    {
+      "id": "in-vis-TH",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/viseme/TH",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n588",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o589",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/viseme/TH"
+      }
+    },
+    {
+      "id": "in-vis-DD",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/viseme/DD",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n590",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o591",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/viseme/DD"
+      }
+    },
+    {
+      "id": "in-vis-kk",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/viseme/kk",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n592",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o593",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/viseme/kk"
+      }
+    },
+    {
+      "id": "in-vis-CH",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/viseme/CH",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n594",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o595",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/viseme/CH"
+      }
+    },
+    {
+      "id": "in-vis-SS",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/viseme/SS",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n596",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o597",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/viseme/SS"
+      }
+    },
+    {
+      "id": "in-vis-nn",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/viseme/nn",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n598",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o599",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/viseme/nn"
+      }
+    },
+    {
+      "id": "in-vis-RR",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/viseme/RR",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n600",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o601",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/viseme/RR"
+      }
+    },
+    {
+      "id": "in-vis-aa",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/viseme/aa",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n602",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o603",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/viseme/aa"
+      }
+    },
+    {
+      "id": "in-vis-E",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/viseme/E",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n604",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o605",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/viseme/E"
+      }
+    },
+    {
+      "id": "in-vis-ih",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/viseme/ih",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n606",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o607",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/viseme/ih"
+      }
+    },
+    {
+      "id": "in-vis-oh",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/viseme/oh",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n608",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o609",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/viseme/oh"
+      }
+    },
+    {
+      "id": "in-vis-ou",
+      "type": "input",
+      "params": {
+        "path": "standard/ros4hri/viseme/ou",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n610",
+      "type": "damp",
+      "params": {
+        "half_life": 0.14
+      }
+    },
+    {
+      "id": "o611",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/viseme/ou"
+      }
+    },
+    {
+      "id": "blink-time",
+      "type": "time",
+      "params": {}
+    },
+    {
+      "id": "c612",
+      "type": "constant",
+      "params": {
+        "value": 8.0
+      }
+    },
+    {
+      "id": "n613",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "n614",
+      "type": "round",
+      "params": {
+        "round_mode": "floor"
+      }
+    },
+    {
+      "id": "n615",
+      "type": "simplenoise",
+      "params": {
+        "noise_seed": 7.0,
+        "frequency": 1.0,
+        "octaves": 1.0
+      }
+    },
+    {
+      "id": "c616",
+      "type": "constant",
+      "params": {
+        "value": 2.0
+      }
+    },
+    {
+      "id": "n617",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n618",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "n619",
+      "type": "modulo",
+      "params": {}
+    },
+    {
+      "id": "c620",
+      "type": "constant",
+      "params": {
+        "value": 0.2
+      }
+    },
+    {
+      "id": "n621",
+      "type": "divide",
+      "params": {}
+    },
+    {
+      "id": "c622",
+      "type": "constant",
+      "params": {
+        "value": 4.0
+      }
+    },
+    {
+      "id": "n623",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n624",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n625",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n626",
+      "type": "lessthan",
+      "params": {}
+    },
+    {
+      "id": "n627",
+      "type": "if",
+      "params": {}
+    },
+    {
+      "id": "n628",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "n629",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "n630",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "n631",
+      "type": "multiply",
+      "params": {}
+    },
+    {
+      "id": "n632",
+      "type": "max",
+      "params": {}
+    },
+    {
+      "id": "o633",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/left_eye_top_eyelid/pos/y"
+      }
+    },
+    {
+      "id": "o634",
+      "type": "output",
+      "params": {
+        "path": "standard/vizij/right_eye_top_eyelid/pos/y"
+      }
+    }
+  ],
+  "edges": [
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n3",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n3",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n3",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n4",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n4",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n8",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c6"
+      },
+      "to": {
+        "node_id": "n8",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n9",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c7"
+      },
+      "to": {
+        "node_id": "n9",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n8"
+      },
+      "to": {
+        "node_id": "n10",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n8"
+      },
+      "to": {
+        "node_id": "n10",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n9"
+      },
+      "to": {
+        "node_id": "n11",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n9"
+      },
+      "to": {
+        "node_id": "n11",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n10"
+      },
+      "to": {
+        "node_id": "n12",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n11"
+      },
+      "to": {
+        "node_id": "n12",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n12"
+      },
+      "to": {
+        "node_id": "n13",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n13",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n14",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n13"
+      },
+      "to": {
+        "node_id": "n14",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n14"
+      },
+      "to": {
+        "node_id": "n15",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n15",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n18",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c16"
+      },
+      "to": {
+        "node_id": "n18",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n19",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c17"
+      },
+      "to": {
+        "node_id": "n19",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n18"
+      },
+      "to": {
+        "node_id": "n20",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n18"
+      },
+      "to": {
+        "node_id": "n20",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n19"
+      },
+      "to": {
+        "node_id": "n21",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n19"
+      },
+      "to": {
+        "node_id": "n21",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n20"
+      },
+      "to": {
+        "node_id": "n22",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n21"
+      },
+      "to": {
+        "node_id": "n22",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n22"
+      },
+      "to": {
+        "node_id": "n23",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n23",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n24",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n23"
+      },
+      "to": {
+        "node_id": "n24",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n24"
+      },
+      "to": {
+        "node_id": "n25",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n25",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n28",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c26"
+      },
+      "to": {
+        "node_id": "n28",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n29",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c27"
+      },
+      "to": {
+        "node_id": "n29",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n28"
+      },
+      "to": {
+        "node_id": "n30",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n28"
+      },
+      "to": {
+        "node_id": "n30",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n29"
+      },
+      "to": {
+        "node_id": "n31",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n29"
+      },
+      "to": {
+        "node_id": "n31",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n30"
+      },
+      "to": {
+        "node_id": "n32",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n31"
+      },
+      "to": {
+        "node_id": "n32",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n32"
+      },
+      "to": {
+        "node_id": "n33",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n33",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n34",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n33"
+      },
+      "to": {
+        "node_id": "n34",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n34"
+      },
+      "to": {
+        "node_id": "n35",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n35",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n38",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c36"
+      },
+      "to": {
+        "node_id": "n38",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n39",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c37"
+      },
+      "to": {
+        "node_id": "n39",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n38"
+      },
+      "to": {
+        "node_id": "n40",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n38"
+      },
+      "to": {
+        "node_id": "n40",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n39"
+      },
+      "to": {
+        "node_id": "n41",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n39"
+      },
+      "to": {
+        "node_id": "n41",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n40"
+      },
+      "to": {
+        "node_id": "n42",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n41"
+      },
+      "to": {
+        "node_id": "n42",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n42"
+      },
+      "to": {
+        "node_id": "n43",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n43",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n44",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n43"
+      },
+      "to": {
+        "node_id": "n44",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n44"
+      },
+      "to": {
+        "node_id": "n45",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n45",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n48",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c46"
+      },
+      "to": {
+        "node_id": "n48",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n49",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c47"
+      },
+      "to": {
+        "node_id": "n49",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n48"
+      },
+      "to": {
+        "node_id": "n50",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n48"
+      },
+      "to": {
+        "node_id": "n50",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n49"
+      },
+      "to": {
+        "node_id": "n51",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n49"
+      },
+      "to": {
+        "node_id": "n51",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n50"
+      },
+      "to": {
+        "node_id": "n52",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n51"
+      },
+      "to": {
+        "node_id": "n52",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n52"
+      },
+      "to": {
+        "node_id": "n53",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n53",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n54",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n53"
+      },
+      "to": {
+        "node_id": "n54",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n54"
+      },
+      "to": {
+        "node_id": "n55",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n55",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n58",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c56"
+      },
+      "to": {
+        "node_id": "n58",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n59",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c57"
+      },
+      "to": {
+        "node_id": "n59",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n58"
+      },
+      "to": {
+        "node_id": "n60",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n58"
+      },
+      "to": {
+        "node_id": "n60",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n59"
+      },
+      "to": {
+        "node_id": "n61",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n59"
+      },
+      "to": {
+        "node_id": "n61",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n60"
+      },
+      "to": {
+        "node_id": "n62",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n61"
+      },
+      "to": {
+        "node_id": "n62",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n62"
+      },
+      "to": {
+        "node_id": "n63",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n63",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n64",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n63"
+      },
+      "to": {
+        "node_id": "n64",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n64"
+      },
+      "to": {
+        "node_id": "n65",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n65",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n68",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c66"
+      },
+      "to": {
+        "node_id": "n68",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n69",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c67"
+      },
+      "to": {
+        "node_id": "n69",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n68"
+      },
+      "to": {
+        "node_id": "n70",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n68"
+      },
+      "to": {
+        "node_id": "n70",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n69"
+      },
+      "to": {
+        "node_id": "n71",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n69"
+      },
+      "to": {
+        "node_id": "n71",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n70"
+      },
+      "to": {
+        "node_id": "n72",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n71"
+      },
+      "to": {
+        "node_id": "n72",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n72"
+      },
+      "to": {
+        "node_id": "n73",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n73",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n74",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n73"
+      },
+      "to": {
+        "node_id": "n74",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n74"
+      },
+      "to": {
+        "node_id": "n75",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n75",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n78",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c76"
+      },
+      "to": {
+        "node_id": "n78",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n79",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c77"
+      },
+      "to": {
+        "node_id": "n79",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n78"
+      },
+      "to": {
+        "node_id": "n80",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n78"
+      },
+      "to": {
+        "node_id": "n80",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n79"
+      },
+      "to": {
+        "node_id": "n81",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n79"
+      },
+      "to": {
+        "node_id": "n81",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n80"
+      },
+      "to": {
+        "node_id": "n82",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n81"
+      },
+      "to": {
+        "node_id": "n82",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n82"
+      },
+      "to": {
+        "node_id": "n83",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n83",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n84",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n83"
+      },
+      "to": {
+        "node_id": "n84",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n84"
+      },
+      "to": {
+        "node_id": "n85",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n85",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n88",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c86"
+      },
+      "to": {
+        "node_id": "n88",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n89",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c87"
+      },
+      "to": {
+        "node_id": "n89",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n88"
+      },
+      "to": {
+        "node_id": "n90",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n88"
+      },
+      "to": {
+        "node_id": "n90",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n89"
+      },
+      "to": {
+        "node_id": "n91",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n89"
+      },
+      "to": {
+        "node_id": "n91",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n90"
+      },
+      "to": {
+        "node_id": "n92",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n91"
+      },
+      "to": {
+        "node_id": "n92",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n92"
+      },
+      "to": {
+        "node_id": "n93",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n93",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n94",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n93"
+      },
+      "to": {
+        "node_id": "n94",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n94"
+      },
+      "to": {
+        "node_id": "n95",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n95",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n98",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c96"
+      },
+      "to": {
+        "node_id": "n98",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n99",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c97"
+      },
+      "to": {
+        "node_id": "n99",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n98"
+      },
+      "to": {
+        "node_id": "n100",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n98"
+      },
+      "to": {
+        "node_id": "n100",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n99"
+      },
+      "to": {
+        "node_id": "n101",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n99"
+      },
+      "to": {
+        "node_id": "n101",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n100"
+      },
+      "to": {
+        "node_id": "n102",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n101"
+      },
+      "to": {
+        "node_id": "n102",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n102"
+      },
+      "to": {
+        "node_id": "n103",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n103",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n104",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n103"
+      },
+      "to": {
+        "node_id": "n104",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n104"
+      },
+      "to": {
+        "node_id": "n105",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n105",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n108",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c106"
+      },
+      "to": {
+        "node_id": "n108",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n109",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c107"
+      },
+      "to": {
+        "node_id": "n109",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n108"
+      },
+      "to": {
+        "node_id": "n110",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n108"
+      },
+      "to": {
+        "node_id": "n110",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n109"
+      },
+      "to": {
+        "node_id": "n111",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n109"
+      },
+      "to": {
+        "node_id": "n111",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n110"
+      },
+      "to": {
+        "node_id": "n112",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n111"
+      },
+      "to": {
+        "node_id": "n112",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n112"
+      },
+      "to": {
+        "node_id": "n113",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n113",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n114",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n113"
+      },
+      "to": {
+        "node_id": "n114",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n114"
+      },
+      "to": {
+        "node_id": "n115",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n115",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n118",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c116"
+      },
+      "to": {
+        "node_id": "n118",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n119",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c117"
+      },
+      "to": {
+        "node_id": "n119",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n118"
+      },
+      "to": {
+        "node_id": "n120",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n118"
+      },
+      "to": {
+        "node_id": "n120",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n119"
+      },
+      "to": {
+        "node_id": "n121",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n119"
+      },
+      "to": {
+        "node_id": "n121",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n120"
+      },
+      "to": {
+        "node_id": "n122",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n121"
+      },
+      "to": {
+        "node_id": "n122",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n122"
+      },
+      "to": {
+        "node_id": "n123",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n123",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n124",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n123"
+      },
+      "to": {
+        "node_id": "n124",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n124"
+      },
+      "to": {
+        "node_id": "n125",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n125",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n128",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c126"
+      },
+      "to": {
+        "node_id": "n128",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n129",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c127"
+      },
+      "to": {
+        "node_id": "n129",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n128"
+      },
+      "to": {
+        "node_id": "n130",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n128"
+      },
+      "to": {
+        "node_id": "n130",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n129"
+      },
+      "to": {
+        "node_id": "n131",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n129"
+      },
+      "to": {
+        "node_id": "n131",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n130"
+      },
+      "to": {
+        "node_id": "n132",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n131"
+      },
+      "to": {
+        "node_id": "n132",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n132"
+      },
+      "to": {
+        "node_id": "n133",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n133",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n134",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n133"
+      },
+      "to": {
+        "node_id": "n134",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n134"
+      },
+      "to": {
+        "node_id": "n135",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n135",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n138",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c136"
+      },
+      "to": {
+        "node_id": "n138",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n139",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c137"
+      },
+      "to": {
+        "node_id": "n139",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n138"
+      },
+      "to": {
+        "node_id": "n140",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n138"
+      },
+      "to": {
+        "node_id": "n140",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n139"
+      },
+      "to": {
+        "node_id": "n141",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n139"
+      },
+      "to": {
+        "node_id": "n141",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n140"
+      },
+      "to": {
+        "node_id": "n142",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n141"
+      },
+      "to": {
+        "node_id": "n142",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n142"
+      },
+      "to": {
+        "node_id": "n143",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n143",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n144",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n143"
+      },
+      "to": {
+        "node_id": "n144",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n144"
+      },
+      "to": {
+        "node_id": "n145",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n145",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n148",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c146"
+      },
+      "to": {
+        "node_id": "n148",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n149",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c147"
+      },
+      "to": {
+        "node_id": "n149",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n148"
+      },
+      "to": {
+        "node_id": "n150",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n148"
+      },
+      "to": {
+        "node_id": "n150",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n149"
+      },
+      "to": {
+        "node_id": "n151",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n149"
+      },
+      "to": {
+        "node_id": "n151",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n150"
+      },
+      "to": {
+        "node_id": "n152",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n151"
+      },
+      "to": {
+        "node_id": "n152",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n152"
+      },
+      "to": {
+        "node_id": "n153",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n153",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n154",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n153"
+      },
+      "to": {
+        "node_id": "n154",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n154"
+      },
+      "to": {
+        "node_id": "n155",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n155",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n158",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c156"
+      },
+      "to": {
+        "node_id": "n158",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n159",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c157"
+      },
+      "to": {
+        "node_id": "n159",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n158"
+      },
+      "to": {
+        "node_id": "n160",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n158"
+      },
+      "to": {
+        "node_id": "n160",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n159"
+      },
+      "to": {
+        "node_id": "n161",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n159"
+      },
+      "to": {
+        "node_id": "n161",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n160"
+      },
+      "to": {
+        "node_id": "n162",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n161"
+      },
+      "to": {
+        "node_id": "n162",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n162"
+      },
+      "to": {
+        "node_id": "n163",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n163",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n164",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n163"
+      },
+      "to": {
+        "node_id": "n164",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n164"
+      },
+      "to": {
+        "node_id": "n165",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n165",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n168",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c166"
+      },
+      "to": {
+        "node_id": "n168",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n169",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c167"
+      },
+      "to": {
+        "node_id": "n169",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n168"
+      },
+      "to": {
+        "node_id": "n170",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n168"
+      },
+      "to": {
+        "node_id": "n170",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n169"
+      },
+      "to": {
+        "node_id": "n171",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n169"
+      },
+      "to": {
+        "node_id": "n171",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n170"
+      },
+      "to": {
+        "node_id": "n172",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n171"
+      },
+      "to": {
+        "node_id": "n172",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n172"
+      },
+      "to": {
+        "node_id": "n173",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n173",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n174",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n173"
+      },
+      "to": {
+        "node_id": "n174",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n174"
+      },
+      "to": {
+        "node_id": "n175",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n175",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n178",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c176"
+      },
+      "to": {
+        "node_id": "n178",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n179",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c177"
+      },
+      "to": {
+        "node_id": "n179",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n178"
+      },
+      "to": {
+        "node_id": "n180",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n178"
+      },
+      "to": {
+        "node_id": "n180",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n179"
+      },
+      "to": {
+        "node_id": "n181",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n179"
+      },
+      "to": {
+        "node_id": "n181",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n180"
+      },
+      "to": {
+        "node_id": "n182",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n181"
+      },
+      "to": {
+        "node_id": "n182",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n182"
+      },
+      "to": {
+        "node_id": "n183",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n183",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n184",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n183"
+      },
+      "to": {
+        "node_id": "n184",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n184"
+      },
+      "to": {
+        "node_id": "n185",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n185",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n188",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c186"
+      },
+      "to": {
+        "node_id": "n188",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n189",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c187"
+      },
+      "to": {
+        "node_id": "n189",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n188"
+      },
+      "to": {
+        "node_id": "n190",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n188"
+      },
+      "to": {
+        "node_id": "n190",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n189"
+      },
+      "to": {
+        "node_id": "n191",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n189"
+      },
+      "to": {
+        "node_id": "n191",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n190"
+      },
+      "to": {
+        "node_id": "n192",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n191"
+      },
+      "to": {
+        "node_id": "n192",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n192"
+      },
+      "to": {
+        "node_id": "n193",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n193",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n194",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n193"
+      },
+      "to": {
+        "node_id": "n194",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n194"
+      },
+      "to": {
+        "node_id": "n195",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n195",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n198",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c196"
+      },
+      "to": {
+        "node_id": "n198",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n199",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c197"
+      },
+      "to": {
+        "node_id": "n199",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n198"
+      },
+      "to": {
+        "node_id": "n200",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n198"
+      },
+      "to": {
+        "node_id": "n200",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n199"
+      },
+      "to": {
+        "node_id": "n201",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n199"
+      },
+      "to": {
+        "node_id": "n201",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n200"
+      },
+      "to": {
+        "node_id": "n202",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n201"
+      },
+      "to": {
+        "node_id": "n202",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n202"
+      },
+      "to": {
+        "node_id": "n203",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n203",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n204",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n203"
+      },
+      "to": {
+        "node_id": "n204",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n204"
+      },
+      "to": {
+        "node_id": "n205",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n205",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n208",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c206"
+      },
+      "to": {
+        "node_id": "n208",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n209",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c207"
+      },
+      "to": {
+        "node_id": "n209",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n208"
+      },
+      "to": {
+        "node_id": "n210",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n208"
+      },
+      "to": {
+        "node_id": "n210",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n209"
+      },
+      "to": {
+        "node_id": "n211",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n209"
+      },
+      "to": {
+        "node_id": "n211",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n210"
+      },
+      "to": {
+        "node_id": "n212",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n211"
+      },
+      "to": {
+        "node_id": "n212",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n212"
+      },
+      "to": {
+        "node_id": "n213",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n213",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n214",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n213"
+      },
+      "to": {
+        "node_id": "n214",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n214"
+      },
+      "to": {
+        "node_id": "n215",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n215",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n218",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c216"
+      },
+      "to": {
+        "node_id": "n218",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n219",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c217"
+      },
+      "to": {
+        "node_id": "n219",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n218"
+      },
+      "to": {
+        "node_id": "n220",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n218"
+      },
+      "to": {
+        "node_id": "n220",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n219"
+      },
+      "to": {
+        "node_id": "n221",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n219"
+      },
+      "to": {
+        "node_id": "n221",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n220"
+      },
+      "to": {
+        "node_id": "n222",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n221"
+      },
+      "to": {
+        "node_id": "n222",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n222"
+      },
+      "to": {
+        "node_id": "n223",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n223",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n224",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n223"
+      },
+      "to": {
+        "node_id": "n224",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n224"
+      },
+      "to": {
+        "node_id": "n225",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n225",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n228",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c226"
+      },
+      "to": {
+        "node_id": "n228",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n229",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c227"
+      },
+      "to": {
+        "node_id": "n229",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n228"
+      },
+      "to": {
+        "node_id": "n230",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n228"
+      },
+      "to": {
+        "node_id": "n230",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n229"
+      },
+      "to": {
+        "node_id": "n231",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n229"
+      },
+      "to": {
+        "node_id": "n231",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n230"
+      },
+      "to": {
+        "node_id": "n232",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n231"
+      },
+      "to": {
+        "node_id": "n232",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n232"
+      },
+      "to": {
+        "node_id": "n233",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n233",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n234",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n233"
+      },
+      "to": {
+        "node_id": "n234",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n234"
+      },
+      "to": {
+        "node_id": "n235",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n235",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n238",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c236"
+      },
+      "to": {
+        "node_id": "n238",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n239",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c237"
+      },
+      "to": {
+        "node_id": "n239",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n238"
+      },
+      "to": {
+        "node_id": "n240",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n238"
+      },
+      "to": {
+        "node_id": "n240",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n239"
+      },
+      "to": {
+        "node_id": "n241",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n239"
+      },
+      "to": {
+        "node_id": "n241",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n240"
+      },
+      "to": {
+        "node_id": "n242",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n241"
+      },
+      "to": {
+        "node_id": "n242",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n242"
+      },
+      "to": {
+        "node_id": "n243",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n243",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n244",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n243"
+      },
+      "to": {
+        "node_id": "n244",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n244"
+      },
+      "to": {
+        "node_id": "n245",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n245",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n248",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c246"
+      },
+      "to": {
+        "node_id": "n248",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n249",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c247"
+      },
+      "to": {
+        "node_id": "n249",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n248"
+      },
+      "to": {
+        "node_id": "n250",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n248"
+      },
+      "to": {
+        "node_id": "n250",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n249"
+      },
+      "to": {
+        "node_id": "n251",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n249"
+      },
+      "to": {
+        "node_id": "n251",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n250"
+      },
+      "to": {
+        "node_id": "n252",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n251"
+      },
+      "to": {
+        "node_id": "n252",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n252"
+      },
+      "to": {
+        "node_id": "n253",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n253",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n254",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n253"
+      },
+      "to": {
+        "node_id": "n254",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n254"
+      },
+      "to": {
+        "node_id": "n255",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n255",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n15"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n25"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n35"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_2"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n45"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_3"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n55"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_4"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n65"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_5"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n75"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_6"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n85"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_7"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n95"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_8"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n105"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_9"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n115"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_10"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n125"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_11"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n135"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_12"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n145"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_13"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n155"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_14"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n165"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_15"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n175"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_16"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n185"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_17"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n195"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_18"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n205"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_19"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n215"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_20"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n225"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_21"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n235"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_22"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n245"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_23"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n255"
+      },
+      "to": {
+        "node_id": "n256",
+        "input": "operand_24"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n256"
+      },
+      "to": {
+        "node_id": "n258",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c257"
+      },
+      "to": {
+        "node_id": "n258",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n259",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-valence"
+      },
+      "to": {
+        "node_id": "n259",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n260",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-arousal"
+      },
+      "to": {
+        "node_id": "n260",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n259"
+      },
+      "to": {
+        "node_id": "n261",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n260"
+      },
+      "to": {
+        "node_id": "n261",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n261"
+      },
+      "to": {
+        "node_id": "n263",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c262"
+      },
+      "to": {
+        "node_id": "n263",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n263"
+      },
+      "to": {
+        "node_id": "n266",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c264"
+      },
+      "to": {
+        "node_id": "n266",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c265"
+      },
+      "to": {
+        "node_id": "n266",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n267",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n267",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n268",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n268",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n268",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n269",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n268"
+      },
+      "to": {
+        "node_id": "n269",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n15"
+      },
+      "to": {
+        "node_id": "n270",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n270",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n271",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n270"
+      },
+      "to": {
+        "node_id": "n271",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n271"
+      },
+      "to": {
+        "node_id": "n272",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n267"
+      },
+      "to": {
+        "node_id": "n272",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n273",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n272"
+      },
+      "to": {
+        "node_id": "n273",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n269"
+      },
+      "to": {
+        "node_id": "n274",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n273"
+      },
+      "to": {
+        "node_id": "n274",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n274"
+      },
+      "to": {
+        "node_id": "n275",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n275"
+      },
+      "to": {
+        "node_id": "o276",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n277",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n277",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n277",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n278",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n277"
+      },
+      "to": {
+        "node_id": "n278",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n25"
+      },
+      "to": {
+        "node_id": "n279",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n279",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n280",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n279"
+      },
+      "to": {
+        "node_id": "n280",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n281",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n280"
+      },
+      "to": {
+        "node_id": "n281",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n278"
+      },
+      "to": {
+        "node_id": "n282",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n281"
+      },
+      "to": {
+        "node_id": "n282",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n282"
+      },
+      "to": {
+        "node_id": "n283",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n283"
+      },
+      "to": {
+        "node_id": "o284",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n285",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n285",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n285",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n286",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n285"
+      },
+      "to": {
+        "node_id": "n286",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n35"
+      },
+      "to": {
+        "node_id": "n287",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n287",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n288",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n287"
+      },
+      "to": {
+        "node_id": "n288",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n289",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n288"
+      },
+      "to": {
+        "node_id": "n289",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n286"
+      },
+      "to": {
+        "node_id": "n290",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n289"
+      },
+      "to": {
+        "node_id": "n290",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n290"
+      },
+      "to": {
+        "node_id": "n291",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n291"
+      },
+      "to": {
+        "node_id": "o292",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n293",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n293",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n293",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n294",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n293"
+      },
+      "to": {
+        "node_id": "n294",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n45"
+      },
+      "to": {
+        "node_id": "n295",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n295",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n296",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n295"
+      },
+      "to": {
+        "node_id": "n296",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n297",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n296"
+      },
+      "to": {
+        "node_id": "n297",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n294"
+      },
+      "to": {
+        "node_id": "n298",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n297"
+      },
+      "to": {
+        "node_id": "n298",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n298"
+      },
+      "to": {
+        "node_id": "n299",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n299"
+      },
+      "to": {
+        "node_id": "o300",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n301",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n301",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n301",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n302",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n301"
+      },
+      "to": {
+        "node_id": "n302",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n55"
+      },
+      "to": {
+        "node_id": "n303",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n303",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n304",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n303"
+      },
+      "to": {
+        "node_id": "n304",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n305",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n304"
+      },
+      "to": {
+        "node_id": "n305",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n302"
+      },
+      "to": {
+        "node_id": "n306",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n305"
+      },
+      "to": {
+        "node_id": "n306",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n306"
+      },
+      "to": {
+        "node_id": "n307",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n307"
+      },
+      "to": {
+        "node_id": "o308",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n309",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n309",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n309",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n310",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n309"
+      },
+      "to": {
+        "node_id": "n310",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n65"
+      },
+      "to": {
+        "node_id": "n311",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n311",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n312",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n311"
+      },
+      "to": {
+        "node_id": "n312",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n313",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n312"
+      },
+      "to": {
+        "node_id": "n313",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n310"
+      },
+      "to": {
+        "node_id": "n314",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n313"
+      },
+      "to": {
+        "node_id": "n314",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n314"
+      },
+      "to": {
+        "node_id": "n315",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n315"
+      },
+      "to": {
+        "node_id": "o316",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n317",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n317",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n317",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n318",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n317"
+      },
+      "to": {
+        "node_id": "n318",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n75"
+      },
+      "to": {
+        "node_id": "n319",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n319",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n320",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n319"
+      },
+      "to": {
+        "node_id": "n320",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n321",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n320"
+      },
+      "to": {
+        "node_id": "n321",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n318"
+      },
+      "to": {
+        "node_id": "n322",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n321"
+      },
+      "to": {
+        "node_id": "n322",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n322"
+      },
+      "to": {
+        "node_id": "n323",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n323"
+      },
+      "to": {
+        "node_id": "o324",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n325",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n325",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n325",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n326",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n325"
+      },
+      "to": {
+        "node_id": "n326",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n85"
+      },
+      "to": {
+        "node_id": "n327",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n327",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n328",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n327"
+      },
+      "to": {
+        "node_id": "n328",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n329",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n328"
+      },
+      "to": {
+        "node_id": "n329",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n326"
+      },
+      "to": {
+        "node_id": "n330",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n329"
+      },
+      "to": {
+        "node_id": "n330",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n330"
+      },
+      "to": {
+        "node_id": "n331",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n331"
+      },
+      "to": {
+        "node_id": "o332",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n333",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n333",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n333",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n334",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n333"
+      },
+      "to": {
+        "node_id": "n334",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n95"
+      },
+      "to": {
+        "node_id": "n335",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n335",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n336",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n335"
+      },
+      "to": {
+        "node_id": "n336",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n337",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n336"
+      },
+      "to": {
+        "node_id": "n337",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n334"
+      },
+      "to": {
+        "node_id": "n338",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n337"
+      },
+      "to": {
+        "node_id": "n338",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n338"
+      },
+      "to": {
+        "node_id": "n339",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n339"
+      },
+      "to": {
+        "node_id": "o340",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n341",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n341",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n341",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n342",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n341"
+      },
+      "to": {
+        "node_id": "n342",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n105"
+      },
+      "to": {
+        "node_id": "n343",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n343",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n344",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n343"
+      },
+      "to": {
+        "node_id": "n344",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n345",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n344"
+      },
+      "to": {
+        "node_id": "n345",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n342"
+      },
+      "to": {
+        "node_id": "n346",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n345"
+      },
+      "to": {
+        "node_id": "n346",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n346"
+      },
+      "to": {
+        "node_id": "n347",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n347"
+      },
+      "to": {
+        "node_id": "o348",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n349",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n349",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n349",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n350",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n349"
+      },
+      "to": {
+        "node_id": "n350",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n115"
+      },
+      "to": {
+        "node_id": "n351",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n351",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n352",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n351"
+      },
+      "to": {
+        "node_id": "n352",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n353",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n352"
+      },
+      "to": {
+        "node_id": "n353",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n350"
+      },
+      "to": {
+        "node_id": "n354",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n353"
+      },
+      "to": {
+        "node_id": "n354",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n354"
+      },
+      "to": {
+        "node_id": "n355",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n355"
+      },
+      "to": {
+        "node_id": "o356",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n357",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n357",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n357",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n358",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n357"
+      },
+      "to": {
+        "node_id": "n358",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n125"
+      },
+      "to": {
+        "node_id": "n359",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n359",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n360",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n359"
+      },
+      "to": {
+        "node_id": "n360",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n361",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n360"
+      },
+      "to": {
+        "node_id": "n361",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n358"
+      },
+      "to": {
+        "node_id": "n362",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n361"
+      },
+      "to": {
+        "node_id": "n362",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n362"
+      },
+      "to": {
+        "node_id": "n363",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n363"
+      },
+      "to": {
+        "node_id": "o364",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n365",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n365",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n365",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n366",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n365"
+      },
+      "to": {
+        "node_id": "n366",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n135"
+      },
+      "to": {
+        "node_id": "n367",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n367",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n368",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n367"
+      },
+      "to": {
+        "node_id": "n368",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n369",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n368"
+      },
+      "to": {
+        "node_id": "n369",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n366"
+      },
+      "to": {
+        "node_id": "n370",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n369"
+      },
+      "to": {
+        "node_id": "n370",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n370"
+      },
+      "to": {
+        "node_id": "n371",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n371"
+      },
+      "to": {
+        "node_id": "o372",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n373",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n373",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n373",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n374",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n373"
+      },
+      "to": {
+        "node_id": "n374",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n145"
+      },
+      "to": {
+        "node_id": "n375",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n375",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n376",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n375"
+      },
+      "to": {
+        "node_id": "n376",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n377",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n376"
+      },
+      "to": {
+        "node_id": "n377",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n374"
+      },
+      "to": {
+        "node_id": "n378",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n377"
+      },
+      "to": {
+        "node_id": "n378",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n378"
+      },
+      "to": {
+        "node_id": "n379",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n379"
+      },
+      "to": {
+        "node_id": "o380",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n381",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n381",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n381",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n382",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n381"
+      },
+      "to": {
+        "node_id": "n382",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n155"
+      },
+      "to": {
+        "node_id": "n383",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n383",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n384",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n383"
+      },
+      "to": {
+        "node_id": "n384",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n385",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n384"
+      },
+      "to": {
+        "node_id": "n385",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n382"
+      },
+      "to": {
+        "node_id": "n386",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n385"
+      },
+      "to": {
+        "node_id": "n386",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n386"
+      },
+      "to": {
+        "node_id": "n387",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n387"
+      },
+      "to": {
+        "node_id": "o388",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n389",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n389",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n389",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n390",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n389"
+      },
+      "to": {
+        "node_id": "n390",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n165"
+      },
+      "to": {
+        "node_id": "n391",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n391",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n392",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n391"
+      },
+      "to": {
+        "node_id": "n392",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n393",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n392"
+      },
+      "to": {
+        "node_id": "n393",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n390"
+      },
+      "to": {
+        "node_id": "n394",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n393"
+      },
+      "to": {
+        "node_id": "n394",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n394"
+      },
+      "to": {
+        "node_id": "n395",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n395"
+      },
+      "to": {
+        "node_id": "o396",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n397",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n397",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n397",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n398",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n397"
+      },
+      "to": {
+        "node_id": "n398",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n175"
+      },
+      "to": {
+        "node_id": "n399",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n399",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n400",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n399"
+      },
+      "to": {
+        "node_id": "n400",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n401",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n400"
+      },
+      "to": {
+        "node_id": "n401",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n398"
+      },
+      "to": {
+        "node_id": "n402",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n401"
+      },
+      "to": {
+        "node_id": "n402",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n402"
+      },
+      "to": {
+        "node_id": "n403",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n403"
+      },
+      "to": {
+        "node_id": "o404",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n405",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n405",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n405",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n406",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n405"
+      },
+      "to": {
+        "node_id": "n406",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n185"
+      },
+      "to": {
+        "node_id": "n407",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n407",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n408",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n407"
+      },
+      "to": {
+        "node_id": "n408",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n409",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n408"
+      },
+      "to": {
+        "node_id": "n409",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n406"
+      },
+      "to": {
+        "node_id": "n410",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n409"
+      },
+      "to": {
+        "node_id": "n410",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n410"
+      },
+      "to": {
+        "node_id": "n411",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n411"
+      },
+      "to": {
+        "node_id": "o412",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n413",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n413",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n413",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n414",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n413"
+      },
+      "to": {
+        "node_id": "n414",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n195"
+      },
+      "to": {
+        "node_id": "n415",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n415",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n416",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n415"
+      },
+      "to": {
+        "node_id": "n416",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n417",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n416"
+      },
+      "to": {
+        "node_id": "n417",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n414"
+      },
+      "to": {
+        "node_id": "n418",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n417"
+      },
+      "to": {
+        "node_id": "n418",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n418"
+      },
+      "to": {
+        "node_id": "n419",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n419"
+      },
+      "to": {
+        "node_id": "o420",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n421",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n421",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n421",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n422",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n421"
+      },
+      "to": {
+        "node_id": "n422",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n205"
+      },
+      "to": {
+        "node_id": "n423",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n423",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n424",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n423"
+      },
+      "to": {
+        "node_id": "n424",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n425",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n424"
+      },
+      "to": {
+        "node_id": "n425",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n422"
+      },
+      "to": {
+        "node_id": "n426",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n425"
+      },
+      "to": {
+        "node_id": "n426",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n426"
+      },
+      "to": {
+        "node_id": "n427",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n427"
+      },
+      "to": {
+        "node_id": "o428",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n429",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n429",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n429",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n430",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n429"
+      },
+      "to": {
+        "node_id": "n430",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n215"
+      },
+      "to": {
+        "node_id": "n431",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n431",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n432",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n431"
+      },
+      "to": {
+        "node_id": "n432",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n433",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n432"
+      },
+      "to": {
+        "node_id": "n433",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n430"
+      },
+      "to": {
+        "node_id": "n434",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n433"
+      },
+      "to": {
+        "node_id": "n434",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n434"
+      },
+      "to": {
+        "node_id": "n435",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n435"
+      },
+      "to": {
+        "node_id": "o436",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n437",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n437",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n437",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n438",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n437"
+      },
+      "to": {
+        "node_id": "n438",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n225"
+      },
+      "to": {
+        "node_id": "n439",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n439",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n440",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n439"
+      },
+      "to": {
+        "node_id": "n440",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n441",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n440"
+      },
+      "to": {
+        "node_id": "n441",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n438"
+      },
+      "to": {
+        "node_id": "n442",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n441"
+      },
+      "to": {
+        "node_id": "n442",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n442"
+      },
+      "to": {
+        "node_id": "n443",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n443"
+      },
+      "to": {
+        "node_id": "o444",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n445",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n445",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n445",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n446",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n445"
+      },
+      "to": {
+        "node_id": "n446",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n235"
+      },
+      "to": {
+        "node_id": "n447",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n447",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n448",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n447"
+      },
+      "to": {
+        "node_id": "n448",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n449",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n448"
+      },
+      "to": {
+        "node_id": "n449",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n446"
+      },
+      "to": {
+        "node_id": "n450",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n449"
+      },
+      "to": {
+        "node_id": "n450",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n450"
+      },
+      "to": {
+        "node_id": "n451",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n451"
+      },
+      "to": {
+        "node_id": "o452",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n453",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n453",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n453",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n454",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n453"
+      },
+      "to": {
+        "node_id": "n454",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n245"
+      },
+      "to": {
+        "node_id": "n455",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n455",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n456",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n455"
+      },
+      "to": {
+        "node_id": "n456",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n457",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n456"
+      },
+      "to": {
+        "node_id": "n457",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n454"
+      },
+      "to": {
+        "node_id": "n458",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n457"
+      },
+      "to": {
+        "node_id": "n458",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n458"
+      },
+      "to": {
+        "node_id": "n459",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n459"
+      },
+      "to": {
+        "node_id": "o460",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-name"
+      },
+      "to": {
+        "node_id": "n461",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n461",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n461",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "n462",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n461"
+      },
+      "to": {
+        "node_id": "n462",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n255"
+      },
+      "to": {
+        "node_id": "n463",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n258"
+      },
+      "to": {
+        "node_id": "n463",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n266"
+      },
+      "to": {
+        "node_id": "n464",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n463"
+      },
+      "to": {
+        "node_id": "n464",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n4"
+      },
+      "to": {
+        "node_id": "n465",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n464"
+      },
+      "to": {
+        "node_id": "n465",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n462"
+      },
+      "to": {
+        "node_id": "n466",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n465"
+      },
+      "to": {
+        "node_id": "n466",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n466"
+      },
+      "to": {
+        "node_id": "n467",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n467"
+      },
+      "to": {
+        "node_id": "o468",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-gaze"
+      },
+      "to": {
+        "node_id": "n472",
+        "input": "v"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c469"
+      },
+      "to": {
+        "node_id": "n472",
+        "input": "index"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-gaze"
+      },
+      "to": {
+        "node_id": "n473",
+        "input": "v"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c470"
+      },
+      "to": {
+        "node_id": "n473",
+        "input": "index"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-gaze"
+      },
+      "to": {
+        "node_id": "n474",
+        "input": "v"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c471"
+      },
+      "to": {
+        "node_id": "n474",
+        "input": "index"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n472"
+      },
+      "to": {
+        "node_id": "n476",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c475"
+      },
+      "to": {
+        "node_id": "n476",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n473"
+      },
+      "to": {
+        "node_id": "n478",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c477"
+      },
+      "to": {
+        "node_id": "n478",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n473"
+      },
+      "to": {
+        "node_id": "n479",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c477"
+      },
+      "to": {
+        "node_id": "n479",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n478"
+      },
+      "to": {
+        "node_id": "n480",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n472"
+      },
+      "to": {
+        "node_id": "n480",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n480"
+      },
+      "to": {
+        "node_id": "n481",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n480"
+      },
+      "to": {
+        "node_id": "n481",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n481"
+      },
+      "to": {
+        "node_id": "n483",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c482"
+      },
+      "to": {
+        "node_id": "n483",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n483"
+      },
+      "to": {
+        "node_id": "n485",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c484"
+      },
+      "to": {
+        "node_id": "n485",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n480"
+      },
+      "to": {
+        "node_id": "n486",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n485"
+      },
+      "to": {
+        "node_id": "n486",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n486"
+      },
+      "to": {
+        "node_id": "n488",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c487"
+      },
+      "to": {
+        "node_id": "n488",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n488"
+      },
+      "to": {
+        "node_id": "n491",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c489"
+      },
+      "to": {
+        "node_id": "n491",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c490"
+      },
+      "to": {
+        "node_id": "n491",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n479"
+      },
+      "to": {
+        "node_id": "n492",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n472"
+      },
+      "to": {
+        "node_id": "n492",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n492"
+      },
+      "to": {
+        "node_id": "n493",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n492"
+      },
+      "to": {
+        "node_id": "n493",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n493"
+      },
+      "to": {
+        "node_id": "n495",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c494"
+      },
+      "to": {
+        "node_id": "n495",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n495"
+      },
+      "to": {
+        "node_id": "n497",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c496"
+      },
+      "to": {
+        "node_id": "n497",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n492"
+      },
+      "to": {
+        "node_id": "n498",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n497"
+      },
+      "to": {
+        "node_id": "n498",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n498"
+      },
+      "to": {
+        "node_id": "n500",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c499"
+      },
+      "to": {
+        "node_id": "n500",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n500"
+      },
+      "to": {
+        "node_id": "n503",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c501"
+      },
+      "to": {
+        "node_id": "n503",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c502"
+      },
+      "to": {
+        "node_id": "n503",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n474"
+      },
+      "to": {
+        "node_id": "n504",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n472"
+      },
+      "to": {
+        "node_id": "n504",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n504"
+      },
+      "to": {
+        "node_id": "n505",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n504"
+      },
+      "to": {
+        "node_id": "n505",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n505"
+      },
+      "to": {
+        "node_id": "n507",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c506"
+      },
+      "to": {
+        "node_id": "n507",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n507"
+      },
+      "to": {
+        "node_id": "n509",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c508"
+      },
+      "to": {
+        "node_id": "n509",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n504"
+      },
+      "to": {
+        "node_id": "n510",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n509"
+      },
+      "to": {
+        "node_id": "n510",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n510"
+      },
+      "to": {
+        "node_id": "n512",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c511"
+      },
+      "to": {
+        "node_id": "n512",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n512"
+      },
+      "to": {
+        "node_id": "n515",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c513"
+      },
+      "to": {
+        "node_id": "n515",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c514"
+      },
+      "to": {
+        "node_id": "n515",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n476"
+      },
+      "to": {
+        "node_id": "n516",
+        "input": "cond"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n491"
+      },
+      "to": {
+        "node_id": "n516",
+        "input": "then"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n516",
+        "input": "else"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n476"
+      },
+      "to": {
+        "node_id": "n517",
+        "input": "cond"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n515"
+      },
+      "to": {
+        "node_id": "n517",
+        "input": "then"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n517",
+        "input": "else"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n516"
+      },
+      "to": {
+        "node_id": "n518",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n517"
+      },
+      "to": {
+        "node_id": "n519",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n518"
+      },
+      "to": {
+        "node_id": "o520",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n519"
+      },
+      "to": {
+        "node_id": "o521",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n476"
+      },
+      "to": {
+        "node_id": "n522",
+        "input": "cond"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n503"
+      },
+      "to": {
+        "node_id": "n522",
+        "input": "then"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n522",
+        "input": "else"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n476"
+      },
+      "to": {
+        "node_id": "n523",
+        "input": "cond"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n515"
+      },
+      "to": {
+        "node_id": "n523",
+        "input": "then"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n523",
+        "input": "else"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n522"
+      },
+      "to": {
+        "node_id": "n524",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n523"
+      },
+      "to": {
+        "node_id": "n525",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n524"
+      },
+      "to": {
+        "node_id": "o526",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n525"
+      },
+      "to": {
+        "node_id": "o527",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-au-1"
+      },
+      "to": {
+        "node_id": "n528",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n528"
+      },
+      "to": {
+        "node_id": "o529",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-au-2"
+      },
+      "to": {
+        "node_id": "n530",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n530"
+      },
+      "to": {
+        "node_id": "o531",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n530"
+      },
+      "to": {
+        "node_id": "o532",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-au-4"
+      },
+      "to": {
+        "node_id": "n533",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n533"
+      },
+      "to": {
+        "node_id": "o534",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n533"
+      },
+      "to": {
+        "node_id": "o535",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-au-5"
+      },
+      "to": {
+        "node_id": "n536",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n536"
+      },
+      "to": {
+        "node_id": "o537",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n536"
+      },
+      "to": {
+        "node_id": "o538",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-au-6"
+      },
+      "to": {
+        "node_id": "n539",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n539"
+      },
+      "to": {
+        "node_id": "o540",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n539"
+      },
+      "to": {
+        "node_id": "o541",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-au-7"
+      },
+      "to": {
+        "node_id": "n542",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n542"
+      },
+      "to": {
+        "node_id": "o543",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n542"
+      },
+      "to": {
+        "node_id": "o544",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-au-9"
+      },
+      "to": {
+        "node_id": "n545",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n545"
+      },
+      "to": {
+        "node_id": "o546",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n545"
+      },
+      "to": {
+        "node_id": "o547",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-au-10"
+      },
+      "to": {
+        "node_id": "n548",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n548"
+      },
+      "to": {
+        "node_id": "o549",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n548"
+      },
+      "to": {
+        "node_id": "o550",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-au-12"
+      },
+      "to": {
+        "node_id": "n551",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n551"
+      },
+      "to": {
+        "node_id": "o552",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n551"
+      },
+      "to": {
+        "node_id": "o553",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-au-15"
+      },
+      "to": {
+        "node_id": "n554",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n554"
+      },
+      "to": {
+        "node_id": "o555",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n554"
+      },
+      "to": {
+        "node_id": "o556",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-au-16"
+      },
+      "to": {
+        "node_id": "n557",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n557"
+      },
+      "to": {
+        "node_id": "o558",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n557"
+      },
+      "to": {
+        "node_id": "o559",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-au-18"
+      },
+      "to": {
+        "node_id": "n560",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n560"
+      },
+      "to": {
+        "node_id": "o561",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-au-19"
+      },
+      "to": {
+        "node_id": "n562",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n562"
+      },
+      "to": {
+        "node_id": "o563",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-au-20"
+      },
+      "to": {
+        "node_id": "n564",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n564"
+      },
+      "to": {
+        "node_id": "o565",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n564"
+      },
+      "to": {
+        "node_id": "o566",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-au-22"
+      },
+      "to": {
+        "node_id": "n567",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n567"
+      },
+      "to": {
+        "node_id": "o568",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-au-24"
+      },
+      "to": {
+        "node_id": "n569",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n569"
+      },
+      "to": {
+        "node_id": "o570",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n569"
+      },
+      "to": {
+        "node_id": "o571",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-au-26"
+      },
+      "to": {
+        "node_id": "n572",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n572"
+      },
+      "to": {
+        "node_id": "o573",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n572"
+      },
+      "to": {
+        "node_id": "o574",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-au-29"
+      },
+      "to": {
+        "node_id": "n575",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n575"
+      },
+      "to": {
+        "node_id": "o576",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-au-34"
+      },
+      "to": {
+        "node_id": "n577",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n577"
+      },
+      "to": {
+        "node_id": "o578",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-au-43"
+      },
+      "to": {
+        "node_id": "n579",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n579"
+      },
+      "to": {
+        "node_id": "o580",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n579"
+      },
+      "to": {
+        "node_id": "o581",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-vis-sil"
+      },
+      "to": {
+        "node_id": "n582",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n582"
+      },
+      "to": {
+        "node_id": "o583",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-vis-PP"
+      },
+      "to": {
+        "node_id": "n584",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n584"
+      },
+      "to": {
+        "node_id": "o585",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-vis-FF"
+      },
+      "to": {
+        "node_id": "n586",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n586"
+      },
+      "to": {
+        "node_id": "o587",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-vis-TH"
+      },
+      "to": {
+        "node_id": "n588",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n588"
+      },
+      "to": {
+        "node_id": "o589",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-vis-DD"
+      },
+      "to": {
+        "node_id": "n590",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n590"
+      },
+      "to": {
+        "node_id": "o591",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-vis-kk"
+      },
+      "to": {
+        "node_id": "n592",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n592"
+      },
+      "to": {
+        "node_id": "o593",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-vis-CH"
+      },
+      "to": {
+        "node_id": "n594",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n594"
+      },
+      "to": {
+        "node_id": "o595",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-vis-SS"
+      },
+      "to": {
+        "node_id": "n596",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n596"
+      },
+      "to": {
+        "node_id": "o597",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-vis-nn"
+      },
+      "to": {
+        "node_id": "n598",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n598"
+      },
+      "to": {
+        "node_id": "o599",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-vis-RR"
+      },
+      "to": {
+        "node_id": "n600",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n600"
+      },
+      "to": {
+        "node_id": "o601",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-vis-aa"
+      },
+      "to": {
+        "node_id": "n602",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n602"
+      },
+      "to": {
+        "node_id": "o603",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-vis-E"
+      },
+      "to": {
+        "node_id": "n604",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n604"
+      },
+      "to": {
+        "node_id": "o605",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-vis-ih"
+      },
+      "to": {
+        "node_id": "n606",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n606"
+      },
+      "to": {
+        "node_id": "o607",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-vis-oh"
+      },
+      "to": {
+        "node_id": "n608",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n608"
+      },
+      "to": {
+        "node_id": "o609",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-vis-ou"
+      },
+      "to": {
+        "node_id": "n610",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n610"
+      },
+      "to": {
+        "node_id": "o611",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "blink-time"
+      },
+      "to": {
+        "node_id": "n613",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c612"
+      },
+      "to": {
+        "node_id": "n613",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n613"
+      },
+      "to": {
+        "node_id": "n614",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n614"
+      },
+      "to": {
+        "node_id": "n615",
+        "input": "x"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n615",
+        "input": "y"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n615"
+      },
+      "to": {
+        "node_id": "n617",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c616"
+      },
+      "to": {
+        "node_id": "n617",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "blink-time"
+      },
+      "to": {
+        "node_id": "n618",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n617"
+      },
+      "to": {
+        "node_id": "n618",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n618"
+      },
+      "to": {
+        "node_id": "n619",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c612"
+      },
+      "to": {
+        "node_id": "n619",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n619"
+      },
+      "to": {
+        "node_id": "n621",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c620"
+      },
+      "to": {
+        "node_id": "n621",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c622"
+      },
+      "to": {
+        "node_id": "n623",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n621"
+      },
+      "to": {
+        "node_id": "n623",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n624",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n621"
+      },
+      "to": {
+        "node_id": "n624",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n623"
+      },
+      "to": {
+        "node_id": "n625",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n624"
+      },
+      "to": {
+        "node_id": "n625",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n621"
+      },
+      "to": {
+        "node_id": "n626",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n626",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n626"
+      },
+      "to": {
+        "node_id": "n627",
+        "input": "cond"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n625"
+      },
+      "to": {
+        "node_id": "n627",
+        "input": "then"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n627",
+        "input": "else"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n627"
+      },
+      "to": {
+        "node_id": "n628",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "n628",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n628",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n579"
+      },
+      "to": {
+        "node_id": "n629",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n443"
+      },
+      "to": {
+        "node_id": "n629",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c2"
+      },
+      "to": {
+        "node_id": "n630",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n629"
+      },
+      "to": {
+        "node_id": "n630",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n628"
+      },
+      "to": {
+        "node_id": "n631",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n630"
+      },
+      "to": {
+        "node_id": "n631",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n631"
+      },
+      "to": {
+        "node_id": "n632",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n629"
+      },
+      "to": {
+        "node_id": "n632",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n632"
+      },
+      "to": {
+        "node_id": "o633",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n632"
+      },
+      "to": {
+        "node_id": "o634",
+        "input": "in"
+      }
+    }
+  ]
+}

--- a/crates/interop/vizij-arora-host/src/lib.rs
+++ b/crates/interop/vizij-arora-host/src/lib.rs
@@ -16,6 +16,10 @@
 //! This is only the logic both hosts would otherwise write twice, once in Rust
 //! and once in TypeScript.
 
+pub mod profiles;
+pub mod ros4hri;
+pub mod standard;
+
 use std::collections::HashMap;
 
 use anyhow::{anyhow, Result};
@@ -45,6 +49,9 @@ pub struct Bundle {
     pub active_program_id: Option<String>,
     /// `poses.config.neutralInputs` — input name → neutral value.
     pub neutral_inputs: HashMap<String, f64>,
+    /// `metadata.faceId` — the rig's namespace (its input paths live under
+    /// `rig/<faceId>/`).
+    pub face_id: Option<String>,
 }
 
 impl Bundle {
@@ -117,12 +124,28 @@ impl Bundle {
             }
         }
 
+        let face_id = metadata
+            .and_then(|m| m.get("faceId"))
+            .and_then(Json::as_str)
+            .map(str::to_string);
+
         Bundle {
             graphs,
             programs,
             active_program_id,
             neutral_inputs,
+            face_id,
         }
+    }
+
+    /// The prefix of this face's rig input paths — `rig/<faceId>/`, or empty
+    /// when the bundle declares no face id. Standard profiles prepend it to
+    /// the control paths they write.
+    pub fn rig_prefix(&self) -> String {
+        self.face_id
+            .as_deref()
+            .map(|id| format!("rig/{id}/"))
+            .unwrap_or_default()
     }
 
     /// The `(id, spec)` of the program `select` names, if any.
@@ -136,11 +159,13 @@ impl Bundle {
     }
 
     /// Compose the device's behavior: the base graphs whose kind is in `wanted`,
+    /// then the given standard `profiles` (e.g. [`ros4hri::ros4hri_source`]),
     /// then the chosen program, then (when `with_animations`) the animation
     /// source — each **last** wins over the earlier ones on any store path they
     /// share (the web composes the same way, for the same last-writer-wins
-    /// reason). So a playing program overrides the base rig, and a playing clip
-    /// overrides both. Returns the composed graph spec.
+    /// reason). So a profile overrides the base rig's resting writes, a playing
+    /// program overrides the profile, and a playing clip overrides everything.
+    /// Returns the composed graph spec.
     ///
     /// Pass `with_animations` when the device has the animation module loaded;
     /// [`animations_source`] dispatches to it, so composing it without the module
@@ -150,6 +175,7 @@ impl Bundle {
         wanted: &[&str],
         select: &ProgramSelect,
         with_animations: bool,
+        profiles: &[(String, Json)],
     ) -> Result<Json> {
         let mut sources: Vec<(String, Json)> = self
             .graphs
@@ -157,6 +183,7 @@ impl Bundle {
             .filter(|(kind, _)| wanted.contains(&kind.as_str()))
             .map(|(kind, spec)| (kind.clone(), spec.clone()))
             .collect();
+        sources.extend_from_slice(profiles);
         if let Some((id, spec)) = self.program(select) {
             log::info!("autoplaying program {id}");
             sources.push((format!("program::{id}"), spec.clone()));
@@ -455,7 +482,7 @@ mod tests {
     fn compose_appends_the_active_program_last() {
         let b = Bundle::from_bundle_json(&bundle_json());
         let composed = b
-            .compose(&["rig", "pose-driver"], &ProgramSelect::Auto, false)
+            .compose(&["rig", "pose-driver"], &ProgramSelect::Auto, false, &[])
             .unwrap();
         let ids: Vec<&str> = composed["nodes"]
             .as_array()
@@ -467,14 +494,59 @@ mod tests {
         assert_eq!(ids, vec!["rig::input_gaze_x", "program::prog.speaks::o"]);
 
         // No autoplay → base graphs only.
-        let base = b.compose(&["rig"], &ProgramSelect::None, false).unwrap();
+        let base = b
+            .compose(&["rig"], &ProgramSelect::None, false, &[])
+            .unwrap();
         assert_eq!(base["nodes"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn compose_inserts_profiles_between_base_and_program() {
+        let b = Bundle::from_bundle_json(&bundle_json());
+        let composed = b
+            .compose(
+                &["rig"],
+                &ProgramSelect::Auto,
+                false,
+                &[ros4hri::ros4hri_source("rig/f/")],
+            )
+            .unwrap();
+        let ids: Vec<&str> = composed["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|n| n["id"].as_str().unwrap())
+            .collect();
+        // Base rig first, profile in the middle, program last (a playing
+        // program out-writes the profile on shared paths).
+        let rig = ids
+            .iter()
+            .position(|id| *id == "rig::input_gaze_x")
+            .unwrap();
+        let profile = ids.iter().position(|id| *id == "ros4hri::in-name").unwrap();
+        let program = ids
+            .iter()
+            .position(|id| *id == "program::prog.speaks::o")
+            .unwrap();
+        assert!(rig < profile && profile < program);
+
+        // Without profiles the composition is untouched — the opt-in default.
+        let bare = b
+            .compose(&["rig"], &ProgramSelect::Auto, false, &[])
+            .unwrap();
+        assert!(!bare["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|n| n["id"].as_str().unwrap().starts_with("ros4hri::")));
     }
 
     #[test]
     fn compose_appends_the_animation_source_last() {
         let b = Bundle::from_bundle_json(&bundle_json());
-        let composed = b.compose(&["rig"], &ProgramSelect::None, true).unwrap();
+        let composed = b
+            .compose(&["rig"], &ProgramSelect::None, true, &[])
+            .unwrap();
         let ids: Vec<String> = composed["nodes"]
             .as_array()
             .unwrap()

--- a/crates/interop/vizij-arora-host/src/profiles.rs
+++ b/crates/interop/vizij-arora-host/src/profiles.rs
@@ -1,0 +1,90 @@
+//! The registry of standard profiles — the composable graph assets that make
+//! a face respond to an external standard's keys. One entry today (ROS4HRI);
+//! the registry exists so hosts, the bundler, and authoring UIs can list what
+//! a user may opt into, uniformly.
+
+use serde_json::{json, Value as Json};
+
+use crate::ros4hri;
+
+/// The bundle graph kind under which a standard profile embeds in a GLB.
+pub const STANDARD_PROFILE_KIND: &str = "standard-profile";
+
+/// A standard profile: its identity and the asset behind it.
+pub struct StandardProfile {
+    /// Registry id, e.g. `ros4hri` — also names the profile everywhere a user
+    /// opts in (CLI flags, bundle graph ids, npm lookups).
+    pub id: &'static str,
+    pub title: &'static str,
+    pub description: &'static str,
+    /// The canonical profile asset, unprefixed, verbatim JSON.
+    pub asset_json: &'static str,
+}
+
+/// Every standard profile Vizij ships.
+pub const STANDARD_PROFILES: [StandardProfile; 1] = [StandardProfile {
+    id: "ros4hri",
+    title: "ROS4HRI",
+    description: "Drives the standard face controls from the standard/ros4hri/* keys: \
+                  expression names and valence/arousal, gaze targets with vergence, FACS \
+                  action units, visemes, idle blink, and the incumbent's ~200 ms smoothing.",
+    asset_json: ros4hri::PROFILE_JSON,
+}];
+
+/// Look a profile up by id.
+pub fn standard_profile(id: &str) -> Option<&'static StandardProfile> {
+    STANDARD_PROFILES.iter().find(|p| p.id == id)
+}
+
+/// The bundle graph id under which `profile_id` embeds in a GLB — stable, so
+/// re-adding replaces rather than duplicates.
+pub fn embedded_graph_id(profile_id: &str) -> String {
+    format!("standard::{profile_id}")
+}
+
+/// A profile's graph as a composable source, with the face's rig prefix
+/// applied to the written control paths. `None` for an unknown id.
+pub fn standard_profile_source(id: &str, rig_prefix: &str) -> Option<(String, Json)> {
+    let profile = standard_profile(id)?;
+    let mut spec: Json = serde_json::from_str(profile.asset_json).ok()?;
+    ros4hri::apply_rig_prefix(&mut spec, rig_prefix);
+    Some((id.to_string(), spec))
+}
+
+/// The registry as JSON — what CLIs print and the web runtime serves for
+/// opt-in pickers.
+pub fn standard_profiles_json() -> Json {
+    Json::Array(
+        STANDARD_PROFILES
+            .iter()
+            .map(|p| {
+                json!({
+                    "id": p.id,
+                    "title": p.title,
+                    "description": p.description,
+                })
+            })
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_lists_ros4hri() {
+        let listed = standard_profiles_json();
+        assert_eq!(listed[0]["id"], "ros4hri");
+        assert!(standard_profile("ros4hri").is_some());
+        assert!(standard_profile("nope").is_none());
+        assert_eq!(embedded_graph_id("ros4hri"), "standard::ros4hri");
+    }
+
+    #[test]
+    fn profile_source_matches_the_ros4hri_source() {
+        let via_registry = standard_profile_source("ros4hri", "rig/f/").expect("known id");
+        let direct = ros4hri::ros4hri_source("rig/f/");
+        assert_eq!(via_registry.1, direct.1);
+    }
+}

--- a/crates/interop/vizij-arora-host/src/ros4hri.rs
+++ b/crates/interop/vizij-arora-host/src/ros4hri.rs
@@ -1,0 +1,556 @@
+//! The built-in ROS4HRI profile: a composable graph source mapping the
+//! `standard/ros4hri/*` store keys (what a ROS bridge writes from the ROS4HRI
+//! topics) onto the [`crate::standard`] face controls.
+//!
+//! The profile is asset-independent by construction — it only writes standard
+//! control paths; what an expression or a viseme *looks like* stays with the
+//! face (its rig and adaptation graphs). Per channel:
+//!
+//! - **Expression** — a non-empty `expression/name` one-hots the named weight;
+//!   otherwise `valence`/`arousal` blend the named weights by proximity to
+//!   each expression's circumplex anchor. Weights are smoothed and written to
+//!   `standard/vizij/expression/<name>`.
+//! - **Gaze** — `gaze/target` (vec3, meters, face frame: x forward, y left,
+//!   z up) maps to per-eye positions with vergence, the incumbent ±0.78 rad →
+//!   ±1 normalization, and a center fallback for targets at or behind the
+//!   face plane (x ≤ 0.1).
+//! - **Action units** — `au/<code>` intensities route to the muscle-tier
+//!   controls per [`crate::standard::FACE_CONTROLS`]; the eyes-closed unit
+//!   also drives the eyelids, and jaw-open additionally drives the de-facto
+//!   `mouth/morph/jaw_open` control.
+//! - **Visemes** — `viseme/<shape>` weights pass through, smoothed, to
+//!   `standard/vizij/viseme/<shape>`.
+//! - **Blink** — an idle generator (≈8 s cycle, deterministically jittered,
+//!   0.2 s parabolic pulse) drives the eyelids, inhibited while the eyes are
+//!   commanded closed or the face is asleep.
+//!
+//! All continuous channels pass through a ~200 ms exponential smoother (the
+//! incumbent ROS4HRI face's dynamics). The graph is generated data: it
+//! composes exactly like [`crate::animations_source`], after the face's own
+//! graphs and before any playing program, so a performance overrides it,
+//! last-writer-wins.
+
+use serde_json::{json, Value as Json};
+
+use crate::standard::{self, EXPRESSION_NAMES, FACE_CONTROLS, VISEME_SHAPES};
+
+/// Source id of the composed profile (node ids get `ros4hri::` prefixes).
+pub const ROS4HRI_SOURCE_ID: &str = "ros4hri";
+
+/// Prefix of every key the profile consumes.
+pub const ROS4HRI_PREFIX: &str = "standard/ros4hri";
+
+/// Input keys, as a ROS bridge writes them.
+pub const EXPRESSION_NAME_KEY: &str = "standard/ros4hri/expression/name";
+pub const EXPRESSION_VALENCE_KEY: &str = "standard/ros4hri/expression/valence";
+pub const EXPRESSION_AROUSAL_KEY: &str = "standard/ros4hri/expression/arousal";
+pub const GAZE_TARGET_KEY: &str = "standard/ros4hri/gaze/target";
+
+/// The key carrying a FACS action-unit intensity, [0, 1].
+pub fn au_key(code: u8) -> String {
+    format!("{ROS4HRI_PREFIX}/au/{code}")
+}
+
+/// The key carrying a viseme-shape weight, [0, 1].
+pub fn viseme_key(shape: &str) -> String {
+    format!("{ROS4HRI_PREFIX}/viseme/{shape}")
+}
+
+/// Circumplex anchor (valence, arousal) per expression name, used to blend
+/// the named weights when only `valence`/`arousal` are commanded. Order
+/// matches [`EXPRESSION_NAMES`].
+#[rustfmt::skip]
+pub const EXPRESSION_ANCHORS: [(f64, f64); 25] = [
+    (0.0, 0.0),     // neutral
+    (-0.7, 0.7),    // angry
+    (-0.7, -0.4),   // sad
+    (0.8, 0.4),     // happy
+    (0.1, 0.8),     // surprised
+    (-0.7, 0.4),    // disgusted
+    (-0.7, 0.8),    // scared
+    (-0.3, 0.3),    // pleading
+    (-0.4, -0.15),  // vulnerable
+    (-0.8, -0.5),   // despaired
+    (-0.5, -0.35),  // guilty
+    (-0.5, -0.25),  // disappointed
+    (-0.35, 0.2),   // embarrassed
+    (-0.8, 0.8),    // horrified
+    (-0.3, 0.1),    // skeptical
+    (-0.5, 0.4),    // annoyed
+    (-0.8, 0.9),    // furious
+    (-0.4, 0.25),   // suspicious
+    (-0.6, -0.3),   // rejected
+    (-0.35, -0.55), // bored
+    (-0.15, -0.7),  // tired
+    (0.0, -0.95),   // asleep
+    (-0.25, 0.35),  // confused
+    (0.5, 0.7),     // amazed
+    (0.7, 0.8),     // excited
+];
+
+/// Smoothing half-life, seconds — ≈200 ms time constant, the incumbent's.
+const HALF_LIFE: f64 = 0.14;
+/// Circumplex kernel radius: anchors farther than this get zero weight.
+const ANCHOR_RADIUS: f64 = 0.6;
+/// Blink cycle length / pulse width, seconds.
+const BLINK_PERIOD: f64 = 8.0;
+const BLINK_WIDTH: f64 = 0.2;
+/// Half the interocular distance, meters — the vergence offset.
+const HALF_IOD: f64 = 0.03;
+/// The incumbent's gaze normalization: ±0.78 rad maps to ±1.
+const GAZE_RANGE_RAD: f64 = 0.78;
+
+/// Incrementally builds the profile's node/edge lists.
+struct GraphBuilder {
+    nodes: Vec<Json>,
+    edges: Vec<Json>,
+    scratch: u32,
+}
+
+impl GraphBuilder {
+    fn new() -> Self {
+        Self {
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            scratch: 0,
+        }
+    }
+
+    fn node(&mut self, id: &str, ty: &str, params: Json) -> String {
+        self.nodes
+            .push(json!({ "id": id, "type": ty, "params": params }));
+        id.to_string()
+    }
+
+    fn edge(&mut self, from: &str, to: &str, input: &str) {
+        self.edges
+            .push(json!({ "from": { "node_id": from }, "to": { "node_id": to, "input": input } }));
+    }
+
+    /// A fresh constant node holding `value`.
+    fn constant(&mut self, value: f64) -> String {
+        self.scratch += 1;
+        let id = format!("c{}", self.scratch);
+        self.node(&id, "constant", json!({ "value": value }))
+    }
+
+    /// A scratch node wired from `inputs` (port name → source node).
+    fn op(&mut self, ty: &str, params: Json, inputs: &[(&str, &str)]) -> String {
+        self.scratch += 1;
+        let id = format!("n{}", self.scratch);
+        self.node(&id, ty, params);
+        for (port, from) in inputs {
+            self.edge(from, &id, port);
+        }
+        id
+    }
+
+    fn sub(&mut self, lhs: &str, rhs: &str) -> String {
+        self.op("subtract", json!({}), &[("lhs", lhs), ("rhs", rhs)])
+    }
+    fn mul(&mut self, a: &str, b: &str) -> String {
+        self.op("multiply", json!({}), &[("operand_0", a), ("operand_1", b)])
+    }
+    fn div(&mut self, lhs: &str, rhs: &str) -> String {
+        self.op("divide", json!({}), &[("lhs", lhs), ("rhs", rhs)])
+    }
+    fn add2(&mut self, a: &str, b: &str) -> String {
+        self.op("add", json!({}), &[("operand_0", a), ("operand_1", b)])
+    }
+    fn max2(&mut self, a: &str, b: &str) -> String {
+        self.op("max", json!({}), &[("operand_0", a), ("operand_1", b)])
+    }
+
+    /// ~200 ms exponential smoothing.
+    fn damp(&mut self, from: &str) -> String {
+        self.op("damp", json!({ "half_life": HALF_LIFE }), &[("in", from)])
+    }
+
+    /// An input node reading `path`, defaulting to `value` until staged.
+    fn input(&mut self, id: &str, path: &str, value: Json) -> String {
+        self.node(id, "input", json!({ "path": path, "value": value }))
+    }
+
+    /// An output node writing `path`.
+    fn output(&mut self, from: &str, path: String) {
+        self.scratch += 1;
+        let id = format!("o{}", self.scratch);
+        self.node(&id, "output", json!({ "path": path }));
+        self.edge(from, &id, "in");
+    }
+
+    /// `atan(num / den)` via the rational approximation `r / (1 + 0.28 r²)`
+    /// (≤1 % error inside the clamped gaze range), normalized by the
+    /// incumbent's ±0.78 rad → ±1 and clamped.
+    fn gaze_angle(&mut self, num: &str, den: &str) -> String {
+        let r = self.div(num, den);
+        let r2 = self.mul(&r, &r);
+        let k = self.constant(0.28);
+        let kr2 = self.mul(&r2, &k);
+        let one = self.constant(1.0);
+        let d = self.add2(&kr2, &one);
+        let atan = self.div(&r, &d);
+        let range = self.constant(GAZE_RANGE_RAD);
+        let norm = self.div(&atan, &range);
+        let lo = self.constant(-1.0);
+        let hi = self.constant(1.0);
+        self.op(
+            "clamp",
+            json!({}),
+            &[("in", &norm), ("min", &lo), ("max", &hi)],
+        )
+    }
+}
+
+/// The composable ROS4HRI profile source: the canonical profile asset
+/// ([`PROFILE_JSON`]) with `rig_prefix` applied. The prefix is prepended to
+/// every written control path (faces namespace their rig inputs, e.g.
+/// `rig/quori_latest/`); pass `""` for unprefixed controls.
+pub fn ros4hri_source(rig_prefix: &str) -> (String, Json) {
+    let mut spec: Json = serde_json::from_str(PROFILE_JSON).expect("profiles/ros4hri.json parses");
+    apply_rig_prefix(&mut spec, rig_prefix);
+    (ROS4HRI_SOURCE_ID.to_string(), spec)
+}
+
+/// The canonical profile asset, verbatim: the graph as data. This file is
+/// what the bundler embeds into GLBs and what the web runtime serves; edit it
+/// by regenerating (`vizij-bundle export-profile ros4hri`) — a test keeps it
+/// in sync with [`generate`].
+pub const PROFILE_JSON: &str = include_str!("../profiles/ros4hri.json");
+
+/// Regenerate the profile graph from first principles, unprefixed — the
+/// export path behind the canonical asset.
+pub fn generate() -> Json {
+    build("").1
+}
+
+/// Prepend `rig_prefix` to every path the profile writes (its `output`
+/// nodes). Input paths — the `standard/ros4hri/*` keys a bridge writes — are
+/// device-global and stay untouched.
+pub fn apply_rig_prefix(spec: &mut Json, rig_prefix: &str) {
+    if rig_prefix.is_empty() {
+        return;
+    }
+    for node in spec
+        .get_mut("nodes")
+        .and_then(Json::as_array_mut)
+        .into_iter()
+        .flatten()
+    {
+        if node.get("type").and_then(Json::as_str) == Some("output") {
+            if let Some(path) = node.pointer_mut("/params/path") {
+                if let Some(p) = path.as_str() {
+                    *path = Json::String(format!("{rig_prefix}{p}"));
+                }
+            }
+        }
+    }
+}
+
+fn build(rig_prefix: &str) -> (String, Json) {
+    let g = &mut GraphBuilder::new();
+    let out = |path: String| format!("{rig_prefix}{path}");
+
+    // --- Expression: name one-hot, else valence/arousal circumplex blend ---
+    let name = g.input("in-name", EXPRESSION_NAME_KEY, json!(""));
+    let valence = g.input("in-valence", EXPRESSION_VALENCE_KEY, json!(0.0));
+    let arousal = g.input("in-arousal", EXPRESSION_AROUSAL_KEY, json!(0.0));
+
+    let zero = g.constant(0.0);
+    let one = g.constant(1.0);
+
+    // 1 when a name is commanded, 0 while the name key is empty.
+    let has_name = g.op(
+        "case",
+        json!({ "case_labels": [""] }),
+        &[("selector", &name), ("operand_0", &zero), ("default", &one)],
+    );
+    let no_name = g.sub(&one, &has_name);
+
+    // Raw circumplex weight per anchor: max(0, 1 − dist² / R²).
+    let radius_sq = g.constant(ANCHOR_RADIUS * ANCHOR_RADIUS);
+    let raw: Vec<String> = EXPRESSION_ANCHORS
+        .iter()
+        .map(|(av, aa)| {
+            let cv = g.constant(*av);
+            let ca = g.constant(*aa);
+            let dv = g.sub(&valence, &cv);
+            let da = g.sub(&arousal, &ca);
+            let dv2 = g.mul(&dv, &dv);
+            let da2 = g.mul(&da, &da);
+            let d2 = g.add2(&dv2, &da2);
+            let frac = g.div(&d2, &radius_sq);
+            let w = g.sub(&one, &frac);
+            g.max2(&w, &zero)
+        })
+        .collect();
+    // Normalize so the blend sums to 1 (ε floors the empty-neighborhood case).
+    let sum = {
+        let ports: Vec<String> = (0..raw.len()).map(|i| format!("operand_{i}")).collect();
+        let refs: Vec<(&str, &str)> = ports
+            .iter()
+            .zip(&raw)
+            .map(|(p, f)| (p.as_str(), f.as_str()))
+            .collect();
+        g.op("add", json!({}), &refs)
+    };
+    let eps = g.constant(1e-6);
+    let denom = g.max2(&sum, &eps);
+
+    // Dead zone: near-zero valence/arousal rests exactly neutral instead of a
+    // blend of every origin-adjacent anchor; commanded affect fades the blend
+    // in over the first 0.15 of circumplex magnitude.
+    let va_active = {
+        let v2 = g.mul(&valence, &valence);
+        let a2 = g.mul(&arousal, &arousal);
+        let mag2 = g.add2(&v2, &a2);
+        let dz2 = g.constant(0.15 * 0.15);
+        let ratio = g.div(&mag2, &dz2);
+        let lo = g.constant(0.0);
+        let hi = g.constant(1.0);
+        g.op(
+            "clamp",
+            json!({}),
+            &[("in", &ratio), ("min", &lo), ("max", &hi)],
+        )
+    };
+    let va_rest = g.sub(&one, &va_active);
+
+    let mut asleep_weight = None;
+    for (i, expr) in EXPRESSION_NAMES.iter().enumerate() {
+        // One-hot from the commanded name.
+        let onehot = g.op(
+            "case",
+            json!({ "case_labels": [expr] }),
+            &[("selector", &name), ("operand_0", &one), ("default", &zero)],
+        );
+        let named = g.mul(&has_name, &onehot);
+        let va_n = g.div(&raw[i], &denom);
+        let va = g.mul(&va_active, &va_n);
+        let va = if *expr == "neutral" {
+            g.add2(&va, &va_rest)
+        } else {
+            va
+        };
+        let blended = g.mul(&no_name, &va);
+        let w = g.add2(&named, &blended);
+        let smooth = g.damp(&w);
+        if *expr == "asleep" {
+            asleep_weight = Some(smooth.clone());
+        }
+        g.output(&smooth, out(standard::expression_path(expr)));
+    }
+
+    // --- Gaze: target vec3 → per-eye positions with vergence ---------------
+    // The resting target sits far ahead so the unverged eyes read straight.
+    let target = g.input(
+        "in-gaze",
+        GAZE_TARGET_KEY,
+        json!({ "x": 10.0, "y": 0.0, "z": 0.0 }),
+    );
+    let (c0, c1, c2) = (g.constant(0.0), g.constant(1.0), g.constant(2.0));
+    let gx = g.op("vectorindex", json!({}), &[("v", &target), ("index", &c0)]);
+    let gy = g.op("vectorindex", json!({}), &[("v", &target), ("index", &c1)]);
+    let gz = g.op("vectorindex", json!({}), &[("v", &target), ("index", &c2)]);
+
+    // Targets at or behind the face plane recenter the eyes (the incumbent
+    // drops them; a pure graph cannot hold the previous pose, so it holds
+    // center — a noted deviation).
+    let min_x = g.constant(0.1);
+    let valid = g.op("greaterthan", json!({}), &[("lhs", &gx), ("rhs", &min_x)]);
+
+    let iod = g.constant(HALF_IOD);
+    let y_left = g.add2(&gy, &iod);
+    let y_right = g.sub(&gy, &iod);
+    let yaw_l = g.gaze_angle(&y_left, &gx);
+    let yaw_r = g.gaze_angle(&y_right, &gx);
+    let pitch = g.gaze_angle(&gz, &gx);
+
+    for (angle, path_x, path_y) in [
+        (&yaw_l, standard::LEFT_EYE_POS_X, standard::LEFT_EYE_POS_Y),
+        (&yaw_r, standard::RIGHT_EYE_POS_X, standard::RIGHT_EYE_POS_Y),
+    ] {
+        let gated_x = g.op(
+            "if",
+            json!({}),
+            &[("cond", &valid), ("then", angle), ("else", &zero)],
+        );
+        let gated_y = g.op(
+            "if",
+            json!({}),
+            &[("cond", &valid), ("then", &pitch), ("else", &zero)],
+        );
+        let sx = g.damp(&gated_x);
+        let sy = g.damp(&gated_y);
+        g.output(&sx, out(path_x.to_string()));
+        g.output(&sy, out(path_y.to_string()));
+    }
+
+    // --- Action units → muscle-tier controls -------------------------------
+    let mut au_codes: Vec<u8> = FACE_CONTROLS.iter().filter_map(|c| c.au).collect();
+    au_codes.sort_unstable();
+    au_codes.dedup();
+    let mut eyes_closed = String::new();
+    for code in au_codes {
+        let input_id = format!("in-au-{code}");
+        let raw = g.input(&input_id, &au_key(code), json!(0.0));
+        let smooth = g.damp(&raw);
+        if code == 43 {
+            eyes_closed = smooth.clone();
+        }
+        for control in standard::controls_for_au(code) {
+            g.output(&smooth, out(standard::face_path(control.name)));
+        }
+        // Jaw-open also drives the de-facto mouth control every current face
+        // implements, so the AU channel moves faces without a muscle tier.
+        if code == 26 {
+            g.output(
+                &smooth,
+                out("standard/vizij/mouth/morph/jaw_open".to_string()),
+            );
+        }
+    }
+
+    // --- Visemes: pass-through, smoothed -----------------------------------
+    for shape in VISEME_SHAPES {
+        let input_id = format!("in-vis-{shape}");
+        let raw = g.input(&input_id, &viseme_key(shape), json!(0.0));
+        let smooth = g.damp(&raw);
+        g.output(&smooth, out(standard::viseme_path(shape)));
+    }
+
+    // --- Blink: jittered idle pulse, inhibited when lids are commanded -----
+    let t = g.node("blink-time", "time", json!({}));
+    let period = g.constant(BLINK_PERIOD);
+    let cycle = g.div(&t, &period);
+    let cycle_floor = g.op("round", json!({ "round_mode": "floor" }), &[("in", &cycle)]);
+    // Deterministic per-cycle jitter shifts the blink ±2 s within its cycle.
+    let jitter = g.op(
+        "simplenoise",
+        json!({ "noise_seed": 7.0, "frequency": 1.0, "octaves": 1.0 }),
+        &[("x", &cycle_floor), ("y", &zero)],
+    );
+    let two = g.constant(2.0);
+    let shift = g.mul(&jitter, &two);
+    let shifted = g.add2(&t, &shift);
+    let phase = g.op("modulo", json!({}), &[("lhs", &shifted), ("rhs", &period)]);
+    // Parabolic pulse 4u(1−u) over the first BLINK_WIDTH seconds of the cycle.
+    let width = g.constant(BLINK_WIDTH);
+    let u = g.div(&phase, &width);
+    let four = g.constant(4.0);
+    let a = g.mul(&four, &u);
+    let b = g.sub(&one, &u);
+    let parabola = g.mul(&a, &b);
+    let in_window = g.op("lessthan", json!({}), &[("lhs", &u), ("rhs", &one)]);
+    let pulse = g.op(
+        "if",
+        json!({}),
+        &[("cond", &in_window), ("then", &parabola), ("else", &zero)],
+    );
+    let pulse = g.op(
+        "clamp",
+        json!({}),
+        &[("in", &pulse), ("min", &zero), ("max", &one)],
+    );
+    // Inhibit while the eyes are commanded closed or the face is asleep.
+    let asleep = asleep_weight.expect("asleep is in EXPRESSION_NAMES");
+    let commanded = g.max2(&eyes_closed, &asleep);
+    let open_share = g.sub(&one, &commanded);
+    let blink = g.mul(&pulse, &open_share);
+    // Lids follow the strongest closer: the blink pulse or the commanded close.
+    let lid = g.max2(&blink, &commanded);
+    g.output(&lid, out(standard::LEFT_EYE_TOP_EYELID_POS_Y.to_string()));
+    g.output(&lid, out(standard::RIGHT_EYE_TOP_EYELID_POS_Y.to_string()));
+
+    (
+        ROS4HRI_SOURCE_ID.to_string(),
+        json!({ "nodes": g.nodes, "edges": g.edges }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec() -> Json {
+        ros4hri_source("rig/test_face/").1
+    }
+
+    /// The committed asset must equal what the generator produces — otherwise
+    /// `export-profile` was not re-run after editing the builder, and the file
+    /// the bundler and web runtime serve is stale. Regenerate with
+    /// `vizij-bundle export-profile ros4hri -o crates/interop/vizij-arora-host/profiles/ros4hri.json`.
+    #[test]
+    fn committed_asset_matches_the_generator() {
+        let committed: Json = serde_json::from_str(PROFILE_JSON).expect("asset parses");
+        assert_eq!(committed, generate(), "profiles/ros4hri.json is stale");
+    }
+
+    #[test]
+    fn source_covers_every_standard_output() {
+        let spec = spec();
+        let paths: Vec<&str> = spec["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|n| n["type"] == "output")
+            .filter_map(|n| n["params"]["path"].as_str())
+            .collect();
+        for expr in EXPRESSION_NAMES {
+            let path = format!("rig/test_face/standard/vizij/expression/{expr}");
+            assert!(paths.contains(&path.as_str()), "missing {path}");
+        }
+        for shape in VISEME_SHAPES {
+            let path = format!("rig/test_face/standard/vizij/viseme/{shape}");
+            assert!(paths.contains(&path.as_str()), "missing {path}");
+        }
+        for control in &FACE_CONTROLS {
+            if control.au.is_some() {
+                let path = format!("rig/test_face/standard/vizij/face/{}", control.name);
+                assert!(paths.contains(&path.as_str()), "missing {path}");
+            }
+        }
+        for path in [
+            "rig/test_face/standard/vizij/left_eye/pos/x",
+            "rig/test_face/standard/vizij/right_eye/pos/y",
+            "rig/test_face/standard/vizij/left_eye_top_eyelid/pos/y",
+            "rig/test_face/standard/vizij/mouth/morph/jaw_open",
+        ] {
+            assert!(paths.contains(&path), "missing {path}");
+        }
+    }
+
+    #[test]
+    fn source_reads_only_ros4hri_keys() {
+        let spec = spec();
+        for node in spec["nodes"].as_array().unwrap() {
+            if node["type"] == "input" {
+                let path = node["params"]["path"].as_str().unwrap();
+                assert!(path.starts_with(ROS4HRI_PREFIX), "unexpected input {path}");
+            }
+        }
+    }
+
+    #[test]
+    fn edges_reference_existing_nodes() {
+        let spec = spec();
+        let ids: std::collections::HashSet<&str> = spec["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|n| n["id"].as_str().unwrap())
+            .collect();
+        for edge in spec["edges"].as_array().unwrap() {
+            for end in [&edge["from"]["node_id"], &edge["to"]["node_id"]] {
+                assert!(ids.contains(end.as_str().unwrap()), "dangling {end}");
+            }
+        }
+    }
+
+    #[test]
+    fn anchors_pair_with_names() {
+        assert_eq!(EXPRESSION_ANCHORS.len(), EXPRESSION_NAMES.len());
+        // Neutral anchors the origin so idle valence/arousal rests neutral.
+        assert_eq!(EXPRESSION_ANCHORS[0], (0.0, 0.0));
+    }
+}

--- a/crates/interop/vizij-arora-host/src/standard.rs
+++ b/crates/interop/vizij-arora-host/src/standard.rs
@@ -1,0 +1,218 @@
+//! The Vizij face standard: the store paths a compliant face implements.
+//!
+//! Faces are driven through named controls on the store, under the
+//! `standard/vizij/` prefix. The vocabulary has three tiers, from coarse to
+//! fine; a face implements what it implements, and standard profiles (like the
+//! ROS4HRI one) degrade to the tiers a face covers:
+//!
+//! - **Gaze & lids** — per-eye position and eyelid controls.
+//! - **Semantic** — one weight per named expression and per viseme shape. The
+//!   expression names are ROS4HRI's set; the viseme shapes are the industry
+//!   15-shape set (the Oculus/Meta convention).
+//! - **Muscle** — fine-grained face controls cherry-picked from FACS action
+//!   units and ARKit blendshapes: FACS supplies the taxonomy (each control
+//!   names an action unit, so ROS4HRI's `FacialActionUnits` maps losslessly),
+//!   ARKit supplies lateralization and naming familiarity (its blendshape
+//!   arrays carry left/right where the FACS message cannot, and assets in the
+//!   wild ship ARKit-named morph targets). Controls exist for the union that
+//!   makes sense on a commanded robot face; ARKit's tracking-only shapes
+//!   (`eyeLook*` — redundant with the gaze tier) and FACS codes a command
+//!   channel cannot express (visibility, head/eye movement — owned by the
+//!   gaze tier) have none.
+//!
+//! Everything is an `f32` weight in [0, 1] unless a constant says otherwise.
+
+/// Prefix of every control path in the Vizij face standard.
+pub const VIZIJ_PREFIX: &str = "standard/vizij";
+
+// --- Gaze & lids ------------------------------------------------------------
+
+/// Eye position controls, normalized [-1, 1]: `pos/x` is the wearer's
+/// left-to-right, `pos/y` is down-to-up.
+pub const LEFT_EYE_POS_X: &str = "standard/vizij/left_eye/pos/x";
+pub const LEFT_EYE_POS_Y: &str = "standard/vizij/left_eye/pos/y";
+pub const RIGHT_EYE_POS_X: &str = "standard/vizij/right_eye/pos/x";
+pub const RIGHT_EYE_POS_Y: &str = "standard/vizij/right_eye/pos/y";
+
+/// Top-eyelid positions, [0, 1]: 0 fully open, 1 fully closed.
+pub const LEFT_EYE_TOP_EYELID_POS_Y: &str = "standard/vizij/left_eye_top_eyelid/pos/y";
+pub const RIGHT_EYE_TOP_EYELID_POS_Y: &str = "standard/vizij/right_eye_top_eyelid/pos/y";
+
+// --- Semantic tier: expressions --------------------------------------------
+
+/// The named expressions, from ROS4HRI's `hri_msgs/Expression` vocabulary.
+/// A face implements an expression by responding to its weight control at
+/// [`expression_path`]; the standard does not prescribe what the expression
+/// looks like — that is the face's authored pose.
+pub const EXPRESSION_NAMES: [&str; 25] = [
+    "neutral",
+    "angry",
+    "sad",
+    "happy",
+    "surprised",
+    "disgusted",
+    "scared",
+    "pleading",
+    "vulnerable",
+    "despaired",
+    "guilty",
+    "disappointed",
+    "embarrassed",
+    "horrified",
+    "skeptical",
+    "annoyed",
+    "furious",
+    "suspicious",
+    "rejected",
+    "bored",
+    "tired",
+    "asleep",
+    "confused",
+    "amazed",
+    "excited",
+];
+
+/// The weight control path for a named expression.
+pub fn expression_path(name: &str) -> String {
+    format!("{VIZIJ_PREFIX}/expression/{name}")
+}
+
+// --- Semantic tier: visemes -------------------------------------------------
+
+/// The viseme shapes, the industry 15-shape set (Oculus/Meta naming). `sil`
+/// is silence — the closed-mouth rest shape.
+pub const VISEME_SHAPES: [&str; 15] = [
+    "sil", "PP", "FF", "TH", "DD", "kk", "CH", "SS", "nn", "RR", "aa", "E", "ih", "oh", "ou",
+];
+
+/// The weight control path for a viseme shape.
+pub fn viseme_path(shape: &str) -> String {
+    format!("{VIZIJ_PREFIX}/viseme/{shape}")
+}
+
+// --- Muscle tier: face controls ---------------------------------------------
+
+/// A fine-grained face control: its Vizij name, the FACS action unit it
+/// expresses (`hri_msgs/FacialActionUnits` code), and the ARKit blendshape it
+/// corresponds to. AU codes repeat across lateralized pairs (FACS does not
+/// split left/right at the code level); ARKit names are unique.
+pub struct FaceControl {
+    pub name: &'static str,
+    pub au: Option<u8>,
+    pub arkit: &'static str,
+}
+
+/// The muscle-tier vocabulary. Ordered by face region, brows to tongue.
+#[rustfmt::skip]
+pub const FACE_CONTROLS: [FaceControl; 35] = [
+    // Brows
+    FaceControl { name: "brow_inner_up", au: Some(1), arkit: "browInnerUp" },
+    FaceControl { name: "brow_outer_up_left", au: Some(2), arkit: "browOuterUpLeft" },
+    FaceControl { name: "brow_outer_up_right", au: Some(2), arkit: "browOuterUpRight" },
+    FaceControl { name: "brow_down_left", au: Some(4), arkit: "browDownLeft" },
+    FaceControl { name: "brow_down_right", au: Some(4), arkit: "browDownRight" },
+    // Eyes
+    FaceControl { name: "eye_wide_left", au: Some(5), arkit: "eyeWideLeft" },
+    FaceControl { name: "eye_wide_right", au: Some(5), arkit: "eyeWideRight" },
+    FaceControl { name: "eye_squint_left", au: Some(7), arkit: "eyeSquintLeft" },
+    FaceControl { name: "eye_squint_right", au: Some(7), arkit: "eyeSquintRight" },
+    FaceControl { name: "eye_closed_left", au: Some(43), arkit: "eyeBlinkLeft" },
+    FaceControl { name: "eye_closed_right", au: Some(43), arkit: "eyeBlinkRight" },
+    // Cheeks & nose
+    FaceControl { name: "cheek_raise_left", au: Some(6), arkit: "cheekSquintLeft" },
+    FaceControl { name: "cheek_raise_right", au: Some(6), arkit: "cheekSquintRight" },
+    FaceControl { name: "cheek_puff", au: Some(34), arkit: "cheekPuff" },
+    FaceControl { name: "nose_sneer_left", au: Some(9), arkit: "noseSneerLeft" },
+    FaceControl { name: "nose_sneer_right", au: Some(9), arkit: "noseSneerRight" },
+    // Jaw
+    FaceControl { name: "jaw_open", au: Some(26), arkit: "jawOpen" },
+    FaceControl { name: "jaw_left", au: None, arkit: "jawLeft" },
+    FaceControl { name: "jaw_right", au: None, arkit: "jawRight" },
+    FaceControl { name: "jaw_forward", au: Some(29), arkit: "jawForward" },
+    // Mouth
+    FaceControl { name: "mouth_smile_left", au: Some(12), arkit: "mouthSmileLeft" },
+    FaceControl { name: "mouth_smile_right", au: Some(12), arkit: "mouthSmileRight" },
+    FaceControl { name: "mouth_frown_left", au: Some(15), arkit: "mouthFrownLeft" },
+    FaceControl { name: "mouth_frown_right", au: Some(15), arkit: "mouthFrownRight" },
+    FaceControl { name: "mouth_press_left", au: Some(24), arkit: "mouthPressLeft" },
+    FaceControl { name: "mouth_press_right", au: Some(24), arkit: "mouthPressRight" },
+    FaceControl { name: "mouth_pucker", au: Some(18), arkit: "mouthPucker" },
+    FaceControl { name: "mouth_funnel", au: Some(22), arkit: "mouthFunnel" },
+    FaceControl { name: "mouth_stretch_left", au: Some(20), arkit: "mouthStretchLeft" },
+    FaceControl { name: "mouth_stretch_right", au: Some(20), arkit: "mouthStretchRight" },
+    FaceControl { name: "mouth_upper_up_left", au: Some(10), arkit: "mouthUpperUpLeft" },
+    FaceControl { name: "mouth_upper_up_right", au: Some(10), arkit: "mouthUpperUpRight" },
+    FaceControl { name: "mouth_lower_down_left", au: Some(16), arkit: "mouthLowerDownLeft" },
+    FaceControl { name: "mouth_lower_down_right", au: Some(16), arkit: "mouthLowerDownRight" },
+    // Tongue
+    FaceControl { name: "tongue_out", au: Some(19), arkit: "tongueOut" },
+];
+
+/// The weight control path for a muscle-tier face control.
+pub fn face_path(control: &str) -> String {
+    format!("{VIZIJ_PREFIX}/face/{control}")
+}
+
+/// The face controls expressing a FACS action unit — the lateralized pair
+/// where the control splits left/right, a single control otherwise, empty for
+/// codes the muscle tier does not express (visibility codes, head and eye
+/// movement — those belong to the gaze tier).
+pub fn controls_for_au(au: u8) -> impl Iterator<Item = &'static FaceControl> {
+    // AU 45 (blink) and AU 43 (eyes closed) command the same lid controls.
+    let au = if au == 45 { 43 } else { au };
+    FACE_CONTROLS.iter().filter(move |c| c.au == Some(au))
+}
+
+/// The face control corresponding to an ARKit blendshape name, if the
+/// vocabulary carries it.
+pub fn control_for_arkit(arkit: &str) -> Option<&'static FaceControl> {
+    FACE_CONTROLS.iter().find(|c| c.arkit == arkit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn face_control_names_and_arkit_names_are_unique() {
+        let mut names: Vec<_> = FACE_CONTROLS.iter().map(|c| c.name).collect();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), FACE_CONTROLS.len());
+        let mut arkit: Vec<_> = FACE_CONTROLS.iter().map(|c| c.arkit).collect();
+        arkit.sort_unstable();
+        arkit.dedup();
+        assert_eq!(arkit.len(), FACE_CONTROLS.len());
+    }
+
+    #[test]
+    fn lateralized_aus_route_to_their_pair() {
+        let brows: Vec<_> = controls_for_au(4).map(|c| c.name).collect();
+        assert_eq!(brows, ["brow_down_left", "brow_down_right"]);
+        let jaw: Vec<_> = controls_for_au(26).map(|c| c.name).collect();
+        assert_eq!(jaw, ["jaw_open"]);
+    }
+
+    #[test]
+    fn blink_aliases_eyes_closed() {
+        let blink: Vec<_> = controls_for_au(45).map(|c| c.name).collect();
+        let closed: Vec<_> = controls_for_au(43).map(|c| c.name).collect();
+        assert_eq!(blink, closed);
+        assert_eq!(blink, ["eye_closed_left", "eye_closed_right"]);
+    }
+
+    #[test]
+    fn head_and_eye_movement_aus_have_no_muscle_control() {
+        for au in [51u8, 55, 61, 63, 69, 70, 73] {
+            assert_eq!(controls_for_au(au).count(), 0, "AU {au}");
+        }
+    }
+
+    #[test]
+    fn arkit_lookup_round_trips() {
+        let c = control_for_arkit("jawOpen").expect("jawOpen");
+        assert_eq!(c.name, "jaw_open");
+        assert_eq!(c.au, Some(26));
+        assert!(control_for_arkit("eyeLookUpLeft").is_none());
+    }
+}

--- a/crates/interop/vizij-arora-web/Cargo.toml
+++ b/crates/interop/vizij-arora-web/Cargo.toml
@@ -30,6 +30,9 @@ vizij-arora-behavior = { path = "../vizij-arora-behavior" }
 
 # Vizij pieces the browser wrapper builds the injected behavior from.
 vizij-api-core = { path = "../../api/vizij-api-core" }
+# The portable host glue: the standard-profile registry (ROS4HRI, …) this
+# crate re-exports to JS as graph objects for the authoring app.
+vizij-arora-host = { path = "../vizij-arora-host" }
 
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = "0.4"

--- a/crates/interop/vizij-arora-web/src/lib.rs
+++ b/crates/interop/vizij-arora-web/src/lib.rs
@@ -373,6 +373,33 @@ fn normalize_values_map_str(values_json: &str) -> Result<String, JsValue> {
         .map_err(|e| JsValue::from_str(&format!("serialize values: {e}")))
 }
 
+/// The standard profiles Vizij ships (ROS4HRI, …) as a JS array of
+/// `{ id, title, description }` — the introspectable list an authoring app
+/// offers for opt-in.
+#[wasm_bindgen(js_name = standardProfiles)]
+pub fn standard_profiles() -> Result<JsValue, JsValue> {
+    let list = vizij_arora_host::profiles::standard_profiles_json();
+    let json =
+        serde_json::to_string(&list).map_err(|e| JsValue::from_str(&format!("profiles: {e}")))?;
+    js_sys::JSON::parse(&json)
+}
+
+/// A standard profile's graph as a JS object, ready to compose or embed —
+/// with `rigPrefix` (e.g. `rig/quori_latest/`) prepended to the control paths
+/// it writes; pass an empty string for the unprefixed graph. `null` for an
+/// unknown id (see [`standard_profiles`]).
+#[wasm_bindgen(js_name = standardProfile)]
+pub fn standard_profile(id: &str, rig_prefix: &str) -> Result<JsValue, JsValue> {
+    match vizij_arora_host::profiles::standard_profile_source(id, rig_prefix) {
+        Some((_, spec)) => {
+            let json = serde_json::to_string(&spec)
+                .map_err(|e| JsValue::from_str(&format!("profile {id}: {e}")))?;
+            js_sys::JSON::parse(&json)
+        }
+        None => Ok(JsValue::NULL),
+    }
+}
+
 /// The passthrough proof graph (`input` path → `output` path), as spec JSON.
 fn passthrough_json(input: &str, output: &str) -> String {
     serde_json::json!({

--- a/crates/tools/vizij-bundle/Cargo.toml
+++ b/crates/tools/vizij-bundle/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "vizij-bundle"
+version = "0.1.0"
+edition = { workspace = true }
+publish = false
+description = "The Vizij face-bundle tool: inspect, unpack, pack, and validate the VIZIJ_bundle carried by a face GLB."
+
+[dependencies]
+anyhow = { workspace = true }
+serde_json = { workspace = true, features = ["preserve_order", "float_roundtrip"] }
+# The GLB container codec (parse/edit the JSON chunk/re-serialize).
+vizij-glb-migrate = { path = "../vizij-glb-migrate" }
+# The face-standard vocabulary the coverage report validates against.
+vizij-arora-host = { path = "../../interop/vizij-arora-host" }

--- a/crates/tools/vizij-bundle/README.md
+++ b/crates/tools/vizij-bundle/README.md
@@ -1,0 +1,45 @@
+# vizij-bundle
+
+The face-bundle tool: reads and rewrites the `VIZIJ_bundle` a face GLB
+carries, and validates a face's coverage of the Vizij standard. The GLB is a
+build artifact — the bundle JSON is the reviewable source of truth, and this
+tool is the deterministic bridge between the two (packing is idempotent, so
+diffs stay meaningful).
+
+```
+vizij-bundle inspect        face.glb
+vizij-bundle unpack         face.glb -o bundle.json
+vizij-bundle pack           face.glb --bundle bundle.json -o out.glb
+vizij-bundle add-graph      face.glb --graph adaptation.json \
+                            --kind standard-adaptation --id my_adaptation -o out.glb
+vizij-bundle add-standard   face.glb --standard ros4hri -o out.glb
+vizij-bundle validate       face.glb [--min-level 2]
+vizij-bundle profiles
+vizij-bundle export-profile ros4hri -o ros4hri.json
+```
+
+- **inspect** — face summary as JSON: id, graphs, the input surface (store
+  paths the rig listens on, rig prefix stripped), animatable features per node.
+- **unpack / pack** — extract the bundle as a pretty-printed sidecar / write a
+  sidecar back into a GLB. Binary chunks are preserved verbatim.
+- **add-graph** — graft one graph into the bundle, replacing any entry with
+  the same id. This is how a face gains a `standard-adaptation` graph (the
+  asset-side mapping from `standard/vizij/*` controls onto the face's own pose
+  weights and morphs) without a full unpack/pack cycle — see
+  `fixtures/faces/quori/standard-adaptation.json` for the demo face's.
+- **add-standard** — embed a shipped standard profile (e.g. `ros4hri`) into the
+  face: the profile's control paths get the face's rig prefix, and it grafts
+  under a stable id (`standard::<profile>`), so re-running updates the embedded
+  copy in place. This is how a GLB opts into a standard systematically; the
+  same profile graph is available to the web authoring app through
+  `@vizij/runtime` (`standardProfile(id, rigPrefix)`).
+- **validate** — the standard-coverage report: which control paths of each
+  tier (gaze & lids, expressions, visemes, muscle) the face's graphs listen
+  on, the compliance level L0–L3, and what is missing. `--min-level` turns it
+  into a CI gate.
+- **profiles** — list the standard profiles Vizij ships, as JSON — the
+  introspectable menu of what a face may opt into.
+- **export-profile** — regenerate a profile's canonical asset (the file
+  `crates/interop/vizij-arora-host/profiles/<id>.json` that Rust embeds and the
+  web runtime serves). Run this after editing the profile's generator; a test
+  fails if the committed asset drifts from it.

--- a/crates/tools/vizij-bundle/src/lib.rs
+++ b/crates/tools/vizij-bundle/src/lib.rs
@@ -1,0 +1,479 @@
+//! The Vizij face-bundle toolkit: read and rewrite the `VIZIJ_bundle` a face
+//! GLB carries, and validate a face's coverage of the Vizij standard.
+//!
+//! The GLB is a build artifact; the bundle JSON is the reviewable source of
+//! truth. `unpack` extracts it as a sidecar, `pack` writes it back, and
+//! `add_graph` grafts one graph (e.g. a face's `standard-adaptation`) without
+//! touching the rest — all deterministic, so packing is idempotent and diffs
+//! stay meaningful.
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde_json::{json, Map, Value as Json};
+use vizij_arora_host::{profiles, standard};
+use vizij_glb_migrate::glb::Glb;
+
+/// A GLB with its parsed JSON chunk, ready for bundle surgery.
+pub struct Face {
+    glb: Glb,
+    pub gltf: Json,
+}
+
+impl Face {
+    /// Parse a GLB byte buffer.
+    pub fn parse(bytes: &[u8]) -> Result<Face> {
+        let glb = Glb::parse(bytes).map_err(|e| anyhow!("not a GLB: {e}"))?;
+        let gltf: Json = serde_json::from_slice(&glb.json).context("GLB JSON chunk")?;
+        Ok(Face { glb, gltf })
+    }
+
+    /// The `VIZIJ_bundle` object: on a node's `extensions`, else the document
+    /// root's (the same lookup the runtimes use).
+    pub fn bundle(&self) -> Option<&Json> {
+        self.gltf
+            .get("nodes")
+            .and_then(Json::as_array)
+            .into_iter()
+            .flatten()
+            .find_map(|node| node.get("extensions").and_then(|e| e.get("VIZIJ_bundle")))
+            .or_else(|| {
+                self.gltf
+                    .get("extensions")
+                    .and_then(|e| e.get("VIZIJ_bundle"))
+            })
+    }
+
+    fn bundle_mut(&mut self) -> Option<&mut Json> {
+        let in_node = self
+            .gltf
+            .get("nodes")
+            .and_then(Json::as_array)
+            .into_iter()
+            .flatten()
+            .position(|node| {
+                node.get("extensions")
+                    .and_then(|e| e.get("VIZIJ_bundle"))
+                    .is_some()
+            });
+        match in_node {
+            Some(i) => self.gltf["nodes"][i]["extensions"].get_mut("VIZIJ_bundle"),
+            None => self
+                .gltf
+                .get_mut("extensions")
+                .and_then(|e| e.get_mut("VIZIJ_bundle")),
+        }
+    }
+
+    /// Replace the face's bundle with `bundle`.
+    pub fn set_bundle(&mut self, bundle: Json) -> Result<()> {
+        let slot = self
+            .bundle_mut()
+            .ok_or_else(|| anyhow!("the GLB carries no VIZIJ_bundle to replace"))?;
+        *slot = bundle;
+        Ok(())
+    }
+
+    /// Graft one graph entry `{kind, id, spec}` into the bundle: replaces the
+    /// entry with the same `id` if present, appends otherwise.
+    pub fn add_graph(&mut self, kind: &str, id: &str, spec: Json) -> Result<()> {
+        let bundle = self
+            .bundle_mut()
+            .ok_or_else(|| anyhow!("the GLB carries no VIZIJ_bundle"))?;
+        let graphs = bundle
+            .get_mut("graphs")
+            .and_then(Json::as_array_mut)
+            .ok_or_else(|| anyhow!("the bundle carries no graphs array"))?;
+        let entry = json!({ "kind": kind, "id": id, "spec": spec });
+        match graphs
+            .iter()
+            .position(|g| g.get("id").and_then(Json::as_str) == Some(id))
+        {
+            Some(i) => graphs[i] = entry,
+            None => graphs.push(entry),
+        }
+        Ok(())
+    }
+
+    /// The prefix of this face's rig input paths — `rig/<faceId>/`, empty when
+    /// the bundle declares no face id.
+    pub fn rig_prefix(&self) -> String {
+        self.bundle()
+            .and_then(|b| b.pointer("/metadata/faceId"))
+            .and_then(Json::as_str)
+            .map(|id| format!("rig/{id}/"))
+            .unwrap_or_default()
+    }
+
+    /// Embed a shipped standard profile (e.g. `ros4hri`) into the face: its
+    /// control paths get this face's rig prefix, and it grafts under a stable
+    /// id (`standard::<profile>`) so re-embedding replaces rather than
+    /// duplicates — the embedded copy stays updatable. Errors on an unknown
+    /// profile id.
+    pub fn add_standard_profile(&mut self, profile_id: &str) -> Result<()> {
+        let (_, spec) = profiles::standard_profile_source(profile_id, &self.rig_prefix())
+            .ok_or_else(|| anyhow!("unknown standard profile {profile_id}"))?;
+        self.add_graph(
+            profiles::STANDARD_PROFILE_KIND,
+            &profiles::embedded_graph_id(profile_id),
+            spec,
+        )
+    }
+
+    /// Serialize back to GLB bytes (the JSON chunk re-encoded, binary chunks
+    /// preserved verbatim).
+    pub fn to_bytes(&mut self) -> Result<Vec<u8>> {
+        self.glb.json = serde_json::to_vec(&self.gltf).context("encode GLB JSON chunk")?;
+        Ok(self.glb.to_bytes())
+    }
+
+    /// Every store path the bundle's graphs read (their `input` nodes), with
+    /// the rig prefix (`rig/<faceId>/`) stripped — the face's input surface,
+    /// in standard vocabulary terms.
+    pub fn input_paths(&self) -> Vec<String> {
+        let Some(bundle) = self.bundle() else {
+            return Vec::new();
+        };
+        let prefix = bundle
+            .pointer("/metadata/faceId")
+            .and_then(Json::as_str)
+            .map(|id| format!("rig/{id}/"))
+            .unwrap_or_default();
+        let mut paths: Vec<String> = bundle
+            .get("graphs")
+            .and_then(Json::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|g| g.pointer("/spec/nodes"))
+            .filter_map(Json::as_array)
+            .flatten()
+            .filter(|n| n.get("type").and_then(Json::as_str) == Some("input"))
+            .filter_map(|n| n.pointer("/params/path").and_then(Json::as_str))
+            .map(|p| p.strip_prefix(&prefix).unwrap_or(p).to_string())
+            .collect();
+        paths.sort();
+        paths.dedup();
+        paths
+    }
+}
+
+/// One tier of the standard-coverage report.
+pub struct TierCoverage {
+    pub tier: &'static str,
+    pub covered: Vec<String>,
+    pub missing: Vec<String>,
+}
+
+/// A face's coverage of the Vizij standard: which control paths of each tier
+/// its graphs listen on. `level` is the highest tier the face fully covers,
+/// in the standard's progression — L0 gaze & lids, L1 expressions, L2
+/// visemes, L3 the muscle tier (half is enough there: faces rig the muscles
+/// they have).
+pub struct Coverage {
+    pub face_id: Option<String>,
+    pub level: u8,
+    pub tiers: Vec<TierCoverage>,
+}
+
+/// Compute a face's standard coverage from its input surface.
+pub fn coverage(face: &Face) -> Coverage {
+    let inputs = face.input_paths();
+    let has = |path: &str| inputs.iter().any(|p| p == path);
+    let split = |paths: Vec<String>| -> (Vec<String>, Vec<String>) {
+        paths.into_iter().partition(|p| has(p))
+    };
+
+    let gaze_paths = vec![
+        standard::LEFT_EYE_POS_X.to_string(),
+        standard::LEFT_EYE_POS_Y.to_string(),
+        standard::RIGHT_EYE_POS_X.to_string(),
+        standard::RIGHT_EYE_POS_Y.to_string(),
+        standard::LEFT_EYE_TOP_EYELID_POS_Y.to_string(),
+        standard::RIGHT_EYE_TOP_EYELID_POS_Y.to_string(),
+    ];
+    let expression_paths: Vec<String> = standard::EXPRESSION_NAMES
+        .iter()
+        .map(|n| standard::expression_path(n))
+        .collect();
+    let viseme_paths: Vec<String> = standard::VISEME_SHAPES
+        .iter()
+        .map(|s| standard::viseme_path(s))
+        .collect();
+    let muscle_paths: Vec<String> = standard::FACE_CONTROLS
+        .iter()
+        .map(|c| standard::face_path(c.name))
+        .collect();
+
+    let (g_cov, g_miss) = split(gaze_paths);
+    let (e_cov, e_miss) = split(expression_paths);
+    let (v_cov, v_miss) = split(viseme_paths);
+    let (m_cov, m_miss) = split(muscle_paths);
+
+    let mut level = 0;
+    let l0 = g_miss.is_empty();
+    if l0 && e_miss.is_empty() {
+        level = 1;
+        if v_miss.is_empty() {
+            level = 2;
+            if m_cov.len() >= m_miss.len() {
+                level = 3;
+            }
+        }
+    }
+
+    Coverage {
+        face_id: face
+            .bundle()
+            .and_then(|b| b.pointer("/metadata/faceId"))
+            .and_then(Json::as_str)
+            .map(str::to_string),
+        level,
+        tiers: vec![
+            TierCoverage {
+                tier: "gaze",
+                covered: g_cov,
+                missing: g_miss,
+            },
+            TierCoverage {
+                tier: "expression",
+                covered: e_cov,
+                missing: e_miss,
+            },
+            TierCoverage {
+                tier: "viseme",
+                covered: v_cov,
+                missing: v_miss,
+            },
+            TierCoverage {
+                tier: "muscle",
+                covered: m_cov,
+                missing: m_miss,
+            },
+        ],
+    }
+}
+
+impl Coverage {
+    /// The report as JSON (the machine-readable `validate` output).
+    pub fn to_json(&self) -> Json {
+        let mut tiers = Map::new();
+        for t in &self.tiers {
+            tiers.insert(
+                t.tier.to_string(),
+                json!({
+                    "covered": t.covered.len(),
+                    "of": t.covered.len() + t.missing.len(),
+                    "missing": t.missing,
+                }),
+            );
+        }
+        json!({
+            "faceId": self.face_id,
+            "level": format!("L{}", self.level),
+            "tiers": tiers,
+        })
+    }
+}
+
+/// A compact inspection summary of a face GLB (the `inspect` output).
+pub fn inspect(face: &Face) -> Json {
+    let morphs: Vec<Json> = face
+        .gltf
+        .get("nodes")
+        .and_then(Json::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|node| {
+            let name = node.get("name").and_then(Json::as_str)?;
+            let features = node
+                .pointer("/extensions/RobotData/features")?
+                .as_object()?;
+            let mut names: Vec<&str> = features.keys().map(String::as_str).collect();
+            names.sort_unstable();
+            Some(json!({ "node": name, "features": names }))
+        })
+        .collect();
+    let graphs: Vec<Json> = face
+        .bundle()
+        .and_then(|b| b.get("graphs"))
+        .and_then(Json::as_array)
+        .into_iter()
+        .flatten()
+        .map(|g| {
+            let nodes = g.pointer("/spec/nodes").and_then(Json::as_array);
+            json!({
+                "kind": g.get("kind"),
+                "id": g.get("id"),
+                "nodes": nodes.map_or(0, Vec::len),
+            })
+        })
+        .collect();
+    json!({
+        "faceId": face.bundle().and_then(|b| b.pointer("/metadata/faceId")),
+        "graphs": graphs,
+        "inputs": face.input_paths(),
+        "animatables": morphs,
+    })
+}
+
+/// Pretty-print JSON with a trailing newline — the sidecar format (stable,
+/// so unpack → pack round-trips byte-identically).
+pub fn to_sidecar(value: &Json) -> Result<String> {
+    let mut text = serde_json::to_string_pretty(value)?;
+    text.push('\n');
+    Ok(text)
+}
+
+/// Read a sidecar (or any JSON file) back.
+pub fn from_sidecar(text: &str) -> Result<Json> {
+    if text.trim().is_empty() {
+        bail!("empty sidecar");
+    }
+    serde_json::from_str(text).context("sidecar JSON")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A minimal GLB carrying a bundle with one rig graph.
+    fn face_bytes(input_paths: &[&str]) -> Vec<u8> {
+        let nodes: Vec<Json> = input_paths
+            .iter()
+            .enumerate()
+            .map(|(i, path)| {
+                json!({ "id": format!("in{i}"), "type": "input", "params": { "path": path } })
+            })
+            .collect();
+        let gltf = json!({
+            "asset": { "version": "2.0" },
+            "nodes": [{
+                "name": "Scene",
+                "extensions": { "VIZIJ_bundle": {
+                    "version": 1,
+                    "metadata": { "faceId": "test_face" },
+                    "graphs": [{ "kind": "rig", "id": "test_rig",
+                                 "spec": { "nodes": nodes, "edges": [] } }],
+                } },
+            }],
+        });
+        let glb = Glb {
+            version: 2,
+            json: serde_json::to_vec(&gltf).unwrap(),
+            tail: Vec::new(),
+        };
+        glb.to_bytes()
+    }
+
+    #[test]
+    fn input_paths_strip_the_rig_prefix() {
+        let bytes = face_bytes(&[
+            "rig/test_face/standard/vizij/left_eye/pos/x",
+            "rig/test_face/custom/thing",
+        ]);
+        let face = Face::parse(&bytes).unwrap();
+        assert_eq!(
+            face.input_paths(),
+            ["custom/thing", "standard/vizij/left_eye/pos/x"]
+        );
+    }
+
+    #[test]
+    fn add_graph_appends_then_replaces() {
+        let bytes = face_bytes(&["rig/test_face/x"]);
+        let mut face = Face::parse(&bytes).unwrap();
+        face.add_graph(
+            "standard-adaptation",
+            "adapt",
+            json!({ "nodes": [], "edges": [] }),
+        )
+        .unwrap();
+        let count = |f: &Face| f.bundle().unwrap()["graphs"].as_array().unwrap().len();
+        assert_eq!(count(&face), 2);
+        // Same id replaces, not duplicates.
+        face.add_graph(
+            "standard-adaptation",
+            "adapt",
+            json!({ "nodes": [], "edges": [] }),
+        )
+        .unwrap();
+        assert_eq!(count(&face), 2);
+
+        // The grafted bundle survives a GLB round-trip.
+        let packed = face.to_bytes().unwrap();
+        let reparsed = Face::parse(&packed).unwrap();
+        assert_eq!(count(&reparsed), 2);
+    }
+
+    #[test]
+    fn add_standard_embeds_a_prefixed_updatable_profile() {
+        let bytes = face_bytes(&["rig/test_face/x"]);
+        let mut face = Face::parse(&bytes).unwrap();
+        face.add_standard_profile("ros4hri").unwrap();
+        assert!(face.add_standard_profile("nope").is_err());
+
+        let graphs = face.bundle().unwrap()["graphs"].as_array().unwrap();
+        let embedded = graphs
+            .iter()
+            .find(|g| g["id"] == "standard::ros4hri")
+            .expect("the profile embedded");
+        assert_eq!(embedded["kind"], "standard-profile");
+        // Its outputs carry this face's rig prefix.
+        let prefixed = embedded["spec"]["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|n| n["type"] == "output")
+            .any(|n| {
+                n["params"]["path"]
+                    .as_str()
+                    .is_some_and(|p| p.starts_with("rig/test_face/standard/vizij/"))
+            });
+        assert!(prefixed, "profile outputs are not rig-prefixed");
+
+        // Re-embedding replaces rather than duplicates — the copy is updatable.
+        let before = graphs.len();
+        face.add_standard_profile("ros4hri").unwrap();
+        assert_eq!(
+            face.bundle().unwrap()["graphs"].as_array().unwrap().len(),
+            before
+        );
+    }
+
+    #[test]
+    fn coverage_levels_progress_by_tier() {
+        // Only two gaze paths: not even L0, and the report names the missing.
+        let bytes = face_bytes(&[
+            "rig/test_face/standard/vizij/left_eye/pos/x",
+            "rig/test_face/standard/vizij/left_eye/pos/y",
+        ]);
+        let cov = coverage(&Face::parse(&bytes).unwrap());
+        assert_eq!(cov.level, 0);
+        assert!(cov.tiers[0]
+            .missing
+            .contains(&standard::RIGHT_EYE_POS_X.to_string()));
+
+        // Full gaze + expressions + visemes: L2.
+        let mut paths: Vec<String> = vec![
+            standard::LEFT_EYE_POS_X.into(),
+            standard::LEFT_EYE_POS_Y.into(),
+            standard::RIGHT_EYE_POS_X.into(),
+            standard::RIGHT_EYE_POS_Y.into(),
+            standard::LEFT_EYE_TOP_EYELID_POS_Y.into(),
+            standard::RIGHT_EYE_TOP_EYELID_POS_Y.into(),
+        ];
+        paths.extend(
+            standard::EXPRESSION_NAMES
+                .iter()
+                .map(|n| standard::expression_path(n)),
+        );
+        paths.extend(
+            standard::VISEME_SHAPES
+                .iter()
+                .map(|s| standard::viseme_path(s)),
+        );
+        let prefixed: Vec<String> = paths.iter().map(|p| format!("rig/test_face/{p}")).collect();
+        let refs: Vec<&str> = prefixed.iter().map(String::as_str).collect();
+        let cov = coverage(&Face::parse(&face_bytes(&refs)).unwrap());
+        assert_eq!(cov.level, 2);
+        assert_eq!(cov.face_id.as_deref(), Some("test_face"));
+    }
+}

--- a/crates/tools/vizij-bundle/src/main.rs
+++ b/crates/tools/vizij-bundle/src/main.rs
@@ -1,0 +1,227 @@
+//! The `vizij-bundle` CLI. Subcommands:
+//!
+//! - `inspect <glb>` — face summary as JSON: id, graphs, input surface,
+//!   animatable features per node.
+//! - `unpack <glb> -o <bundle.json>` — extract the `VIZIJ_bundle` as a
+//!   pretty-printed sidecar (the reviewable source of truth).
+//! - `pack <glb> --bundle <bundle.json> -o <out.glb>` — write a sidecar back
+//!   into a GLB.
+//! - `add-graph <glb> --graph <spec.json> --kind <kind> --id <id> -o <out.glb>`
+//!   — graft one graph (e.g. a face's `standard-adaptation`) into the bundle,
+//!   replacing any entry with the same id.
+//! - `add-standard <glb> --standard <profile> -o <out.glb>` — embed a shipped
+//!   standard profile (see `profiles`) into the face: the profile's control
+//!   paths get the face's rig prefix, and re-adding replaces, so the embedded
+//!   copy is updatable.
+//! - `validate <glb>` — standard-coverage report (tiers, level, missing
+//!   paths) as JSON; exits 1 below `--min-level`.
+//! - `profiles` — list the standard profiles Vizij ships, as JSON.
+//! - `export-profile <profile> [-o <file.json>]` — regenerate a profile's
+//!   canonical asset from its generator (stdout without `-o`).
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use anyhow::{anyhow, bail, Context, Result};
+use vizij_arora_host::{profiles, ros4hri};
+
+struct Args {
+    command: String,
+    /// The positional argument: a GLB path, or a profile id for
+    /// `export-profile`.
+    target: Option<String>,
+    output: Option<PathBuf>,
+    bundle: Option<PathBuf>,
+    graph: Option<PathBuf>,
+    kind: Option<String>,
+    id: Option<String>,
+    standard: Option<String>,
+    min_level: u8,
+}
+
+const USAGE: &str = "usage: vizij-bundle <command> …
+  inspect        <face.glb>
+  unpack         <face.glb> -o <bundle.json>
+  pack           <face.glb> --bundle <bundle.json> -o <out.glb>
+  add-graph      <face.glb> --graph <spec.json> --kind <kind> --id <id> -o <out.glb>
+  add-standard   <face.glb> --standard <profile> -o <out.glb>
+  validate       <face.glb> [--min-level <0-3>]
+  profiles
+  export-profile <profile> [-o <file.json>]";
+
+fn parse_args() -> Result<Args> {
+    let mut args = std::env::args().skip(1);
+    let command = args.next().ok_or_else(|| anyhow!("{USAGE}"))?;
+    let mut target = None;
+    let mut output = None;
+    let mut bundle = None;
+    let mut graph = None;
+    let mut kind = None;
+    let mut id = None;
+    let mut standard = None;
+    let mut min_level = 0;
+    while let Some(arg) = args.next() {
+        let mut value = |name: &str| {
+            args.next()
+                .ok_or_else(|| anyhow!("{name} expects a value\n{USAGE}"))
+        };
+        match arg.as_str() {
+            "-o" | "--output" => output = Some(PathBuf::from(value("-o")?)),
+            "--bundle" => bundle = Some(PathBuf::from(value("--bundle")?)),
+            "--graph" => graph = Some(PathBuf::from(value("--graph")?)),
+            "--kind" => kind = Some(value("--kind")?),
+            "--id" => id = Some(value("--id")?),
+            "--standard" => standard = Some(value("--standard")?),
+            "--min-level" => min_level = value("--min-level")?.parse().context("--min-level")?,
+            "-h" | "--help" => bail!("{USAGE}"),
+            _ if target.is_none() => target = Some(arg),
+            _ => bail!("unexpected argument {arg}\n{USAGE}"),
+        }
+    }
+    Ok(Args {
+        command,
+        target,
+        output,
+        bundle,
+        graph,
+        kind,
+        id,
+        standard,
+        min_level,
+    })
+}
+
+/// The commands that work on shipped assets rather than a GLB.
+fn run_assets(args: &Args) -> Result<Option<ExitCode>> {
+    match args.command.as_str() {
+        "profiles" => {
+            println!(
+                "{}",
+                vizij_bundle::to_sidecar(&profiles::standard_profiles_json())?
+            );
+            Ok(Some(ExitCode::SUCCESS))
+        }
+        "export-profile" => {
+            let id = args
+                .target
+                .as_deref()
+                .ok_or_else(|| anyhow!("export-profile needs a profile id\n{USAGE}"))?;
+            profiles::standard_profile(id)
+                .ok_or_else(|| anyhow!("unknown profile {id} (see `vizij-bundle profiles`)"))?;
+            // One generator today; the registry keys which one to run.
+            let spec = match id {
+                "ros4hri" => ros4hri::generate(),
+                _ => unreachable!("registered profiles have generators"),
+            };
+            let text = vizij_bundle::to_sidecar(&spec)?;
+            match &args.output {
+                Some(path) => std::fs::write(path, text)
+                    .with_context(|| format!("write {}", path.display()))?,
+                None => print!("{text}"),
+            }
+            Ok(Some(ExitCode::SUCCESS))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn run() -> Result<ExitCode> {
+    let args = parse_args()?;
+    if let Some(code) = run_assets(&args)? {
+        return Ok(code);
+    }
+
+    let glb = PathBuf::from(
+        args.target
+            .as_deref()
+            .ok_or_else(|| anyhow!("missing <face.glb>\n{USAGE}"))?,
+    );
+    let bytes = std::fs::read(&glb).with_context(|| format!("read {}", glb.display()))?;
+    let mut face = vizij_bundle::Face::parse(&bytes)?;
+
+    match args.command.as_str() {
+        "inspect" => {
+            println!(
+                "{}",
+                vizij_bundle::to_sidecar(&vizij_bundle::inspect(&face))?
+            );
+        }
+        "unpack" => {
+            let bundle = face
+                .bundle()
+                .ok_or_else(|| anyhow!("the GLB carries no VIZIJ_bundle"))?;
+            let text = vizij_bundle::to_sidecar(bundle)?;
+            match &args.output {
+                Some(path) => std::fs::write(path, text)
+                    .with_context(|| format!("write {}", path.display()))?,
+                None => print!("{text}"),
+            }
+        }
+        "pack" => {
+            let path = args
+                .bundle
+                .ok_or_else(|| anyhow!("pack needs --bundle\n{USAGE}"))?;
+            let text = std::fs::read_to_string(&path)
+                .with_context(|| format!("read {}", path.display()))?;
+            face.set_bundle(vizij_bundle::from_sidecar(&text)?)?;
+            let out = args
+                .output
+                .ok_or_else(|| anyhow!("pack needs -o\n{USAGE}"))?;
+            std::fs::write(&out, face.to_bytes()?)
+                .with_context(|| format!("write {}", out.display()))?;
+        }
+        "add-graph" => {
+            let path = args
+                .graph
+                .ok_or_else(|| anyhow!("add-graph needs --graph\n{USAGE}"))?;
+            let text = std::fs::read_to_string(&path)
+                .with_context(|| format!("read {}", path.display()))?;
+            let kind = args
+                .kind
+                .ok_or_else(|| anyhow!("add-graph needs --kind\n{USAGE}"))?;
+            let id = args
+                .id
+                .ok_or_else(|| anyhow!("add-graph needs --id\n{USAGE}"))?;
+            face.add_graph(&kind, &id, vizij_bundle::from_sidecar(&text)?)?;
+            let out = args
+                .output
+                .ok_or_else(|| anyhow!("add-graph needs -o\n{USAGE}"))?;
+            std::fs::write(&out, face.to_bytes()?)
+                .with_context(|| format!("write {}", out.display()))?;
+        }
+        "add-standard" => {
+            let id = args
+                .standard
+                .ok_or_else(|| anyhow!("add-standard needs --standard\n{USAGE}"))?;
+            face.add_standard_profile(&id)?;
+            let out = args
+                .output
+                .ok_or_else(|| anyhow!("add-standard needs -o\n{USAGE}"))?;
+            std::fs::write(&out, face.to_bytes()?)
+                .with_context(|| format!("write {}", out.display()))?;
+        }
+        "validate" => {
+            let coverage = vizij_bundle::coverage(&face);
+            println!("{}", vizij_bundle::to_sidecar(&coverage.to_json())?);
+            if coverage.level < args.min_level {
+                eprintln!(
+                    "coverage L{} is below the required L{}",
+                    coverage.level, args.min_level
+                );
+                return Ok(ExitCode::FAILURE);
+            }
+        }
+        other => bail!("unknown command {other}\n{USAGE}"),
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("vizij-bundle: {e:#}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/vizij/Cargo.toml
+++ b/crates/vizij/Cargo.toml
@@ -66,6 +66,9 @@ vizij-animation-module = { path = "../interop/vizij-animation-module" }
 # The interpreter-module SPAWN/HALT codecs and RunPolicy the device test
 # drives the graph interpreter with.
 arora-behavior = "8"
+# The bundler, for the Quori integration test (grafts the standard-adaptation
+# sidecar into the demo GLB before driving it over the ROS4HRI keys).
+vizij-bundle = { path = "../tools/vizij-bundle" }
 
 [features]
 default = []

--- a/crates/vizij/src/device.rs
+++ b/crates/vizij/src/device.rs
@@ -72,6 +72,10 @@ pub struct FaceConfig {
     pub program: ProgramSelect,
     /// Stage the bundle's neutral inputs into the store at boot.
     pub stage_neutral: bool,
+    /// Compose the built-in ROS4HRI profile (`standard/ros4hri/*` keys drive
+    /// the face's standard controls). On by default in the binary, opt-out
+    /// via `--no-ros4hri`.
+    pub ros4hri: bool,
 }
 
 /// The bridges the device serves beyond the always-on open local bridge — a
@@ -130,12 +134,21 @@ pub fn load_face(glb: &Path, config: &FaceConfig) -> Result<(String, FaceMeta, S
         .with_context(|| format!("cannot resolve {}", glb.display()))?;
     let meta = FaceMeta::from_glb_file(&canonical)?;
     let wanted: Vec<&str> = config.wanted.iter().map(String::as_str).collect();
+    // The standard profiles this face composes: ROS4HRI unless opted out. The
+    // profile writes the face's namespaced standard controls, so it takes the
+    // bundle's rig prefix.
+    let mut profiles = Vec::new();
+    if config.ros4hri {
+        profiles.push(vizij_arora_host::ros4hri::ros4hri_source(
+            &meta.bundle.rig_prefix(),
+        ));
+    }
     // `with_animations`: the device always loads the animation module (see
     // `builder_for`), so the animation source it dispatches to is always
     // composed — inert until a clip plays.
     let spec = meta
         .bundle
-        .compose(&wanted, &config.program, true)?
+        .compose(&wanted, &config.program, true, &profiles)?
         .to_string();
     parse_spec(&spec).map_err(|e| anyhow!("composed spec does not parse: {e}"))?;
     Ok((canonical.to_string_lossy().into_owned(), meta, spec))
@@ -507,5 +520,223 @@ mod tests {
             .expect("the handle's stop call dispatches");
         arora.step(Duration::from_millis(16)).expect("step");
         assert_eq!(status(&arora), Some(task::failure()), "halted");
+    }
+
+    use vizij_api_core::value::{as_float, text, vec3, Value};
+    use vizij_arora_host::ros4hri::{self, ros4hri_source};
+    use vizij_arora_host::standard;
+
+    /// A device running only the ROS4HRI profile (unprefixed controls) — the
+    /// headless harness for the profile's mapping math: stage `standard/
+    /// ros4hri/*` keys, tick, read `standard/vizij/*` controls back.
+    fn ros4hri_device() -> arora::Arora {
+        let spec = compose_sources(&[ros4hri_source("")])
+            .expect("compose the ros4hri profile")
+            .to_string();
+        builder_for(&spec, RigHal::new(), BlackboardStore::new())
+            .expect("build the device over the profile")
+            .build()
+            .expect("build arora")
+    }
+
+    fn stage(arora: &arora::Arora, path: &str, value: Value) {
+        let mut change = StateChange::new();
+        change.set.insert(Key::from(path), Some(value));
+        arora.store().write(change).expect("stage");
+    }
+
+    fn read_f32(arora: &arora::Arora, path: &str) -> f32 {
+        let key = Key::from(path);
+        let value = arora
+            .store()
+            .read(std::slice::from_ref(&key))
+            .into_iter()
+            .next()
+            .flatten()
+            .unwrap_or_else(|| panic!("{path} absent"));
+        as_float(&value).unwrap_or_else(|| panic!("{path} not a float"))
+    }
+
+    /// Settle the ~200 ms smoothers: 2 s of 16 ms ticks.
+    fn settle(arora: &mut arora::Arora) {
+        for _ in 0..125 {
+            arora.step(Duration::from_millis(16)).expect("step");
+        }
+    }
+
+    #[test]
+    fn ros4hri_profile_rests_neutral() {
+        let mut arora = ros4hri_device();
+        settle(&mut arora);
+        assert!(read_f32(&arora, &standard::expression_path("neutral")) > 0.95);
+        assert!(read_f32(&arora, &standard::expression_path("happy")) < 0.01);
+        assert!(read_f32(&arora, &standard::expression_path("skeptical")) < 0.01);
+        // Eyes at their default forward target: centered.
+        assert!(read_f32(&arora, standard::LEFT_EYE_POS_X).abs() < 0.01);
+    }
+
+    #[test]
+    fn ros4hri_expression_name_one_hots() {
+        let mut arora = ros4hri_device();
+        stage(&arora, ros4hri::EXPRESSION_NAME_KEY, text("happy"));
+        settle(&mut arora);
+        assert!(read_f32(&arora, &standard::expression_path("happy")) > 0.95);
+        assert!(read_f32(&arora, &standard::expression_path("neutral")) < 0.01);
+        assert!(read_f32(&arora, &standard::expression_path("sad")) < 0.01);
+    }
+
+    #[test]
+    fn ros4hri_valence_arousal_blends_anchors() {
+        let mut arora = ros4hri_device();
+        stage(&arora, ros4hri::EXPRESSION_VALENCE_KEY, float(0.8));
+        stage(&arora, ros4hri::EXPRESSION_AROUSAL_KEY, float(0.4));
+        settle(&mut arora);
+        // The happy anchor sits at (0.8, 0.4): dominant, blended with its
+        // positive-affect neighbors, nothing negative.
+        let happy = read_f32(&arora, &standard::expression_path("happy"));
+        assert!(happy > 0.4, "happy = {happy}");
+        assert!(read_f32(&arora, &standard::expression_path("angry")) < 0.01);
+        assert!(read_f32(&arora, &standard::expression_path("neutral")) < 0.05);
+    }
+
+    #[test]
+    fn ros4hri_gaze_maps_eyes_with_vergence() {
+        let mut arora = ros4hri_device();
+        stage(&arora, ros4hri::GAZE_TARGET_KEY, vec3([1.0, 0.3, 0.2]));
+        settle(&mut arora);
+        let left_x = read_f32(&arora, standard::LEFT_EYE_POS_X);
+        let right_x = read_f32(&arora, standard::RIGHT_EYE_POS_X);
+        let left_y = read_f32(&arora, standard::LEFT_EYE_POS_Y);
+        // atan(0.33)/0.78 ≈ 0.41 (left, verged outward), atan(0.27)/0.78 ≈ 0.34.
+        assert!((0.35..=0.46).contains(&left_x), "left_x = {left_x}");
+        assert!((0.29..=0.40).contains(&right_x), "right_x = {right_x}");
+        assert!(left_x > right_x, "vergence: {left_x} <= {right_x}");
+        // atan(0.2)/0.78 ≈ 0.25.
+        assert!((0.20..=0.31).contains(&left_y), "left_y = {left_y}");
+
+        // Targets at or behind the face plane recenter the eyes.
+        stage(&arora, ros4hri::GAZE_TARGET_KEY, vec3([0.05, 0.5, 0.0]));
+        settle(&mut arora);
+        assert!(read_f32(&arora, standard::LEFT_EYE_POS_X).abs() < 0.01);
+    }
+
+    #[test]
+    fn ros4hri_action_units_route_to_muscles() {
+        let mut arora = ros4hri_device();
+        stage(&arora, &ros4hri::au_key(12), float(1.0));
+        stage(&arora, &ros4hri::au_key(26), float(0.8));
+        settle(&mut arora);
+        // AU 12 (lip corner puller) drives the lateralized smile pair.
+        assert!(read_f32(&arora, &standard::face_path("mouth_smile_left")) > 0.95);
+        assert!(read_f32(&arora, &standard::face_path("mouth_smile_right")) > 0.95);
+        assert!(read_f32(&arora, &standard::face_path("mouth_frown_left")) < 0.01);
+        // AU 26 (jaw drop) drives the muscle control and the de-facto mouth morph.
+        let jaw = read_f32(&arora, &standard::face_path("jaw_open"));
+        assert!((0.75..=0.85).contains(&jaw), "jaw = {jaw}");
+        let defacto = read_f32(&arora, "standard/vizij/mouth/morph/jaw_open");
+        assert!((0.75..=0.85).contains(&defacto), "de-facto jaw = {defacto}");
+    }
+
+    #[test]
+    fn ros4hri_visemes_pass_through() {
+        let mut arora = ros4hri_device();
+        stage(&arora, &ros4hri::viseme_key("aa"), float(1.0));
+        settle(&mut arora);
+        assert!(read_f32(&arora, &standard::viseme_path("aa")) > 0.95);
+        assert!(read_f32(&arora, &standard::viseme_path("oh")) < 0.01);
+    }
+
+    #[test]
+    fn ros4hri_blink_pulses_and_commanded_close_wins() {
+        let mut arora = ros4hri_device();
+        // Over 10 s the jittered 8 s cycle blinks at least once; between
+        // blinks the lids rest open.
+        let mut min_lid = f32::MAX;
+        let mut max_lid = f32::MIN;
+        for _ in 0..625 {
+            arora.step(Duration::from_millis(16)).expect("step");
+            let lid = read_f32(&arora, standard::LEFT_EYE_TOP_EYELID_POS_Y);
+            min_lid = min_lid.min(lid);
+            max_lid = max_lid.max(lid);
+        }
+        assert!(max_lid > 0.5, "no blink in 10 s (max lid {max_lid})");
+        assert!(min_lid < 0.05, "lids never rest open (min lid {min_lid})");
+
+        // Commanded eyes-closed holds the lids shut and inhibits the pulse.
+        stage(&arora, &ros4hri::au_key(43), float(1.0));
+        settle(&mut arora);
+        for _ in 0..300 {
+            arora.step(Duration::from_millis(16)).expect("step");
+            let lid = read_f32(&arora, standard::LEFT_EYE_TOP_EYELID_POS_Y);
+            assert!(lid > 0.9, "lid opened while commanded closed ({lid})");
+        }
+    }
+
+    /// End-to-end over the real demo face: graft Quori's standard-adaptation
+    /// sidecar into `Quori_Current_Extended.glb` with the bundler, compose the
+    /// ROS4HRI profile, and drive the ROS4HRI keys through to Quori's pose
+    /// plane. Needs the GLB: set `VIZIJ_FIXTURES` to a directory holding it
+    /// (the snapshot-regression convention); skipped otherwise.
+    #[test]
+    fn ros4hri_drives_the_adapted_quori() {
+        let Ok(fixtures) = std::env::var("VIZIJ_FIXTURES") else {
+            eprintln!("VIZIJ_FIXTURES unset — skipping the Quori integration test");
+            return;
+        };
+        let glb = std::path::Path::new(&fixtures).join("Quori_Current_Extended.glb");
+        let bytes = std::fs::read(&glb).expect("read the Quori GLB");
+
+        // The bundler grafts the committed adaptation sidecar into the bundle.
+        let sidecar = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../fixtures/faces/quori/standard-adaptation.json"
+        );
+        let spec = vizij_bundle::from_sidecar(
+            &std::fs::read_to_string(sidecar).expect("read the adaptation sidecar"),
+        )
+        .expect("parse the adaptation sidecar");
+        let mut face = vizij_bundle::Face::parse(&bytes).expect("parse the Quori GLB");
+        face.add_graph("standard-adaptation", "quori_standard_adaptation", spec)
+            .expect("graft the adaptation");
+        let adapted = face.to_bytes().expect("repack the GLB");
+        let cov = vizij_bundle::coverage(&vizij_bundle::Face::parse(&adapted).unwrap());
+        assert!(cov.level >= 2, "adapted Quori below L2 (L{})", cov.level);
+
+        let dir = std::env::temp_dir().join("vizij-ros4hri-quori");
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("Quori_Current_Extended_adapted.glb");
+        std::fs::write(&path, &adapted).expect("write the adapted GLB");
+
+        // Compose like the binary's defaults: standard graphs + the ROS4HRI
+        // profile, no autoplay (the idle program would contend on gaze paths).
+        let config = FaceConfig {
+            wanted: ["rig", "pose-driver", "pose", "standard-adaptation"]
+                .map(String::from)
+                .to_vec(),
+            program: ProgramSelect::None,
+            stage_neutral: true,
+            ros4hri: true,
+        };
+        let (_, meta, spec) = load_face(&path, &config).expect("load the adapted face");
+        let store = BlackboardStore::new();
+        stage_neutral_pose(&store, &meta);
+        let mut arora = builder_for(&spec, RigHal::new(), store)
+            .expect("build the device")
+            .build()
+            .expect("build arora");
+
+        // A ROS4HRI expression command reaches Quori's emotion-pose plane.
+        stage(&arora, ros4hri::EXPRESSION_NAME_KEY, text("happy"));
+        settle(&mut arora);
+        let waist = read_f32(&arora, "rig/quori_latest/standard/vizij/expression/happy");
+        assert!(waist > 0.95, "profile output missing (happy = {waist})");
+        let pose = read_f32(&arora, "rig/quori_latest/poses/pose_d_happy_d.weight");
+        assert!(pose > 0.95, "adaptation output missing (pose = {pose})");
+
+        // A viseme command reaches the letter-pose plane.
+        stage(&arora, &ros4hri::viseme_key("aa"), float(1.0));
+        settle(&mut arora);
+        let mouth = read_f32(&arora, "rig/quori_latest/poses/pose_a.weight");
+        assert!(mouth > 0.95, "viseme mapping missing (pose_a = {mouth})");
     }
 }

--- a/crates/vizij/src/main.rs
+++ b/crates/vizij/src/main.rs
@@ -60,8 +60,9 @@ struct Cli {
     fit: view::Fit,
 
     /// Compose only these bundle graph kinds (comma-separated), e.g. "rig" or
-    /// "rig,pose-driver". Default: rig + pose-driver.
-    #[arg(long, default_value = "rig,pose-driver,pose")]
+    /// "rig,pose-driver". Default: rig + pose-driver + the face's standard
+    /// adaptation graphs.
+    #[arg(long, default_value = "rig,pose-driver,pose,standard-adaptation")]
     graphs: String,
 
     /// Publish rendered frames into the store as HAL `view/frame` readings, at
@@ -87,6 +88,12 @@ struct Cli {
     /// Don't stage the bundle's `neutralInputs` into the store at boot.
     #[arg(long)]
     no_stage_neutral: bool,
+
+    /// Don't compose the built-in ROS4HRI profile (on by default: the
+    /// `standard/ros4hri/*` keys — expression, gaze, action units, visemes —
+    /// drive the face's standard controls, with idle blink and smoothing).
+    #[arg(long)]
+    no_ros4hri: bool,
 
     /// Expose the device's keys over ROS 2 topics: `--ros2 [namespace][:domain]`
     /// (namespace empty and domain 0 by default). Composes with the local bridge.
@@ -136,6 +143,7 @@ fn main() -> Result<()> {
         wanted,
         program,
         stage_neutral: !cli.no_stage_neutral,
+        ros4hri: !cli.no_ros4hri,
     };
     let bridges = device::BridgeConfig {
         #[cfg(feature = "ros2")]

--- a/fixtures/faces/quori/standard-adaptation.json
+++ b/fixtures/faces/quori/standard-adaptation.json
@@ -1,0 +1,1698 @@
+{
+  "nodes": [
+    {
+      "id": "c0",
+      "type": "constant",
+      "params": {
+        "value": 0.0
+      }
+    },
+    {
+      "id": "c1",
+      "type": "constant",
+      "params": {
+        "value": 1.0
+      }
+    },
+    {
+      "id": "in_expr_neutral",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/neutral",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_angry",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/angry",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_sad",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/sad",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_happy",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/happy",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_surprised",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/surprised",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_disgusted",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/disgusted",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_scared",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/scared",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_pleading",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/pleading",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_vulnerable",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/vulnerable",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_despaired",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/despaired",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_guilty",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/guilty",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_disappointed",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/disappointed",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_embarrassed",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/embarrassed",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_horrified",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/horrified",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_skeptical",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/skeptical",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_annoyed",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/annoyed",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_furious",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/furious",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_suspicious",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/suspicious",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_rejected",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/rejected",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_bored",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/bored",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_tired",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/tired",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_asleep",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/asleep",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_confused",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/confused",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_amazed",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/amazed",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_expr_excited",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/expression/excited",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_vis_sil",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/viseme/sil",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_vis_PP",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/viseme/PP",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_vis_FF",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/viseme/FF",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_vis_TH",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/viseme/TH",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_vis_DD",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/viseme/DD",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_vis_kk",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/viseme/kk",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_vis_CH",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/viseme/CH",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_vis_SS",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/viseme/SS",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_vis_nn",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/viseme/nn",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_vis_RR",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/viseme/RR",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_vis_aa",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/viseme/aa",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_vis_E",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/viseme/E",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_vis_ih",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/viseme/ih",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_vis_oh",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/viseme/oh",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "in_vis_ou",
+      "type": "input",
+      "params": {
+        "path": "rig/quori_latest/standard/vizij/viseme/ou",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "sum_d_anger",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "clamp_d_anger",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "out_d_anger",
+      "type": "output",
+      "params": {
+        "path": "rig/quori_latest/poses/pose_d_anger_d.weight"
+      }
+    },
+    {
+      "id": "sum_d_sad",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "clamp_d_sad",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "out_d_sad",
+      "type": "output",
+      "params": {
+        "path": "rig/quori_latest/poses/pose_d_sad_d.weight"
+      }
+    },
+    {
+      "id": "sum_d_concerned",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "clamp_d_concerned",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "out_d_concerned",
+      "type": "output",
+      "params": {
+        "path": "rig/quori_latest/poses/pose_d_concerned_d.weight"
+      }
+    },
+    {
+      "id": "sum_d_surprise",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "clamp_d_surprise",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "out_d_surprise",
+      "type": "output",
+      "params": {
+        "path": "rig/quori_latest/poses/pose_d_surprise_d.weight"
+      }
+    },
+    {
+      "id": "sum_d_happy",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "clamp_d_happy",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "out_d_happy",
+      "type": "output",
+      "params": {
+        "path": "rig/quori_latest/poses/pose_d_happy_d.weight"
+      }
+    },
+    {
+      "id": "sum_d_sleepy",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "clamp_d_sleepy",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "out_d_sleepy",
+      "type": "output",
+      "params": {
+        "path": "rig/quori_latest/poses/pose_d_sleepy_d.weight"
+      }
+    },
+    {
+      "id": "sum_d_neutral",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "clamp_d_neutral",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "out_d_neutral",
+      "type": "output",
+      "params": {
+        "path": "rig/quori_latest/poses/pose_d_neutral_d.weight"
+      }
+    },
+    {
+      "id": "sum_p",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "clamp_p",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "out_p",
+      "type": "output",
+      "params": {
+        "path": "rig/quori_latest/poses/pose_p.weight"
+      }
+    },
+    {
+      "id": "sum_f",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "clamp_f",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "out_f",
+      "type": "output",
+      "params": {
+        "path": "rig/quori_latest/poses/pose_f.weight"
+      }
+    },
+    {
+      "id": "sum_t_2",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "clamp_t_2",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "out_t_2",
+      "type": "output",
+      "params": {
+        "path": "rig/quori_latest/poses/pose_t_2.weight"
+      }
+    },
+    {
+      "id": "sum_t",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "clamp_t",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "out_t",
+      "type": "output",
+      "params": {
+        "path": "rig/quori_latest/poses/pose_t.weight"
+      }
+    },
+    {
+      "id": "sum_k",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "clamp_k",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "out_k",
+      "type": "output",
+      "params": {
+        "path": "rig/quori_latest/poses/pose_k.weight"
+      }
+    },
+    {
+      "id": "sum_s",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "clamp_s",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "out_s",
+      "type": "output",
+      "params": {
+        "path": "rig/quori_latest/poses/pose_s.weight"
+      }
+    },
+    {
+      "id": "sum_r",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "clamp_r",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "out_r",
+      "type": "output",
+      "params": {
+        "path": "rig/quori_latest/poses/pose_r.weight"
+      }
+    },
+    {
+      "id": "sum_a",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "clamp_a",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "out_a",
+      "type": "output",
+      "params": {
+        "path": "rig/quori_latest/poses/pose_a.weight"
+      }
+    },
+    {
+      "id": "sum_e",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "clamp_e",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "out_e",
+      "type": "output",
+      "params": {
+        "path": "rig/quori_latest/poses/pose_e.weight"
+      }
+    },
+    {
+      "id": "sum_i",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "clamp_i",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "out_i",
+      "type": "output",
+      "params": {
+        "path": "rig/quori_latest/poses/pose_i.weight"
+      }
+    },
+    {
+      "id": "sum_o",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "clamp_o",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "out_o",
+      "type": "output",
+      "params": {
+        "path": "rig/quori_latest/poses/pose_o.weight"
+      }
+    },
+    {
+      "id": "sum_u",
+      "type": "add",
+      "params": {}
+    },
+    {
+      "id": "clamp_u",
+      "type": "clamp",
+      "params": {}
+    },
+    {
+      "id": "out_u",
+      "type": "output",
+      "params": {
+        "path": "rig/quori_latest/poses/pose_u.weight"
+      }
+    }
+  ],
+  "edges": [
+    {
+      "from": {
+        "node_id": "in_expr_angry"
+      },
+      "to": {
+        "node_id": "sum_d_anger",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_furious"
+      },
+      "to": {
+        "node_id": "sum_d_anger",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_annoyed"
+      },
+      "to": {
+        "node_id": "sum_d_anger",
+        "input": "operand_2"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_disgusted"
+      },
+      "to": {
+        "node_id": "sum_d_anger",
+        "input": "operand_3"
+      }
+    },
+    {
+      "from": {
+        "node_id": "sum_d_anger"
+      },
+      "to": {
+        "node_id": "clamp_d_anger",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c0"
+      },
+      "to": {
+        "node_id": "clamp_d_anger",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "clamp_d_anger",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clamp_d_anger"
+      },
+      "to": {
+        "node_id": "out_d_anger",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_sad"
+      },
+      "to": {
+        "node_id": "sum_d_sad",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_despaired"
+      },
+      "to": {
+        "node_id": "sum_d_sad",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_disappointed"
+      },
+      "to": {
+        "node_id": "sum_d_sad",
+        "input": "operand_2"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_guilty"
+      },
+      "to": {
+        "node_id": "sum_d_sad",
+        "input": "operand_3"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_rejected"
+      },
+      "to": {
+        "node_id": "sum_d_sad",
+        "input": "operand_4"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_vulnerable"
+      },
+      "to": {
+        "node_id": "sum_d_sad",
+        "input": "operand_5"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_embarrassed"
+      },
+      "to": {
+        "node_id": "sum_d_sad",
+        "input": "operand_6"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_pleading"
+      },
+      "to": {
+        "node_id": "sum_d_sad",
+        "input": "operand_7"
+      }
+    },
+    {
+      "from": {
+        "node_id": "sum_d_sad"
+      },
+      "to": {
+        "node_id": "clamp_d_sad",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c0"
+      },
+      "to": {
+        "node_id": "clamp_d_sad",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "clamp_d_sad",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clamp_d_sad"
+      },
+      "to": {
+        "node_id": "out_d_sad",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_scared"
+      },
+      "to": {
+        "node_id": "sum_d_concerned",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_horrified"
+      },
+      "to": {
+        "node_id": "sum_d_concerned",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_suspicious"
+      },
+      "to": {
+        "node_id": "sum_d_concerned",
+        "input": "operand_2"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_skeptical"
+      },
+      "to": {
+        "node_id": "sum_d_concerned",
+        "input": "operand_3"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_confused"
+      },
+      "to": {
+        "node_id": "sum_d_concerned",
+        "input": "operand_4"
+      }
+    },
+    {
+      "from": {
+        "node_id": "sum_d_concerned"
+      },
+      "to": {
+        "node_id": "clamp_d_concerned",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c0"
+      },
+      "to": {
+        "node_id": "clamp_d_concerned",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "clamp_d_concerned",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clamp_d_concerned"
+      },
+      "to": {
+        "node_id": "out_d_concerned",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_surprised"
+      },
+      "to": {
+        "node_id": "sum_d_surprise",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_amazed"
+      },
+      "to": {
+        "node_id": "sum_d_surprise",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "sum_d_surprise"
+      },
+      "to": {
+        "node_id": "clamp_d_surprise",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c0"
+      },
+      "to": {
+        "node_id": "clamp_d_surprise",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "clamp_d_surprise",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clamp_d_surprise"
+      },
+      "to": {
+        "node_id": "out_d_surprise",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_happy"
+      },
+      "to": {
+        "node_id": "sum_d_happy",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_excited"
+      },
+      "to": {
+        "node_id": "sum_d_happy",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "sum_d_happy"
+      },
+      "to": {
+        "node_id": "clamp_d_happy",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c0"
+      },
+      "to": {
+        "node_id": "clamp_d_happy",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "clamp_d_happy",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clamp_d_happy"
+      },
+      "to": {
+        "node_id": "out_d_happy",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_bored"
+      },
+      "to": {
+        "node_id": "sum_d_sleepy",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_tired"
+      },
+      "to": {
+        "node_id": "sum_d_sleepy",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_asleep"
+      },
+      "to": {
+        "node_id": "sum_d_sleepy",
+        "input": "operand_2"
+      }
+    },
+    {
+      "from": {
+        "node_id": "sum_d_sleepy"
+      },
+      "to": {
+        "node_id": "clamp_d_sleepy",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c0"
+      },
+      "to": {
+        "node_id": "clamp_d_sleepy",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "clamp_d_sleepy",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clamp_d_sleepy"
+      },
+      "to": {
+        "node_id": "out_d_sleepy",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_expr_neutral"
+      },
+      "to": {
+        "node_id": "sum_d_neutral",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "sum_d_neutral"
+      },
+      "to": {
+        "node_id": "clamp_d_neutral",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c0"
+      },
+      "to": {
+        "node_id": "clamp_d_neutral",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "clamp_d_neutral",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clamp_d_neutral"
+      },
+      "to": {
+        "node_id": "out_d_neutral",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_vis_PP"
+      },
+      "to": {
+        "node_id": "sum_p",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "sum_p"
+      },
+      "to": {
+        "node_id": "clamp_p",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c0"
+      },
+      "to": {
+        "node_id": "clamp_p",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "clamp_p",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clamp_p"
+      },
+      "to": {
+        "node_id": "out_p",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_vis_FF"
+      },
+      "to": {
+        "node_id": "sum_f",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "sum_f"
+      },
+      "to": {
+        "node_id": "clamp_f",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c0"
+      },
+      "to": {
+        "node_id": "clamp_f",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "clamp_f",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clamp_f"
+      },
+      "to": {
+        "node_id": "out_f",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_vis_TH"
+      },
+      "to": {
+        "node_id": "sum_t_2",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "sum_t_2"
+      },
+      "to": {
+        "node_id": "clamp_t_2",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c0"
+      },
+      "to": {
+        "node_id": "clamp_t_2",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "clamp_t_2",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clamp_t_2"
+      },
+      "to": {
+        "node_id": "out_t_2",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_vis_DD"
+      },
+      "to": {
+        "node_id": "sum_t",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_vis_nn"
+      },
+      "to": {
+        "node_id": "sum_t",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "sum_t"
+      },
+      "to": {
+        "node_id": "clamp_t",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c0"
+      },
+      "to": {
+        "node_id": "clamp_t",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "clamp_t",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clamp_t"
+      },
+      "to": {
+        "node_id": "out_t",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_vis_kk"
+      },
+      "to": {
+        "node_id": "sum_k",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "sum_k"
+      },
+      "to": {
+        "node_id": "clamp_k",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c0"
+      },
+      "to": {
+        "node_id": "clamp_k",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "clamp_k",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clamp_k"
+      },
+      "to": {
+        "node_id": "out_k",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_vis_CH"
+      },
+      "to": {
+        "node_id": "sum_s",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_vis_SS"
+      },
+      "to": {
+        "node_id": "sum_s",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "sum_s"
+      },
+      "to": {
+        "node_id": "clamp_s",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c0"
+      },
+      "to": {
+        "node_id": "clamp_s",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "clamp_s",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clamp_s"
+      },
+      "to": {
+        "node_id": "out_s",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_vis_RR"
+      },
+      "to": {
+        "node_id": "sum_r",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "sum_r"
+      },
+      "to": {
+        "node_id": "clamp_r",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c0"
+      },
+      "to": {
+        "node_id": "clamp_r",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "clamp_r",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clamp_r"
+      },
+      "to": {
+        "node_id": "out_r",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_vis_aa"
+      },
+      "to": {
+        "node_id": "sum_a",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "sum_a"
+      },
+      "to": {
+        "node_id": "clamp_a",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c0"
+      },
+      "to": {
+        "node_id": "clamp_a",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "clamp_a",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clamp_a"
+      },
+      "to": {
+        "node_id": "out_a",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_vis_E"
+      },
+      "to": {
+        "node_id": "sum_e",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "sum_e"
+      },
+      "to": {
+        "node_id": "clamp_e",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c0"
+      },
+      "to": {
+        "node_id": "clamp_e",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "clamp_e",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clamp_e"
+      },
+      "to": {
+        "node_id": "out_e",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_vis_ih"
+      },
+      "to": {
+        "node_id": "sum_i",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "sum_i"
+      },
+      "to": {
+        "node_id": "clamp_i",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c0"
+      },
+      "to": {
+        "node_id": "clamp_i",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "clamp_i",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clamp_i"
+      },
+      "to": {
+        "node_id": "out_i",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_vis_oh"
+      },
+      "to": {
+        "node_id": "sum_o",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "sum_o"
+      },
+      "to": {
+        "node_id": "clamp_o",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c0"
+      },
+      "to": {
+        "node_id": "clamp_o",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "clamp_o",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clamp_o"
+      },
+      "to": {
+        "node_id": "out_o",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in_vis_ou"
+      },
+      "to": {
+        "node_id": "sum_u",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "sum_u"
+      },
+      "to": {
+        "node_id": "clamp_u",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c0"
+      },
+      "to": {
+        "node_id": "clamp_u",
+        "input": "min"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c1"
+      },
+      "to": {
+        "node_id": "clamp_u",
+        "input": "max"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clamp_u"
+      },
+      "to": {
+        "node_id": "out_u",
+        "input": "in"
+      }
+    }
+  ]
+}

--- a/npm/@vizij/runtime/src/index.ts
+++ b/npm/@vizij/runtime/src/index.ts
@@ -34,6 +34,17 @@ import { loadBindings as loadWasmBindingsBrowser } from "@vizij/wasm-loader/brow
 export type GraphSpecInput = object | string;
 
 /**
+ * A standard profile Vizij ships — a composable graph that makes a face
+ * respond to an external standard's keys (e.g. ROS4HRI). Listed by
+ * {@link standardProfiles}; its graph is fetched with {@link standardProfile}.
+ */
+export interface StandardProfile {
+  id: string;
+  title: string;
+  description: string;
+}
+
+/**
  * A spec-level graph edit — `{ upsert_nodes, remove_nodes, upsert_edges,
  * remove_edges }` in the Vizij spec vocabulary, or a JSON string of the same.
  * Every edge incident to an upserted node must appear in `upsert_edges`.
@@ -85,6 +96,8 @@ interface WasmBindings {
   VizijArora: {
     start(graph_json?: string, modules?: RuntimeModule[]): Promise<WasmVizijArora>;
   };
+  standardProfiles(): StandardProfile[];
+  standardProfile(id: string, rig_prefix: string): object | null;
 }
 
 const bindingCache: { current: WasmBindings | null } = { current: null };
@@ -341,6 +354,31 @@ export async function startRuntime(
     graph === undefined ? undefined : typeof graph === "string" ? graph : JSON.stringify(graph);
   const inner = await bindings.VizijArora.start(graphJson, modules);
   return new Runtime(inner);
+}
+
+/**
+ * The standard profiles Vizij ships (ROS4HRI, …) — the introspectable list an
+ * authoring app offers so a user can pick which standards a face opts into.
+ * Calls {@link init} if it has not run yet.
+ */
+export async function standardProfiles(input?: InitInput): Promise<StandardProfile[]> {
+  await init(input);
+  return bindingCache.current!.standardProfiles();
+}
+
+/**
+ * A standard profile's graph as a spec object, ready to compose into a running
+ * runtime or embed into a face GLB. `rigPrefix` (e.g. `"rig/quori_latest/"`) is
+ * prepended to the control paths the profile writes; omit it for the
+ * unprefixed graph. `null` for an unknown id (see {@link standardProfiles}).
+ */
+export async function standardProfile(
+  id: string,
+  rigPrefix = "",
+  input?: InitInput,
+): Promise<object | null> {
+  await init(input);
+  return bindingCache.current!.standardProfile(id, rigPrefix);
 }
 
 export { toValueJSON } from "@vizij/value-json";


### PR DESCRIPTION
Official ROS4HRI topic support, out of the box. Design per the revised [ros4hri face plan](https://github.com/vizij-ai/vizij-docs/blob/docs/ros4hri-face-plan/active_projects/runtime/ros4hri_face/standards-and-adaptation.md): the layered waist — bridge keys → built-in profile → `standard/vizij` controls → the face's own adaptation.

**Where the new components live** (deliberately listed — move them if you want them elsewhere):

- **`crates/interop/vizij-arora-host/src/standard.rs`** — the Vizij face-standard vocabulary. Keeps the de-facto gaze/lid paths, adds `expression/<name>` (ROS4HRI's 25 names), `viseme/<shape>` (the industry 15-shape set; the incumbent's 7 embed), and a 35-control muscle tier cherry-picked from **FACS ⊕ ARKit**: FACS supplies the taxonomy (each control names an action unit, so `hri_msgs/FacialActionUnits` maps losslessly), ARKit supplies lateralization + the blendshape names wild assets ship. `eyeLook*` and head/eye AU codes are deliberately absent (the gaze tier owns them).
- **`crates/interop/vizij-arora-host/src/ros4hri.rs`** — the built-in profile, generated as pure graph data (no new node types, no host functions): name one-hot via text-`case`, valence/arousal circumplex blend with a neutral dead zone, gaze with vergence + the incumbent ±0.78 rad mapping + `x ≤ 0.1` recenter, AU→muscle routing (jaw-open also drives the de-facto `mouth/morph/jaw_open`), viseme pass-through, jittered idle blink with commanded-close inhibition, ~200 ms smoothing throughout.
- **`Bundle::compose(wanted, select, with_animations, profiles)`** — profiles are **opt-in for library callers** (empty slice = exactly the old behavior) and compose between the base graphs and the program, so a playing program/clip out-writes the profile (the settled precedence). The **vizij binary enables ROS4HRI by default**; `--no-ros4hri` opts out; `standard-adaptation` joins the default `--graphs`.
- **`crates/tools/vizij-bundle`** — the bundler: `inspect` / `unpack` / `pack` / `add-graph` / `validate`, where validate reports standard coverage (L0 gaze → L3 muscle) and `--min-level` makes it a CI gate. Reuses `vizij-glb-migrate`'s GLB codec.
- **`fixtures/faces/quori/standard-adaptation.json`** — Quori's asset-side adaptation (expressions → its 7 emotion poses, visemes → its letter poses), grafted into `Quori_Current_Extended.glb` by the bundler.
- **`vizij-api-core` fix**: `normalize_graph_spec_value` was aliasing a `case` node's fixed `selector`/`default` edge ports into `operand_N`, making them unreachable — every case node silently evaluated to its no-match NaN. Fixed with a regression test.

**Verification** (headless, no ROS, no real faces except the gated e2e):
- `vizij-arora-host` 15/15 — vocabulary, profile structure, compose ordering/opt-in.
- `vizij` device tests 8/8 — the generated profile evaluated by a real device: name one-hot, V/A blend, rest-is-neutral, gaze vergence + behind-plane recenter, AU routing, viseme pass-through, blink pulse + inhibition.
- `vizij-bundle` 3/3 — prefix stripping, add-graph round-trip, coverage levels.
- **`ros4hri_drives_the_adapted_quori`** (VIZIJ_FIXTURES-gated, added to the CI snapshot job): grafts the sidecar into the real GLB, then `expression/name = "happy"` → `pose_d_happy_d.weight > 0.95` and viseme `aa` → `pose_a.weight > 0.95` — the full chain on the demo face.

Known deviations, called out in code: behind-plane gaze targets recenter instead of holding (a pure graph holds no previous pose); viseme timeout-decay waits for the speech-plane work; the idle program contends LWW with profile gaze when autoplaying (arbitration deferred to spawn policies, per plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)