### PR TITLE
feat(graph): task runs as graph structure — spawn/halt on the ProcessingGraph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "arora"
-version = "9.7.0"
+version = "9.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465ee4cfa78a49ff8e107d57425b2afd5105987fed282dfa0676015757c76af5"
+checksum = "e28ae967be614d0e53835a58fe1c11b6fa4ba434e29de781d8abf1841eec4300"
 dependencies = [
  "anyhow",
  "arora-behavior",
@@ -429,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "arora-behavior-tree"
-version = "6.3.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f001b96641fa9b941a2866125c5e0b9787cf3b865e922b54e0cf780e7d6b04d4"
+checksum = "4e765bed1cd96ecc8d160e45baecc7237a87953c918b3e956f6c4b0ec017512a"
 dependencies = [
  "anyhow",
  "arora-behavior",
@@ -9788,7 +9788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -10369,7 +10369,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.3",
  "static_assertions",
 ]
 
@@ -10624,6 +10624,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arora",
+ "arora-behavior",
  "arora-bridge-ros2",
  "arora-types",
  "bevy",
@@ -10807,9 +10808,10 @@ dependencies = [
 
 [[package]]
 name = "vizij-graph-core"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
+ "arora-behavior-tree-types",
  "criterion",
  "hashbrown 0.17.1",
  "k",
@@ -11827,7 +11829,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/api/vizij-api-core/src/value.rs
+++ b/crates/api/vizij-api-core/src/value.rs
@@ -29,10 +29,9 @@
 
 use arora_types::gen_uuid_from_str;
 use arora_types::keyvalue::{KeyValue, KeyValueField};
-use arora_types::value::{Enumeration, Structure};
 use uuid::Uuid;
 
-pub use arora_types::value::{StructureField, StructureWithoutId, Value};
+pub use arora_types::value::{Enumeration, Structure, StructureField, StructureWithoutId, Value};
 
 // ---- declared type / field ids ------------------------------------------------
 

--- a/crates/interop/vizij-arora-behavior/src/lib.rs
+++ b/crates/interop/vizij-arora-behavior/src/lib.rs
@@ -29,15 +29,18 @@ use std::collections::HashMap;
 use arora_behavior::graph::GraphDiff;
 use arora_behavior::{
     built_in, interpreter_module, BehaviorContext, BehaviorError, BehaviorInterpreter,
-    BehaviorStatus, Graph,
+    BehaviorStatus, Graph, RunPolicy, TaskHandle, TaskId,
 };
 use arora_types::call::{Call, CallBridge};
 use arora_types::data::{DataStore, Key, StateChange};
-use arora_types::value::{StructureField, Value};
+use arora_types::value::{Structure, StructureField, Value};
 use uuid::Uuid;
 use vizij_api_core::TypedPath;
 use vizij_graph_core::eval::{evaluate_all_with_functions, GraphRuntime, NodeFunctions};
-use vizij_graph_core::types::{GraphSpec, NodeType};
+pub use vizij_graph_core::task;
+use vizij_graph_core::types::{
+    EdgeInputEndpoint, EdgeOutputEndpoint, EdgeSpec, GraphSpec, NodeParams, NodeSpec, NodeType,
+};
 
 /// Adapts an Arora [`CallBridge`] to graph-core's [`NodeFunctions`] host interface.
 ///
@@ -52,12 +55,13 @@ struct CallBridgeFunctions<'a> {
     function_modules: &'a HashMap<Uuid, Uuid>,
 }
 
-impl NodeFunctions for CallBridgeFunctions<'_> {
-    fn call(&mut self, function: Uuid, args: &[(Uuid, Value)]) -> Result<Value, String> {
-        let module_id = *self
-            .function_modules
-            .get(&function)
-            .ok_or_else(|| format!("no module registered for external function {function}"))?;
+impl CallBridgeFunctions<'_> {
+    fn dispatch(
+        &mut self,
+        module_id: Uuid,
+        function: Uuid,
+        args: &[(Uuid, Value)],
+    ) -> Result<Value, String> {
         let args: Vec<StructureField> = args
             .iter()
             .map(|(id, value)| StructureField {
@@ -75,6 +79,40 @@ impl NodeFunctions for CallBridgeFunctions<'_> {
             .map_err(|e| format!("module call failed: {e}"))?;
         Ok(result.ret)
     }
+}
+
+impl NodeFunctions for CallBridgeFunctions<'_> {
+    fn call(&mut self, function: Uuid, args: &[(Uuid, Value)]) -> Result<Value, String> {
+        let module_id = *self
+            .function_modules
+            .get(&function)
+            .ok_or_else(|| format!("no module registered for external function {function}"))?;
+        self.dispatch(module_id, function, args)
+    }
+
+    /// A task-run call names its module itself, so it dispatches without a
+    /// `function -> module` entry; one falls back to the map like any other
+    /// external function.
+    fn call_module(
+        &mut self,
+        module: Option<Uuid>,
+        function: Uuid,
+        args: &[(Uuid, Value)],
+    ) -> Result<Value, String> {
+        match module {
+            Some(module_id) => self.dispatch(module_id, function, args),
+            None => self.call(function, args),
+        }
+    }
+}
+
+/// The handle-side index of one live run: where its fragment lives in the
+/// graph and which status key it reports on. The run itself is graph
+/// structure — these are the coordinates for pruning and sweeping it.
+struct GraphRun {
+    run_node: String,
+    status_node: String,
+    status_key: Key,
 }
 
 /// A Vizij node graph as an Arora behavior interpreter.
@@ -98,6 +136,13 @@ pub struct ProcessingGraph {
     /// [`CallBridge`]. See [`CallBridgeFunctions`] for why this map is needed and where it
     /// should come from.
     function_modules: HashMap<Uuid, Uuid>,
+    /// Live task runs by the identity their [`TaskHandle`] carries. Each run is
+    /// a grafted fragment in [`graph`](Self::graph); this index holds its
+    /// pruning coordinates and status key.
+    runs: HashMap<TaskId, GraphRun>,
+    /// Halts requested since the last tick; applied by the next tick, which
+    /// owns the store.
+    pending_halts: Vec<TaskId>,
 }
 
 /// Normalize and deserialize a Vizij graph spec from JSON (any form the spec
@@ -171,7 +216,78 @@ impl ProcessingGraph {
             rt: GraphRuntime::default(),
             inputs: Vec::new(),
             function_modules: HashMap::new(),
+            runs: HashMap::new(),
+            pending_halts: Vec::new(),
         })
+    }
+
+    /// The retained shared-model graph — the editable source of truth,
+    /// including any live task-run fragments. What a LOAD replaces, an EDIT
+    /// edits, and an introspector reads.
+    pub fn graph(&self) -> &Graph {
+        &self.graph
+    }
+
+    /// Remove a run's fragment from the retained graph; takes effect at the
+    /// next lowering. The run's status key keeps its last value — pruning
+    /// removes structure, not state.
+    fn prune_run(&mut self, run: &GraphRun) -> Result<(), BehaviorError> {
+        let diff = graph_codec::GraphSpecDiff {
+            remove_nodes: vec![run.run_node.clone(), run.status_node.clone()],
+            ..graph_codec::GraphSpecDiff::default()
+        };
+        let diff = graph_codec::spec_diff_to_graph_diff(&diff)
+            .map_err(|message| BehaviorError { message })?;
+        self.graph.apply(diff).map_err(|e| BehaviorError {
+            message: format!("prune run: {e}"),
+        })?;
+        self.dirty = true;
+        Ok(())
+    }
+
+    /// Apply the halts requested since the last tick: write `Status::Failure`
+    /// to each halted run's status key and prune its fragment. A halt naming
+    /// an unknown or finished run was already served — nothing to do.
+    fn process_halts(&mut self, store: &dyn DataStore) -> Result<(), BehaviorError> {
+        for task in std::mem::take(&mut self.pending_halts) {
+            let Some(run) = self.runs.remove(&task) else {
+                continue;
+            };
+            let mut change = StateChange::new();
+            change
+                .set
+                .insert(run.status_key.clone(), Some(task::failure()));
+            store.write(change).map_err(|e| BehaviorError {
+                message: e.to_string(),
+            })?;
+            self.prune_run(&run)?;
+        }
+        Ok(())
+    }
+
+    /// Prune every run whose status key holds a terminal status. The latched
+    /// task-run node would never fire again anyway; sweeping returns the graph
+    /// to runs-that-are-live structure.
+    fn sweep_terminal_runs(&mut self, store: &dyn DataStore) -> Result<(), BehaviorError> {
+        let ended: Vec<TaskId> = self
+            .runs
+            .iter()
+            .filter(|(_, run)| {
+                store
+                    .read(std::slice::from_ref(&run.status_key))
+                    .into_iter()
+                    .next()
+                    .flatten()
+                    .is_some_and(|status| task::is_terminal(&status))
+            })
+            .map(|(task, _)| *task)
+            .collect();
+        for task in ended {
+            if let Some(run) = self.runs.remove(&task) {
+                self.prune_run(&run)?;
+            }
+        }
+        Ok(())
     }
 
     /// Re-lower the evaluator's spec from the retained graph and refresh the
