### PR TITLE
test(vizij): live ROS 2 LookAt E2E — a typed DDS action client drives the real device

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,16 +385,16 @@ dependencies = [
 
 [[package]]
 name = "arora"
-version = "9.9.0"
+version = "9.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28ae967be614d0e53835a58fe1c11b6fa4ba434e29de781d8abf1841eec4300"
+checksum = "e2876a5b088b105c8008d86225352c9518dc3d6d4ee14615d6709d6b150317fd"
 dependencies = [
  "anyhow",
  "arora-behavior",
  "arora-behavior-tree",
  "arora-bridge",
  "arora-bridge-ws",
- "arora-engine 4.0.0",
+ "arora-engine 4.1.0",
  "arora-hal",
  "arora-simple-data-store",
  "arora-studio-bridge-client",
@@ -478,11 +478,13 @@ dependencies = [
 
 [[package]]
 name = "arora-bridge-ros2"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7efc0bc42a2cc0081f2a9028f2fa6f061a02fe80afb34104a4e4fb0afe5fbd1"
+checksum = "d1f687abdfbe5037b3758d336296950799f5c94a6f734a45309ad72bd268e0da"
 dependencies = [
+ "arora-behavior-tree-types",
  "arora-bridge",
+ "arora-msgs-ros2",
  "arora-types",
  "async-trait",
  "futures",
@@ -515,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "arora-buffers"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaa641c4ef4139cde554ca709690f05e8214b4379e8d2245a67c2159b3a8076"
+checksum = "89ce00d45413fbb68ac324475a7fd495d5da1983cdec98d3d7e11ac60f47524b"
 dependencies = [
  "arora-types",
  "bytes",
@@ -556,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "arora-engine"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d129b70d3fca9b3f4168badfafd839a24b23c4f5d74d76a3ddb81ecc897ae7c7"
+checksum = "cd685c0799d615dd23d5931cf8e4548058f980f1af1f0a9c0ed99101c3f2ae70"
 dependencies = [
  "anyhow",
  "arora-buffers",
@@ -645,6 +647,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "arora-msgs-ros2"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6833cfbcd415843d6b5477fa32219ea2731a7c8dc1cc5d6270c64e49b1b23425"
+dependencies = [
+ "arora-types",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde-big-array",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "arora-registry"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "arora-types"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e17cc7d475627aa6275487e9029633fca4eee4b0ed4956667faa4c18763fe7"
+checksum = "b3f5838774ed426d8670c2dbfdf37a8560bc671248b44999a0c326be9b7d18b4"
 dependencies = [
  "arora-types-derive",
  "async-trait",
@@ -8573,9 +8590,9 @@ dependencies = [
 
 [[package]]
 name = "ros2-client-multi-rmw"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03956b245d11777d1bd8c9cfe007a34b1bf6bfed0ff132cb5d26fc728d8fbfd2"
+checksum = "fd046a2d7fabf807d119dc2315e020e9d4e5a69e827a6c71990f6ebfb5751adc"
 dependencies = [
  "async-channel",
  "bstr",
@@ -9037,6 +9054,15 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -10625,6 +10651,7 @@ dependencies = [
  "anyhow",
  "arora",
  "arora-behavior",
+ "arora-behavior-tree-types",
  "arora-bridge-ros2",
  "arora-types",
  "bevy",
@@ -10634,6 +10661,8 @@ dependencies = [
  "futures",
  "image",
  "log",
+ "rand 0.9.5",
+ "ros2-client-multi-rmw",
  "serde",
  "serde_json",
  "tokio",
@@ -10667,7 +10696,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "arora-buffers",
- "arora-engine 4.0.0",
+ "arora-engine 4.1.0",
  "arora-module-core",
  "arora-module-rust",
  "arora-registry",
@@ -11841,7 +11870,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ js-sys = "0.3"
 anyhow = "1"
 serde-wasm-bindgen = "0.6"
 
+
 [profile.release]
 opt-level = "s"
 lto = true

--- a/crates/vizij/Cargo.toml
+++ b/crates/vizij/Cargo.toml
@@ -29,11 +29,11 @@ bevy = "0.19"
 # 9.7 adds `with_host_module`, which registers the animation module natively (a
 # `HostModule` of in-process functions) — no wasm guest, no bindep, so the
 # workspace stays on stable.
-arora = "9.7"
+arora = "9.10"
 # The ROS 2 bridge, attached under `--ros2` (feature `ros2`). Heavy (ros2-client
 # + a DDS/Zenoh backend), so opt-in; the Studio bridge rides arora's own
 # `studio-bridge` feature instead (`--studio`).
-arora-bridge-ros2 = { version = "3", optional = true }
+arora-bridge-ros2 = { version = "3.2", optional = true }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 # The command pump's async plumbing: the TUI command stream and the per-run
 # stop signal.
@@ -69,6 +69,12 @@ arora-behavior = "8"
 # The bundler, for the Quori integration test (grafts the standard-adaptation
 # sidecar into the demo GLB before driving it over the ROS4HRI keys).
 vizij-bundle = { path = "../tools/vizij-bundle" }
+# The Status enumeration ids the gaze signature marks its action shape with.
+arora-behavior-tree-types = "1"
+# The typed ROS 2 peer of the live action E2E (the semio-ai ros2-client fork;
+# the library imports as `ros2_client`).
+ros2-client = { package = "ros2-client-multi-rmw", version = "0.11.0", default-features = false, features = ["jazzy", "dds"] }
+rand = "0.9"
 
 [features]
 default = []

--- a/crates/vizij/src/device.rs
+++ b/crates/vizij/src/device.rs
@@ -241,7 +241,11 @@ pub fn start(glb: &Path, config: FaceConfig, bridges: BridgeConfig, mode: Mode) 
 /// with the animation module loaded so the composed animation source's
 /// `ExternalFunction` nodes dispatch and its transport is callable. `None`
 /// (logged) when the spec does not encode or the baked-in module does not load.
-fn builder_for(spec: &str, rig: RigHal, store: BlackboardStore) -> Option<arora::AroraBuilder> {
+pub(crate) fn builder_for(
+    spec: &str,
+    rig: RigHal,
+    store: BlackboardStore,
+) -> Option<arora::AroraBuilder> {
     let spec = match parse_spec(spec) {
         Ok(spec) => spec,
         Err(e) => {

--- a/crates/vizij/src/main.rs
+++ b/crates/vizij/src/main.rs
@@ -16,6 +16,8 @@ mod animation;
 mod device;
 mod frames;
 mod meta;
+#[cfg(all(test, feature = "ros2"))]
+mod ros2_tests;
 mod snapshot;
 mod view;
 

--- a/crates/vizij/src/ros2_tests.rs
+++ b/crates/vizij/src/ros2_tests.rs
@@ -1,0 +1,296 @@
+//! Live ROS 2 end-to-end: a typed action client drives a LookAt task run on
+//! the real vizij device over DDS.
+//!
+//! The whole production chain is under test — discovery (`DescribeMethods`
+//! over the described gaze host module), the bridge's action synthesis, SPAWN
+//! into the node-graph interpreter (the run grafts as graph structure and
+//! reports on its status key), cancel → halt → `CANCELED`. The only scripted
+//! piece is the gaze skill itself, which tracks indefinitely (`Running` every
+//! invocation) like the real LookAt.
+
+use std::time::Duration;
+
+use arora_behavior_tree_types::STATUS_ENUMERATION_ID;
+use arora_types::call::CallResult;
+use arora_types::gen_uuid_from_str;
+use arora_types::record::module::frozen::{Function, Parameter};
+use arora_types::record::ty::{FrozenScalar, FrozenTy, PrimitiveKind};
+use arora_types::record::{FrozenReference, Version};
+use arora_types::value::Value;
+use rand::Rng;
+use ros2_client::action_msgs::GoalStatusEnum;
+use ros2_client::{Context, ContextOptions, Message, Name, NodeName, NodeOptions, ServiceMapping};
+use serde::{Deserialize, Serialize};
+use vizij_arora_behavior::task;
+use vizij_arora_hal::RigHal;
+use vizij_arora_store::BlackboardStore;
+
+use crate::device::builder_for;
+
+// The typed client's view of the action.
+#[derive(Serialize, Deserialize, Clone)]
+struct LookAtGoal {
+    policy: String,
+    x: f64,
+}
+impl Message for LookAtGoal {}
+/// The run populates no result keys (v1 hosts one call, §2.2.2 of the
+/// task-runs proposal), so the synthesised Result carries the goal status
+/// alone — an empty payload on the typed side.
+#[derive(Serialize, Deserialize, Clone)]
+struct LookAtResult {}
+impl Message for LookAtResult {}
+#[derive(Serialize, Deserialize)]
+struct LookAtFeedback {
+    gaze_error: f32,
+}
+impl Message for LookAtFeedback {}
+
+fn gaze_module() -> arora::HostModule {
+    let look_at_signature = {
+        let mut parameters = std::collections::HashMap::new();
+        let mut parameter_ordering = Vec::new();
+        for (name, kind) in [("policy", PrimitiveKind::String), ("x", PrimitiveKind::F64)] {
+            let id = gen_uuid_from_str(name);
+            parameter_ordering.push(id);
+            parameters.insert(
+                id,
+                Parameter {
+                    name: name.to_string(),
+                    ty: FrozenTy::from(kind),
+                    mutable: false,
+                },
+            );
+        }
+        Function {
+            parameters,
+            parameter_ordering,
+            // The behavior `Status` return is the action marker: the bridge
+            // exposes this method as a ROS 2 action, not a service.
+            return_ty: FrozenTy::FrozenScalar(FrozenScalar {
+                reference: FrozenReference {
+                    id: STATUS_ENUMERATION_ID,
+                    version: Version::parse("1.0.0").expect("a valid version"),
+                },
+            }),
+        }
+    };
+    let speak_signature = {
+        let text = gen_uuid_from_str("text");
+        let mut parameters = std::collections::HashMap::new();
+        parameters.insert(
+            text,
+            Parameter {
+                name: "text".to_string(),
+                ty: FrozenTy::from(PrimitiveKind::String),
+                mutable: false,
+            },
+        );
+        Function {
+            parameters,
+            parameter_ordering: vec![text],
+            return_ty: FrozenTy::from(PrimitiveKind::F64),
+        }
+    };
+    arora::ModuleBuilder::new(gen_uuid_from_str("gaze-module"))
+        // The gaze skill: every invocation steers toward its target and
+        // reports `Running` — indefinite tracking, like the real LookAt.
+        .described_function(
+            gen_uuid_from_str("look_at"),
+            "look_at",
+            look_at_signature,
+            |_call| {
+                Ok(CallResult {
+                    ret: task::running(),
+                    mutated: Vec::new(),
+                })
+            },
+        )
+        // A plain method: it rides the service plane in the same run — the
+        // discriminator between "raw services are broken live" and "the
+        // action assembly is at fault".
+        .described_function(
+            gen_uuid_from_str("speak"),
+            "speak",
+            speak_signature,
+            |_call| {
+                Ok(CallResult {
+                    ret: Value::F64(1.0),
+                    mutated: Vec::new(),
+                })
+            },
+        )
+        .build()
+}
+
+fn create_test_node(domain_id: u16, name_suffix: &str) -> (Context, ros2_client::Node) {
+    let ctx = Context::with_options(ContextOptions::new().domain_id(domain_id))
+        .expect("create the test context");
+    let node_name = NodeName::new("/", &format!("test_{name_suffix}")).expect("a valid node name");
+    let node = ctx
+        .new_node(node_name, NodeOptions::new())
+        .expect("create the test node");
+    (ctx, node)
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[cfg_attr(
+    target_os = "macos",
+    ignore = "DDS multicast SPDP discovery is unreliable on macOS loopback (rustdds has no \
+              unicast-peer/interface config); this runs on Linux CI. To run locally, ensure an \
+              active multicast-capable interface and use --ignored."
+)]
+async fn a_look_at_action_runs_on_the_vizij_device_over_dds() {
+    let _ = env_logger::builder()
+        .parse_filters("warn")
+        .is_test(true)
+        .try_init();
+    let domain_id: u16 = rand::rng().random_range(1..=200);
+
+    // The real device: node-graph interpreter, gaze host module, ROS 2 bridge.
+    let bridge = arora_bridge_ros2::Ros2Bridge::new(arora_bridge_ros2::Ros2BridgeConfig::new(
+        "robot", domain_id,
+    ))
+    .await;
+    let mut arora = builder_for(
+        r#"{ "nodes": [], "edges": [] }"#,
+        RigHal::new(),
+        BlackboardStore::new(),
+    )
+    .expect("build the device")
+    .with_host_module(gaze_module())
+    .with_bridge(Box::new(bridge))
+    .build()
+    .expect("build arora");
+
+    // The device loop: real steps, the cadence a running vizij holds.
+    let device = async {
+        loop {
+            arora.step(Duration::from_millis(16)).expect("step");
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    };
+    tokio::pin!(device);
+
+    let client_flow = async {
+        let (_ctx, mut node) = create_test_node(domain_id, "action_client");
+        // The reliable service profile ros2-client's own action examples use —
+        // the best-effort default drops service requests.
+        let service_qos = {
+            use ros2_client::ros2::{policy, QosPolicyBuilder};
+            QosPolicyBuilder::new()
+                .reliability(policy::Reliability::Reliable {
+                    max_blocking_time: ros2_client::ros2::Duration::from_millis(100),
+                })
+                .history(policy::History::KeepLast { depth: 4 })
+                .durability(policy::Durability::TransientLocal)
+                .build()
+        };
+
+        // Probe the method-service plane first: speak() on /robot/methods.
+        #[derive(Serialize, Deserialize, Clone)]
+        struct SpeakRequest {
+            text: String,
+        }
+        impl Message for SpeakRequest {}
+        #[derive(Serialize, Deserialize, Debug)]
+        struct SpeakResponse {
+            result: f64,
+        }
+        impl Message for SpeakResponse {}
+        let speak_client = node
+            .create_client::<ros2_client::AService<SpeakRequest, SpeakResponse>>(
+                ServiceMapping::Enhanced,
+                &Name::parse("/robot/methods/speak").expect("a valid service name"),
+                &ros2_client::ServiceTypeName::new("arora", "speak"),
+                service_qos.clone(),
+                service_qos.clone(),
+            )
+            .expect("the speak client creates");
+        eprintln!("[client] probing the method service");
+        loop {
+            let sent = speak_client.async_send_request(SpeakRequest {
+                text: "hello".to_string(),
+            });
+            match tokio::time::timeout(Duration::from_secs(2), sent).await {
+                Ok(Ok(req_id)) => {
+                    match tokio::time::timeout(
+                        Duration::from_secs(2),
+                        speak_client.async_receive_response(req_id),
+                    )
+                    .await
+                    {
+                        Ok(Ok(response)) => {
+                            assert!((response.result - 1.0).abs() < f64::EPSILON);
+                            eprintln!("[client] method service OK");
+                            break;
+                        }
+                        other => eprintln!("[client] speak response attempt: {other:?}"),
+                    }
+                }
+                other => eprintln!("[client] speak send attempt: {other:?}"),
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+
+        // The typed action client on /robot/actions/look_at.
+        let qos = ros2_client::action::ActionClientQosPolicies {
+            goal_service: service_qos.clone(),
+            result_service: service_qos.clone(),
+            cancel_service: service_qos.clone(),
+            feedback_subscription: service_qos.clone(),
+            status_subscription: service_qos.clone(),
+        };
+        let client = node
+            .create_action_client::<ros2_client::Action<LookAtGoal, LookAtResult, LookAtFeedback>>(
+                ServiceMapping::Enhanced,
+                &Name::parse("/robot/actions/look_at").expect("a valid action name"),
+                &ros2_client::ActionTypeName::new("arora", "look_at"),
+                qos,
+            )
+            .expect("the action client creates");
+
+        // Send the goal until the graph connects and the server accepts. The
+        // accepted goal SPAWNs a run into the device's node graph.
+        let goal = LookAtGoal {
+            policy: "track".to_string(),
+            x: 1.5,
+        };
+        eprintln!("[client] sending goal");
+        let goal_id = loop {
+            match tokio::time::timeout(Duration::from_secs(2), client.async_send_goal(goal.clone()))
+                .await
+            {
+                Ok(Ok((goal_id, response))) if response.accepted => break goal_id,
+                other => {
+                    eprintln!("[client] send_goal attempt: {other:?}");
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                }
+            }
+        };
+        eprintln!("[client] goal accepted — the run is live in the graph");
+
+        // The run tracks indefinitely; cancel ends it. The bridge halts the
+        // run (its status key goes terminal) and reports CANCELED — it is the
+        // party that issued the halt.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        eprintln!("[client] canceling");
+        client
+            .async_cancel_goal(goal_id, ros2_client::builtin_interfaces::Time::ZERO)
+            .await
+            .expect("cancel round-trips");
+        eprintln!("[client] cancel answered; requesting result");
+        let (status, LookAtResult {}) = client
+            .async_request_result(goal_id)
+            .await
+            .expect("the result arrives");
+        assert_eq!(status, GoalStatusEnum::Canceled);
+    };
+
+    tokio::select! {
+        _ = &mut device => unreachable!("the device loop never returns"),
+        result = tokio::time::timeout(Duration::from_secs(60), client_flow) => {
+            result.expect("the action lifecycle timed out");
+        }
+    }
+}


### PR DESCRIPTION
The out-of-the-box demonstration: a **typed ROS 2 action client** runs the LookAt lifecycle against the **real vizij device** — no scripted runtime anywhere. Discovery (`DescribeMethods` over a *described* gaze host module) → the bridge synthesises `/robot/actions/look_at` → SendGoal → SPAWN grafts the run into the node graph → its status key drives `EXECUTING` → cancel → halt → `CANCELED`. A `speak` method-service probe discriminates a broken service plane from a broken action assembly. macOS-ignored (DDS multicast on loopback), runs on Linux.

Builds on the released arora family — **arora 9.10, arora-bridge-ros2 3.2** from crates.io, stable toolchain, no patches. (Stacked on the merged #84.)

## Frictions found on the way (the point of the exercise)

1. **Nothing fed the method index** — every real device answered `DescribeMethods` with an empty list. Fixed for host modules by [#202](https://github.com/semio-ai/arora-sdk/pull/202) (`described_function`); guest headers still unindexed (`TypeRef` carries no type versions).
2. **arora-bridge-ros2 3.2.0 was silently failing to publish** — its dep `arora-msgs-ros2` was missing from release.yml's publishable set; the job swallowed the failure as a warning. Fixed by [#204](https://github.com/semio-ai/arora-sdk/pull/204).
3. **Result/Feedback types are synthesised from observed values**, and **a bare function cannot populate feedback/result keys** — only graph structure writes the store. Both point at the systematic fix (a function is a parameterized fragment) discussed in [vizij-docs #9](https://github.com/vizij-ai/vizij-docs/pull/9) §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)