@@ -214,6 +330,10 @@ impl ProcessingGraph {
         call_bridge: &mut dyn CallBridge,
         dt: f32,
     ) -> Result<(), BehaviorError> {
+        // Halts requested since the last tick: write each halted run's
+        // terminal status and prune its fragment — this phase owns the store.
+        self.process_halts(store)?;
+
         // An edit landed since the last lowering: rebuild the spec from the
         // retained graph against this tick, so the edit (and any lowering
         // problem it introduced) takes effect here.
@@ -256,6 +376,10 @@ impl ProcessingGraph {
         store.write(change).map_err(|e| BehaviorError {
             message: e.to_string(),
         })?;
+
+        // A run whose status just went terminal is done; its fragment leaves
+        // the graph.
+        self.sweep_terminal_runs(store)?;
         Ok(())
     }
 }
@@ -297,6 +421,114 @@ impl BehaviorInterpreter for ProcessingGraph {
             message: format!("graph diff: {e}"),
         })?;
         self.dirty = true;
+        Ok(())
+    }
+
+    /// Spawn `call` as a concurrent task run — the interpreter module's SPAWN
+    /// entry point. The run grafts into the running graph as a two-node
+    /// fragment: a [`NodeType::TaskRun`] node carrying the whole call in its
+    /// params (module, function, args bundle) over an [`NodeType::Output`] on
+    /// the run's status key. The graph's ordinary evaluation then advances the
+    /// run once per tick and the Output convention publishes its `Status` —
+    /// the run is structure, introspectable through [`graph`](Self::graph)
+    /// like everything else, and pruned when it ends.
+    fn spawn(&mut self, call: Call, policy: RunPolicy) -> Result<TaskHandle, BehaviorError> {
+        // v1 runs every task concurrently — the graph's ordinary semantics
+        // (overlapping actuation writes are last-write-wins). Richer
+        // `RunPolicy` arbitration lands as visible graph structure later; the
+        // policy is accepted and treated as `Concurrent` until then.
+        let _ = policy;
+        let task = TaskId(Uuid::new_v4());
+        let module = call
+            .module_id
+            .map(|m| m.to_string())
+            .unwrap_or_else(|| "none".to_string());
+        let prefix = format!("arora/tasks/{module}/{}/{}", call.id, task.0);
+        let status_key = Key::from(format!("{prefix}/status"));
+        let status_path =
+            TypedPath::parse(&format!("{prefix}/status")).map_err(|e| BehaviorError {
+                message: format!("the status key does not parse as a path: {e}"),
+            })?;
+
+        let run_node = format!("task/{}/run", task.0);
+        let status_node = format!("task/{}/status", task.0);
+        let diff = graph_codec::GraphSpecDiff {
+            upsert_nodes: vec![
+                NodeSpec {
+                    id: run_node.clone(),
+                    kind: NodeType::TaskRun,
+                    params: NodeParams {
+                        module: call.module_id,
+                        function: Some(call.id),
+                        value: Some(Value::Structure(Structure {
+                            id: call.id,
+                            fields: call.args.clone(),
+                        })),
+                        ..NodeParams::default()
+                    },
+                    output_shapes: Default::default(),
+                    input_defaults: Default::default(),
+                },
+                NodeSpec {
+                    id: status_node.clone(),
+                    kind: NodeType::Output,
+                    params: NodeParams {
+                        path: Some(status_path),
+                        ..NodeParams::default()
+                    },
+                    output_shapes: Default::default(),
+                    input_defaults: Default::default(),
+                },
+            ],
+            upsert_edges: vec![EdgeSpec {
+                from: EdgeOutputEndpoint {
+                    node_id: run_node.clone(),
+                    output: "out".to_string(),
+                },
+                to: EdgeInputEndpoint {
+                    node_id: status_node.clone(),
+                    input: "in".to_string(),
+                },
+                selector: None,
+            }],
+            ..graph_codec::GraphSpecDiff::default()
+        };
+        let diff = graph_codec::spec_diff_to_graph_diff(&diff)
+            .map_err(|message| BehaviorError { message })?;
+        self.runs.insert(
+            task,
+            GraphRun {
+                run_node,
+                status_node,
+                status_key: status_key.clone(),
+            },
+        );
+        self.graph
+            .apply(diff)
+            .map_err(|e| BehaviorError {
+                message: format!("graft run: {e}"),
+            })
+            .inspect_err(|_| {
+                self.runs.remove(&task);
+            })?;
+        self.dirty = true;
+
+        Ok(TaskHandle {
+            id: task,
+            stop: interpreter_module::encode_halt(task),
+            status: status_key,
+            feedback: vec![Key::from(format!("{prefix}/feedback"))],
+            result: vec![Key::from(format!("{prefix}/result"))],
+            update: vec![Key::from(format!("{prefix}/update"))],
+        })
+    }
+
+    /// Halt a run — the interpreter module's HALT entry point. Applied on the
+    /// next tick, which owns the store: the run's terminal status is written
+    /// and its fragment pruned. Idempotent — halting an unknown or finished
+    /// run is a clean no-op.
+    fn halt(&mut self, task: TaskId) -> Result<(), BehaviorError> {
+        self.pending_halts.push(task);
         Ok(())
     }
 }
@@ -587,5 +819,185 @@ mod tests {
 
         assert_eq!(read(&store, "anim/x"), Some(float(0.75)));
         assert_eq!(read(&store, "anim/y"), Some(float(0.5)));
+    }
+
+    /// A bridge scripting the spawned function: serves each call from a queue
+    /// of return values (an empty queue keeps serving `Running`) and records
+    /// every call.
+    struct RunBridge {
+        responses: std::collections::VecDeque<Value>,
+        calls: Vec<Call>,
+    }
+
+    impl RunBridge {
+        fn new(responses: Vec<Value>) -> Self {
+            Self {
+                responses: responses.into(),
+                calls: Vec::new(),
+            }
+        }
+    }
+
+    impl CallBridge for RunBridge {
+        fn arora_call(&mut self, call: Call) -> Result<CallResult, CallError> {
+            self.calls.push(call);
+            let ret = self.responses.pop_front().unwrap_or_else(task::running);
+            Ok(CallResult {
+                ret,
+                mutated: Vec::new(),
+            })
+        }
+        fn arora_register_callable(&mut self, _callable: Rc<dyn Callable>) -> CallableId {
+            unimplemented!()
+        }
+        fn arora_unregister_callable(&mut self, _callable_id: &CallableId) {
+            unimplemented!()
+        }
+        fn arora_call_indirect(&mut self, _callable_id: &CallableId) -> Result<Value, CallError> {
+            unimplemented!()
+        }
+    }
+
+    fn look_at() -> Call {
+        Call {
+            module_id: Some(Uuid::from_u128(0x6761)),
+            id: Uuid::from_u128(0x6c61),
+            args: vec![StructureField {
+                id: Uuid::from_u128(0x7861),
+                value: Box::new(float(0.5)),
+            }],
+        }
+    }
+
+    fn read_key(store: &SimpleDataStore, key: &Key) -> Option<Value> {
+        store
+            .read(std::slice::from_ref(key))
+            .into_iter()
+            .next()
+            .flatten()
+    }
+
+    /// SPAWN grafts a run as graph structure: the fragment is visible through
+    /// `graph()` before it ever ticks, ordinary evaluation advances it once per
+    /// tick, and its `Status` lands on the handle's status key.
+    #[test]
+    fn spawn_grafts_a_run_that_reports_on_its_status_key() {
+        let store = SimpleDataStore::new();
+        let mut graph =
+            ProcessingGraph::from_spec(passthrough("sensor/x", "actuator/y")).expect("from_spec");
+        store
+            .write(StateChange::set("sensor/x", float(0.75)))
+            .unwrap();
+        let nodes_before = graph.graph().nodes.len();
+
+        let handle = graph
+            .spawn(look_at(), RunPolicy::Concurrent)
+            .expect("spawn");
+        assert_eq!(graph.graph().nodes.len(), nodes_before + 2);
+        assert!(handle.status.path.starts_with("arora/tasks/"));
+
+        let mut bridge = RunBridge::new(Vec::new());
+        graph.tick_store(&store, &mut bridge, 0.016).expect("tick");
+        assert_eq!(read_key(&store, &handle.status), Some(task::running()));
+
+        // The spawned call reached its module intact.
+        assert_eq!(bridge.calls.len(), 1);
+        assert_eq!(bridge.calls[0].module_id, look_at().module_id);
+        assert_eq!(bridge.calls[0].id, look_at().id);
+        assert_eq!(bridge.calls[0].args, look_at().args);
+
+        // A run outlives the tick that started it.
+        graph.tick_store(&store, &mut bridge, 0.016).expect("tick");
+        assert_eq!(bridge.calls.len(), 2);
+    }
+
+    /// A run returning a terminal status is swept out of the graph and its
+    /// function is never invoked again; the status key keeps the terminal
+    /// value.
+    #[test]
+    fn a_terminal_run_is_swept_and_never_invoked_again() {
+        let store = SimpleDataStore::new();
+        let mut graph =
+            ProcessingGraph::from_spec(passthrough("sensor/x", "actuator/y")).expect("from_spec");
+        store
+            .write(StateChange::set("sensor/x", float(0.75)))
+            .unwrap();
+        let nodes_before = graph.graph().nodes.len();
+
+        let handle = graph
+            .spawn(look_at(), RunPolicy::Concurrent)
+            .expect("spawn");
+        let mut bridge = RunBridge::new(vec![task::success()]);
+        graph.tick_store(&store, &mut bridge, 0.016).expect("tick");
+
+        assert_eq!(read_key(&store, &handle.status), Some(task::success()));
+        assert_eq!(graph.graph().nodes.len(), nodes_before);
+
+        graph.tick_store(&store, &mut bridge, 0.016).expect("tick");
+        graph.tick_store(&store, &mut bridge, 0.016).expect("tick");
+        assert_eq!(bridge.calls.len(), 1);
+        assert_eq!(read_key(&store, &handle.status), Some(task::success()));
+    }
+
+    /// HALT writes `Failure` and prunes on the next tick — which owns the
+    /// store — and is idempotent at every stage.
+    #[test]
+    fn halt_fails_the_run_and_prunes_its_fragment() {
+        let store = SimpleDataStore::new();
+        let mut graph =
+            ProcessingGraph::from_spec(passthrough("sensor/x", "actuator/y")).expect("from_spec");
+        store
+            .write(StateChange::set("sensor/x", float(0.75)))
+            .unwrap();
+        let nodes_before = graph.graph().nodes.len();
+
+        let handle = graph
+            .spawn(look_at(), RunPolicy::Concurrent)
+            .expect("spawn");
+        let mut bridge = RunBridge::new(Vec::new());
+        graph.tick_store(&store, &mut bridge, 0.016).expect("tick");
+        assert_eq!(read_key(&store, &handle.status), Some(task::running()));
+
+        graph.halt(handle.id).expect("halt");
+        graph.halt(handle.id).expect("halting twice is a no-op");
+        graph.tick_store(&store, &mut bridge, 0.016).expect("tick");
+
+        assert_eq!(read_key(&store, &handle.status), Some(task::failure()));
+        assert_eq!(graph.graph().nodes.len(), nodes_before);
+        assert_eq!(bridge.calls.len(), 1);
+
+        graph
+            .halt(handle.id)
+            .expect("halting a finished run is a no-op");
+        graph.tick_store(&store, &mut bridge, 0.016).expect("tick");
+        assert_eq!(read_key(&store, &handle.status), Some(task::failure()));
+    }
+
+    /// Runs coexist: the main graph keeps flowing and concurrent runs demux on
+    /// their own status keys.
+    #[test]
+    fn runs_coexist_with_the_main_graph_and_each_other() {
+        let store = SimpleDataStore::new();
+        let mut graph =
+            ProcessingGraph::from_spec(passthrough("sensor/x", "actuator/y")).expect("from_spec");
+        store
+            .write(StateChange::set("sensor/x", float(0.75)))
+            .unwrap();
+
+        let first = graph
+            .spawn(look_at(), RunPolicy::Concurrent)
+            .expect("spawn");
+        let second = graph
+            .spawn(look_at(), RunPolicy::Concurrent)
+            .expect("spawn");
+        assert_ne!(first.status.path, second.status.path);
+
+        let mut bridge = RunBridge::new(Vec::new());
+        graph.tick_store(&store, &mut bridge, 0.016).expect("tick");
+
+        assert_eq!(read(&store, "actuator/y"), Some(float(0.75)));
+        assert_eq!(read_key(&store, &first.status), Some(task::running()));
+        assert_eq!(read_key(&store, &second.status), Some(task::running()));
+        assert_eq!(bridge.calls.len(), 2);
     }
 }

--- a/crates/node-graph/vizij-graph-core/CHANGELOG.md
+++ b/crates/node-graph/vizij-graph-core/CHANGELOG.md
@@ -4,10 +4,19 @@ All notable changes to `vizij-graph-core`. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [1.1.0] - 2026-07-29
 
 ### Added
 
+- `TaskRun` node: hosts one task run — a self-contained module call (module,
+  function, argument bundle as params) invoked each evaluation, emitting the
+  run's behavior `Status` and latching once terminal. Grafted per spawned run
+  by the interpreter.
+- `task` module: the behavior `Status` vocabulary on the value plane
+  (constructors, terminality, return coercion), ids from
+  `arora-behavior-tree-types`.
+- `NodeFunctions::call_module`: module-addressed dispatch with a default that
+  falls back to `call`, so registry-style hosts need no wiring.
 - `ExternalFunction` node plus the `NodeFunctions` call-bridge seam: a graph
   node can call out to host-provided functions.
 - The path-less `Output` node applies a keyed record batch to its keys: an

--- a/crates/node-graph/vizij-graph-core/Cargo.toml
+++ b/crates/node-graph/vizij-graph-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "vizij-graph-core"
-version = "1.0.0"
+version = "1.1.0"
 edition     = "2021"
 license     = "MIT OR Apache-2.0"
 description = "Core node‑graph engine used by Vizij."
@@ -18,6 +18,9 @@ thiserror  = { workspace = true }
 hashbrown  = { workspace = true }
 anyhow     = { workspace = true }
 vizij-api-core = { version = "1", path = "../../api/vizij-api-core" }
+# Declares the behavior `Status` enumeration (type + variant ids) a task run
+# speaks; types only, no interpreter.
+arora-behavior-tree-types = "1"
 uuid = { version = "1", features = ["serde"] }
 k = { version = "0.32", optional = true, default-features = false }
 urdf-rs = { version = "0.9", optional = true }

--- a/crates/node-graph/vizij-graph-core/src/eval/eval_node.rs
+++ b/crates/node-graph/vizij-graph-core/src/eval/eval_node.rs
@@ -387,7 +387,57 @@ fn evaluate_kind_inner(
         NodeType::Input => eval_input_node(rt, spec, outputs),
         NodeType::Output => eval_output(inputs, outputs),
         NodeType::ExternalFunction => eval_external_function(params, inputs, outputs, functions),
+        NodeType::TaskRun => eval_task_run(rt, spec, outputs, functions),
     }
+}
+
+fn eval_task_run(
+    rt: &mut GraphRuntime,
+    spec: &NodeSpec,
+    outputs: &mut OutputSlots,
+    functions: Option<&mut dyn NodeFunctions>,
+) -> Result<(), String> {
+    use super::graph_runtime::{NodeRuntimeState, TaskRunState};
+
+    // A terminal run is latched: its function is not invoked again; the node
+    // keeps emitting the terminal status until its fragment is pruned.
+    if let Some(NodeRuntimeState::TaskRun(state)) = rt.node_states.get(&spec.id) {
+        if let Some(latched) = state.latched.clone() {
+            return single_output(outputs, latched);
+        }
+    }
+
+    let function = spec
+        .params
+        .function
+        .ok_or_else(|| "TaskRun node requires a function id".to_string())?;
+    let functions = functions.ok_or_else(|| {
+        "TaskRun node evaluated without a function host (graph run outside a host)".to_string()
+    })?;
+
+    // The argument bundle: one structure whose fields are the call's args.
+    let args: Vec<(Uuid, Value)> = match &spec.params.value {
+        Some(Value::Structure(bundle)) => bundle
+            .fields
+            .iter()
+            .map(|field| (field.id, (*field.value).clone()))
+            .collect(),
+        None => Vec::new(),
+        Some(_) => {
+            return Err("a TaskRun argument bundle is a structure of call args".to_string());
+        }
+    };
+
+    let status = crate::task::coerce(functions.call_module(spec.params.module, function, &args)?);
+    if crate::task::is_terminal(&status) {
+        rt.node_states.insert(
+            spec.id.clone(),
+            NodeRuntimeState::TaskRun(TaskRunState {
+                latched: Some(status.clone()),
+            }),
+        );
+    }
+    single_output(outputs, status)
 }
 
 fn eval_external_function(

--- a/crates/node-graph/vizij-graph-core/src/eval/graph_runtime.rs
+++ b/crates/node-graph/vizij-graph-core/src/eval/graph_runtime.rs
@@ -101,6 +101,16 @@ pub enum NodeRuntimeState {
     Slew(SlewState),
     #[cfg(feature = "urdf_ik")]
     UrdfKinematics(UrdfKinematicsState),
+    TaskRun(TaskRunState),
+}
+
+/// State of a [`TaskRun`](crate::types::NodeType::TaskRun) node's hosted run.
+#[derive(Debug, Default)]
+pub struct TaskRunState {
+    /// The terminal status value the run latched on, once it has ended. A
+    /// latched run's function is not invoked again; the node keeps emitting
+    /// this value until its fragment is pruned.
+    pub latched: Option<Value>,
 }
 
 /// Data staged by the host for consumption by [`NodeType::Input`](crate::types::NodeType::Input).

--- a/crates/node-graph/vizij-graph-core/src/eval/node_function.rs
+++ b/crates/node-graph/vizij-graph-core/src/eval/node_function.rs
@@ -32,6 +32,21 @@ pub trait NodeFunction {
 pub trait NodeFunctions {
     /// Invoke the function identified by `function` with `args`.
     fn call(&mut self, function: Uuid, args: &[(Uuid, Value)]) -> Result<Value, String>;
+
+    /// Invoke `function` addressed to `module` with `args` — how a
+    /// [`TaskRun`](crate::types::NodeType::TaskRun) node dispatches its
+    /// self-contained call. A host that routes by module honours `module`; the
+    /// default ignores it and resolves the function like [`call`](Self::call),
+    /// so registry-style hosts need no extra wiring.
+    fn call_module(
+        &mut self,
+        module: Option<Uuid>,
+        function: Uuid,
+        args: &[(Uuid, Value)],
+    ) -> Result<Value, String> {
+        let _ = module;
+        self.call(function, args)
+    }
 }
 
 /// A registry of [`NodeFunction`]s keyed by their stable id.

--- a/crates/node-graph/vizij-graph-core/src/lib.rs
+++ b/crates/node-graph/vizij-graph-core/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod eval;
 pub mod schema;
+pub mod task;
 pub mod topo;
 pub mod types;
 

--- a/crates/node-graph/vizij-graph-core/src/schema.rs
+++ b/crates/node-graph/vizij-graph-core/src/schema.rs
@@ -2721,6 +2721,27 @@ pub fn registry() -> Registry {
         params: vec![],
     });
 
+    // Task-run hosting (self-contained module call emitting a latched Status)
+    nodes.push(NodeSignature {
+        type_id: TaskRun,
+        name: "Task Run",
+        category: "Functions",
+        doc: "Hosts one task run: invokes its module function (module, function and argument \
+              bundle are params) each evaluation and emits the run's behavior Status, latched \
+              once terminal. Grafted per spawned run by the interpreter.",
+        inputs: vec![],
+        variadic_inputs: None,
+        outputs: vec![PortSpec {
+            id: "out",
+            ty: PortType::Any,
+            label: "Out",
+            doc: "The run's behavior Status value; a terminal status is latched.",
+            optional: false,
+        }],
+        variadic_outputs: None,
+        params: vec![],
+    });
+
     Registry {
         version: "1.0.0",
         nodes,

--- a/crates/node-graph/vizij-graph-core/src/task.rs
+++ b/crates/node-graph/vizij-graph-core/src/task.rs
@@ -1,0 +1,62 @@
+//! The behavior `Status` vocabulary a [`TaskRun`](crate::types::NodeType::TaskRun)
+//! node speaks on the value plane.
+//!
+//! A run's lifecycle travels as the behavior `Status` enumeration — `Running` /
+//! `Success` / `Failure` over unit payloads — the value an interpreter writes to
+//! a run's status key and the one the ROS action plane maps to a goal status.
+//! The type and variant ids come from `arora-behavior-tree-types`, the crate
+//! declaring the enumeration, so the encoding cannot drift from the rest of the
+//! Arora ecosystem. The graph core only constructs these values and recognizes
+//! terminality; it never interprets the payloads.
+
+use arora_behavior_tree_types::{
+    STATUS_ENUMERATION_ID, STATUS_FAILURE_VARIANT_ID, STATUS_RUNNING_VARIANT_ID,
+    STATUS_SUCCESS_VARIANT_ID,
+};
+use uuid::Uuid;
+use vizij_api_core::value::{Enumeration, Value};
+
+fn status(variant_id: Uuid) -> Value {
+    Value::Enumeration(Enumeration {
+        id: STATUS_ENUMERATION_ID,
+        variant_id,
+        value: Box::new(Value::Unit),
+    })
+}
+
+/// The `Status::Running` value: the run is live and will be advanced again.
+pub fn running() -> Value {
+    status(STATUS_RUNNING_VARIANT_ID)
+}
+
+/// The `Status::Success` value: the run ended cleanly.
+pub fn success() -> Value {
+    status(STATUS_SUCCESS_VARIANT_ID)
+}
+
+/// The `Status::Failure` value: the run ended in failure — also what a halt
+/// writes, since a halted run did not reach its goal.
+pub fn failure() -> Value {
+    status(STATUS_FAILURE_VARIANT_ID)
+}
+
+/// Whether `value` is a terminal `Status` — `Success` or `Failure`. Anything
+/// that is not a `Status` enumeration is not terminal.
+pub fn is_terminal(value: &Value) -> bool {
+    match value {
+        Value::Enumeration(e) if e.id == STATUS_ENUMERATION_ID => {
+            e.variant_id != STATUS_RUNNING_VARIANT_ID
+        }
+        _ => false,
+    }
+}
+
+/// Coerce a module call's return into the run's `Status`: a `Status` value
+/// passes through; any other return means the call completed its work in one
+/// invocation — `Success`.
+pub fn coerce(ret: Value) -> Value {
+    match &ret {
+        Value::Enumeration(e) if e.id == STATUS_ENUMERATION_ID => ret,
+        _ => success(),
+    }
+}

--- a/crates/node-graph/vizij-graph-core/src/types.rs
+++ b/crates/node-graph/vizij-graph-core/src/types.rs
@@ -157,6 +157,16 @@ pub enum NodeType {
     /// Invokes an external function (resolved by opaque id) through the host-provided
     /// [`NodeFunctions`](crate::eval::NodeFunctions) interface.
     ExternalFunction,
+    /// Hosts one task run: invokes a module function each evaluation and emits
+    /// the run's behavior [`Status`](crate::task) value on `out`, latched once
+    /// terminal.
+    ///
+    /// Unlike [`ExternalFunction`](Self::ExternalFunction), the call is fully
+    /// self-contained in the params — [`module`](NodeParams::module),
+    /// [`function`](NodeParams::function), and the argument bundle in
+    /// [`value`](NodeParams::value) — so a run grafts into a live graph without
+    /// argument-feeder wiring.
+    TaskRun,
 }
 
 /// Node-construction parameters consumed selectively by different [`NodeType`] variants.
@@ -300,6 +310,11 @@ pub struct NodeParams {
     /// Record field carrying each entry's value; see [`key_field`](Self::key_field).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub value_field: Option<Uuid>,
+    /// Module the [`NodeType::TaskRun`] function is dispatched to, when the run
+    /// names one. `None` leaves resolution to the host's function→module map,
+    /// like an [`NodeType::ExternalFunction`] call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub module: Option<Uuid>,
 }
 
 /// Rounding strategy for [`NodeType::Round`].

--- a/crates/vizij/Cargo.toml
+++ b/crates/vizij/Cargo.toml
@@ -62,6 +62,11 @@ vizij-arora-behavior = { path = "../interop/vizij-arora-behavior" }
 # dependency and no nightly. Its generated `Value` conversions marshal the calls.
 vizij-animation-module = { path = "../interop/vizij-animation-module" }
 
+[dev-dependencies]
+# The interpreter-module SPAWN/HALT codecs and RunPolicy the device test
+# drives the graph interpreter with.
+arora-behavior = "8"
+
 [features]
 default = []
 # `--ros2 [namespace][:domain]`: expose the device's keys over ROS 2 topics.

--- a/crates/vizij/src/device.rs
+++ b/crates/vizij/src/device.rs
@@ -433,4 +433,79 @@ mod tests {
             "{ANIMATION_PLAYERS_PATH} absent — the animation module did not dispatch",
         );
     }
+
+    /// A LookAt-style behavior spawned through the device: the SPAWN call
+    /// reaches the graph interpreter through the engine, the run grafts into
+    /// the running node graph and reports on its status key each step, and the
+    /// handle's stop call halts it — all in-process, no bridge involved.
+    #[test]
+    fn a_look_at_run_advances_and_halts_through_the_device() {
+        use arora_behavior::{interpreter_module, RunPolicy};
+        use arora_types::call::{Call, CallResult};
+        use arora_types::value::{StructureField, Value};
+        use uuid::Uuid;
+        use vizij_arora_behavior::task;
+
+        const GAZE_MODULE: Uuid = Uuid::from_u128(0x67617a65);
+        const LOOK_AT: Uuid = Uuid::from_u128(0x6c6f6f6b);
+        const TARGET: Uuid = Uuid::from_u128(0x74617267);
+
+        // A gaze skill that tracks indefinitely, like the real LookAt: every
+        // invocation steers toward its target and reports `Running`.
+        let gaze = arora::ModuleBuilder::new(GAZE_MODULE)
+            .function(LOOK_AT, |_call| {
+                Ok(CallResult {
+                    ret: task::running(),
+                    mutated: Vec::new(),
+                })
+            })
+            .build();
+
+        let mut arora = builder_for(
+            r#"{ "nodes": [], "edges": [] }"#,
+            RigHal::new(),
+            BlackboardStore::new(),
+        )
+        .expect("build the device")
+        .with_host_module(gaze)
+        .build()
+        .expect("build arora");
+
+        let look_at = Call {
+            module_id: Some(GAZE_MODULE),
+            id: LOOK_AT,
+            args: vec![StructureField {
+                id: TARGET,
+                value: Box::new(Value::F32(0.5)),
+            }],
+        };
+        let spawned = arora
+            .call(interpreter_module::encode_spawn(
+                &look_at,
+                RunPolicy::Concurrent,
+            ))
+            .expect("SPAWN dispatches through the engine");
+        let handle =
+            interpreter_module::decode_spawn_result(&spawned.ret).expect("a TaskHandle comes back");
+
+        let status = |arora: &arora::Arora| {
+            arora
+                .store()
+                .read(std::slice::from_ref(&handle.status))
+                .into_iter()
+                .next()
+                .flatten()
+        };
+
+        arora.step(Duration::from_millis(16)).expect("step");
+        assert_eq!(status(&arora), Some(task::running()));
+        arora.step(Duration::from_millis(16)).expect("step");
+        assert_eq!(status(&arora), Some(task::running()), "indefinite tracking");
+
+        arora
+            .call(handle.stop.clone())
+            .expect("the handle's stop call dispatches");
+        arora.step(Duration::from_millis(16)).expect("step");
+        assert_eq!(status(&arora), Some(task::failure()), "halted");
+    }
 }

--- a/npm/@vizij/node-graph/src/metadata/registry.json
+++ b/npm/@vizij/node-graph/src/metadata/registry.json
@@ -3140,6 +3140,23 @@
         }
       ],
       "params": []
+    },
+    {
+      "type_id": "taskrun",
+      "name": "Task Run",
+      "category": "Functions",
+      "doc": "Hosts one task run: invokes its module function (module, function and argument bundle are params) each evaluation and emits the run's behavior Status, latched once terminal. Grafted per spawned run by the interpreter.",
+      "inputs": [],
+      "outputs": [
+        {
+          "id": "out",
+          "ty": "any",
+          "label": "Out",
+          "doc": "The run's behavior Status value; a terminal status is latched.",
+          "optional": false
+        }
+      ],
+      "params": []
     }
   ]
 }

--- a/npm/@vizij/node-graph/src/metadata/registry.ts
+++ b/npm/@vizij/node-graph/src/metadata/registry.ts
@@ -3143,6 +3143,23 @@ const registry: Registry = {
         }
       ],
       "params": []
+    },
+    {
+      "type_id": "taskrun",
+      "name": "Task Run",
+      "category": "Functions",
+      "doc": "Hosts one task run: invokes its module function (module, function and argument bundle are params) each evaluation and emits the run's behavior Status, latched once terminal. Grafted per spawned run by the interpreter.",
+      "inputs": [],
+      "outputs": [
+        {
+          "id": "out",
+          "ty": "any",
+          "label": "Out",
+          "doc": "The run's behavior Status value; a terminal status is latched.",
+          "optional": false
+        }
+      ],
+      "params": []
     }
   ]
 };

--- a/npm/@vizij/node-graph/src/types.d.ts
+++ b/npm/@vizij/node-graph/src/types.d.ts
@@ -107,7 +107,8 @@ export type NodeType =
   | "mathsubrecord"
   | "input"
   | "output"
-  | "externalfunction";
+  | "externalfunction"
+  | "taskrun";
 
 export type ShapeJSON =
   | { id: "Scalar"; meta?: Record<string, string> }


### PR DESCRIPTION
The node-graph twin of arora's behavior-tree runner scaffold ([arora-sdk #200](https://github.com/semio-ai/arora-sdk/pull/200)): `BehaviorInterpreter::spawn`/`halt` on `ProcessingGraph`, with runs hosted as **graph structure**.

## How a run is hosted

- **SPAWN grafts a two-node fragment**: a new `taskrun` node — self-contained, the whole spawned call in its params (module, function, argument bundle as one literal `Structure`) — wired into a standard `output` node on the run's status key (`arora/tasks/<module>/<function>/<run_id>/status`). Ordinary evaluation advances the run once per tick; the `output` convention publishes its behavior `Status`.
- **Terminal latches in node state** (which the warm `GraphRuntime` keeps across re-lowering), so a finished run never re-invokes its function; the interpreter sweeps terminal fragments out of the graph after their final write.
- **`halt` queues; the next tick — which owns the store — writes `Failure` and prunes.** Idempotent at every stage.
- **Same keys, same `TaskHandle`, same `Status` vocabulary as the tree** (ids from `arora-behavior-tree-types`): an observer — the ROS 2 action plane included — cannot tell which interpreter hosts its run.

## Pieces

- `vizij-graph-core` **1.1.0**: the `TaskRun` node (schema-registered), the `task` Status vocabulary, and `NodeFunctions::call_module` — module-addressed dispatch with a default falling back to `call`, so a `taskrun` honours its call's own module id where an `externalfunction` resolves through the function→module map.
- `vizij-api-core`: re-exports the value `Enumeration`/`Structure` types.
- `vizij-arora-behavior`: `spawn`/`halt`, the halt/sweep phases in `tick_store`, a `graph()` accessor (runs are introspectable), `pub use task`.
- arora re-pinned 9.9 (the interpreter-module SPAWN/HALT wiring).

## Validation

- 19 interpreter tests, including: graft visible through `graph()` before the first tick, status on the handle's key, terminal sweep + never-reinvoked, halt idempotence, run/main coexistence, concurrent-run demux.
- A device-level test drives a LookAt-style run through the **real engine**: SPAWN via the interpreter module, status per step, halt via the handle's `stop` call (`a_look_at_run_advances_and_halts_through_the_device`).

The live ROS 2 E2E (typed DDS action client against this device) is stacked next — it needs [arora-sdk #201](https://github.com/semio-ai/arora-sdk/pull/201)/[#202](https://github.com/semio-ai/arora-sdk/pull/202) released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)