### PR TITLE
docs(vizij): document the face standard & ROS4HRI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ What you read here should give you everything you need to build, test, and publi
 
 1. [Workspace Layout](#workspace-layout)
 2. [Domain Stacks](#domain-stacks)
-3. [Toolchain & Requirements](#toolchain--requirements)
-4. [Setup](#setup)
-5. [Common Workflows](#common-workflows)
-6. [Testing](#testing)
-7. [Publishing & Versioning](#publishing--versioning)
-8. [Development Tips](#development-tips)
-9. [Reference Documentation](#reference-documentation)
+3. [Face Standard & ROS4HRI](#face-standard--ros4hri)
+4. [Toolchain & Requirements](#toolchain--requirements)
+5. [Setup](#setup)
+6. [Common Workflows](#common-workflows)
+7. [Testing](#testing)
+8. [Publishing & Versioning](#publishing--versioning)
+9. [Development Tips](#development-tips)
+10. [Reference Documentation](#reference-documentation)
 
 ---
 
@@ -47,8 +48,12 @@ vizij-rs/
 │  │  ├─ vizij-arora-store         # Vizij Blackboard exposed as an Arora DataStore
 │  │  ├─ vizij-arora-hal           # Vizij rig presented as an Arora HAL
 │  │  ├─ vizij-arora-behavior      # Vizij node graph as an Arora behavior interpreter
+│  │  ├─ vizij-arora-host          # Bundle composition + the face standard & ROS4HRI profile
 │  │  ├─ vizij-arora-web           # Browser wasm cdylib: Vizij runtime as an Arora device
 │  │  └─ vizij-animation-module    # vizij-animation-core packaged as an Arora wasm module
+│  ├─ tools/
+│  │  └─ vizij-bundle              # Face-GLB bundle tool: inspect/pack/validate, embed standard profiles
+│  ├─ vizij                        # The native app: cargo run shows a face, running an arora
 │  └─ test-fixtures/
 │     └─ vizij-test-fixtures       # Loads JSON fixtures referenced across stacks
 ├─ npm/
@@ -90,6 +95,7 @@ The `crates/interop/*` family adapts the Vizij stacks onto Arora runtime seams s
 | `vizij-arora-store`      | Vizij Blackboard exposed as an Arora `DataStore`.                      | — |
 | `vizij-arora-hal`        | Vizij rig presented as an Arora HAL.                                   | — |
 | `vizij-arora-behavior`   | Vizij node graph driven as an Arora behavior interpreter.              | — |
+| `vizij-arora-host`       | Composes a face's bundle graphs; hosts the [face standard](docs/face-standard.md) vocabulary and the [ROS4HRI](docs/ros4hri.md) profile. | — |
 | `vizij-arora-web`        | Browser wasm cdylib composing a Vizij runtime as an Arora device.      | `@vizij/runtime` |
 | `vizij-animation-module` | `vizij-animation-core` packaged as an Arora wasm module.               | `@vizij/animation-module` |
 
@@ -102,6 +108,32 @@ The `crates/interop/*` family adapts the Vizij stacks onto Arora runtime seams s
 | `@vizij/wasm-loader` | Shared loader that caches wasm-bindgen modules, resolves `file://` URLs, and enforces ABI checks. |
 
 These packages build quickly (`pnpm run build:shared`) and should be rebuilt whenever fixtures or API contracts change.
+
+---
+
+## Face Standard & ROS4HRI
+
+Vizij faces are driven through a **named-control vocabulary on the store**, the
+`standard/vizij/*` [face standard](docs/face-standard.md): gaze & lids,
+expressions and visemes, and a fine muscle tier (one control per FACS action
+unit / ARKit blendshape). A caller writes a control; the face's own graphs turn
+it into the motion of its particular rig — so the same command drives any face.
+
+On top of it, Vizij ships a built-in **[ROS4HRI](docs/ros4hri.md) profile**: a
+graph mapping ROS4HRI's face vocabulary (`hri_msgs/Expression`,
+`FacialActionUnits`, gaze, plus a viseme extension) onto the standard. It is
+on by default in the `vizij` binary (`--no-ros4hri` opts out) and opt-in for
+library callers. The profile is a canonical, editable asset
+(`crates/interop/vizij-arora-host/profiles/ros4hri.json`) that
+[`vizij-bundle`](crates/tools/vizij-bundle/README.md) can embed into a face GLB
+and [`@vizij/runtime`](npm/@vizij/runtime/README.md) serves to authoring apps.
+
+- **[Face standard](docs/face-standard.md)** — the control vocabulary (the three
+  tiers, the expression/viseme/muscle tables).
+- **[ROS4HRI support](docs/ros4hri.md)** — the profile, its `standard/ros4hri/*`
+  key contract, and how to enable and embed it.
+- **[`vizij-bundle`](crates/tools/vizij-bundle/README.md)** — inspect, pack,
+  `validate` coverage (L0–L3), and `add-standard` a profile into a face.
 
 ---
 
@@ -337,6 +369,9 @@ Use `scripts/dry-run-release.sh` to sanity-check the end-to-end flow (builds, wa
 - [vizij-graph-core/README](crates/node-graph/vizij-graph-core/README.md)
 - [vizij-api-core/README](crates/api/vizij-api-core/README.md)
 - [vizij-test-fixtures/README](crates/test-fixtures/vizij-test-fixtures/README.md)
+- [vizij/README](crates/vizij/README.md) — the native app (the `vizij` binary)
+- [vizij-bundle/README](crates/tools/vizij-bundle/README.md) — the face-GLB bundle tool
+- [Face standard](docs/face-standard.md) & [ROS4HRI support](docs/ros4hri.md)
 - [@vizij/node-graph/README](npm/@vizij/node-graph/README.md)
 - [@vizij/animation/README](npm/@vizij/animation/README.md)
 - [@vizij/value-json/README](npm/@vizij/value-json/README.md)

--- a/crates/vizij/README.md
+++ b/crates/vizij/README.md
@@ -33,6 +33,36 @@ cargo run -p vizij -- --glb face.glb --snapshot out.png --size 763x760
   `WinitPlugin` disabled, `ScheduleRunnerPlugin`, camera → `RenderTarget`
   image, `gpu_readback` → PNG.
 
+## Flags
+
+`cargo run -p vizij -- --glb <face.glb>` plus:
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--glb <path>` | required | the face GLB (embedded `RobotData` + `VIZIJ_bundle`) |
+| `--graphs <kinds>` | `rig,pose-driver,pose,standard-adaptation` | compose only these bundle graph kinds |
+| `--no-ros4hri` | off (profile **on**) | drop the built-in [ROS4HRI](../../docs/ros4hri.md) profile |
+| `--program <id>` | bundle's active program | autoplay this motiongraph program |
+| `--no-autoplay` | off | hold the rig's authored/neutral pose |
+| `--no-stage-neutral` | off | don't stage the bundle's `neutralInputs` at boot |
+| `--snapshot <png>` | — | render one frame offscreen and exit (no window) |
+| `--headless` | off | run windowless, streaming frames into the store |
+| `--size WxH` | `763x486` | offscreen render size (`--snapshot` / `--headless`) |
+| `--frame-rate <hz>` | `15` | publish rendered frames as HAL `view/frame` readings; 0 disables |
+| `--frame-format <fmt>` | `png` | encoding of published frames |
+| `--background <rrggbb>` | `000000` | clear color |
+| `--ambient <f>` | `π/2` | three.js-style ambient intensity |
+| `--unlit` | off | render materials unlit (albedo passthrough) |
+| `--fit <contain\|cover>` | `contain` | how the face fits the window |
+
+The ROS 2 and Studio bridges are build features (they compose with arora's local
+WS bridge):
+
+| Flag | Feature | Effect |
+|---|---|---|
+| `--ros2 [namespace][:domain]` | `ros2` | expose the device's keys over ROS 2 topics |
+| `--studio` | `studio` | attach the Semio Studio bridge (configured from the environment) |
+
 ## Lighting model
 
 The web renders `MeshStandardMaterial` under a single `ambientLight(π/2)`,
@@ -66,10 +96,10 @@ vizij-web (`apps/vizij-authoring/e2e/`, headed — headless Chromium does not
 composite the WebGL canvas), loading the `quori:latest` / `toasty:basic`
 presets.
 
-## Not yet here (VIZ-47 stages)
+## Not yet here
 
-Animation module loading (clip transport), egui panels (inputs, transport,
-bridges), bridge flags (`--ros2`, `--studio`; arora's local WS bridge attaches
-when the device runs via `Arora::run`), `--headless` frames-to-store
-(`view/frame` as `ArrayU8`), and packaging. See
-`docs/proposal-vizij-native-app.md`.
+The native app is otherwise complete (VIZ-47): the animation module + clip
+transport, the ROS 2 / Studio bridge flags, and `--headless` frames-to-store all
+landed. The egui inspector panels (VIZ-82) were dropped — the operator surface is
+the arora TUI + the store — and packaging (a distributable bundle) is still open.
+See `docs/proposal-vizij-native-app.md`.

--- a/docs/face-standard.md
+++ b/docs/face-standard.md
@@ -1,0 +1,122 @@
+# The Vizij face standard
+
+A compliant Vizij face is driven through **named controls on the store**, under
+the `standard/vizij/` prefix. A caller — a behavior, a bridge, a performance —
+writes a control; the face's own graphs turn that control into the motion of its
+particular rig. The vocabulary is the contract between the two, so the same
+command drives any face and any face can be swapped under the same command.
+
+The controls live in [`vizij-arora-host`'s `standard`
+module](../crates/interop/vizij-arora-host/src/standard.rs), which is the
+authoritative source; this page mirrors it.
+
+Everything is an `f32` weight in `[0, 1]` unless stated otherwise.
+
+## Three tiers
+
+The vocabulary runs coarse to fine. A face implements what it implements, and a
+standard profile (like [ROS4HRI](ros4hri.md)) degrades to the tiers a face
+covers.
+
+1. **Gaze & lids** — where the eyes point and how open they are.
+2. **Semantic** — one weight per named expression and per viseme shape.
+3. **Muscle** — fine-grained controls, one per FACS action unit / ARKit
+   blendshape.
+
+## Gaze & lids
+
+| Control path | Range | Meaning |
+|---|---|---|
+| `standard/vizij/left_eye/pos/x` | `[-1, 1]` | eye left→right (subject's own left is negative) |
+| `standard/vizij/left_eye/pos/y` | `[-1, 1]` | eye down→up |
+| `standard/vizij/right_eye/pos/x` | `[-1, 1]` | as above, right eye |
+| `standard/vizij/right_eye/pos/y` | `[-1, 1]` | as above, right eye |
+| `standard/vizij/left_eye_top_eyelid/pos/y` | `[0, 1]` | 0 open, 1 closed |
+| `standard/vizij/right_eye_top_eyelid/pos/y` | `[0, 1]` | 0 open, 1 closed |
+
+Per-eye positions (rather than a single gaze vector) let a profile command
+vergence; the ROS4HRI profile computes them from a face-frame target.
+
+## Semantic tier
+
+### Expressions
+
+One weight per named expression, at `standard/vizij/expression/<name>`. The
+names are ROS4HRI's `hri_msgs/Expression` vocabulary (25). The standard does
+**not** prescribe what an expression looks like — that is the face's authored
+pose; it prescribes only the name a caller commands.
+
+```
+neutral   angry      sad         happy        surprised
+disgusted scared     pleading    vulnerable   despaired
+guilty    disappointed embarrassed horrified  skeptical
+annoyed   furious    suspicious  rejected     bored
+tired     asleep     confused    amazed       excited
+```
+
+### Visemes
+
+One weight per viseme shape, at `standard/vizij/viseme/<shape>`. The shapes are
+the industry 15-shape set (Oculus/Meta naming); `sil` is silence, the
+closed-mouth rest shape.
+
+```
+sil PP FF TH DD kk CH SS nn RR aa E ih oh ou
+```
+
+## Muscle tier
+
+Fine-grained controls at `standard/vizij/face/<control>`, cherry-picked from two
+standards so each is reachable from either:
+
+- **FACS supplies the taxonomy.** Each control names a facial action unit, so
+  ROS4HRI's `hri_msgs/FacialActionUnits` maps onto the muscle tier losslessly.
+  AU codes repeat across lateralized pairs — FACS does not split left/right at
+  the code level.
+- **ARKit supplies lateralization and naming.** Its blendshape arrays carry the
+  left/right the FACS message cannot, and assets in the wild ship ARKit-named
+  morph targets, so an ARKit name resolves directly to a control.
+
+Controls exist for the union that makes sense on a *commanded* robot face.
+ARKit's tracking-only shapes (`eyeLook*` — redundant with the gaze tier) and
+FACS codes a command channel cannot express (visibility, head and eye
+movement — owned by the gaze tier) have none.
+
+| Control | AU | ARKit | Control | AU | ARKit |
+|---|---|---|---|---|---|
+| `brow_inner_up` | 1 | browInnerUp | `mouth_smile_left` | 12 | mouthSmileLeft |
+| `brow_outer_up_left` | 2 | browOuterUpLeft | `mouth_smile_right` | 12 | mouthSmileRight |
+| `brow_outer_up_right` | 2 | browOuterUpRight | `mouth_frown_left` | 15 | mouthFrownLeft |
+| `brow_down_left` | 4 | browDownLeft | `mouth_frown_right` | 15 | mouthFrownRight |
+| `brow_down_right` | 4 | browDownRight | `mouth_press_left` | 24 | mouthPressLeft |
+| `eye_wide_left` | 5 | eyeWideLeft | `mouth_press_right` | 24 | mouthPressRight |
+| `eye_wide_right` | 5 | eyeWideRight | `mouth_pucker` | 18 | mouthPucker |
+| `eye_squint_left` | 7 | eyeSquintLeft | `mouth_funnel` | 22 | mouthFunnel |
+| `eye_squint_right` | 7 | eyeSquintRight | `mouth_stretch_left` | 20 | mouthStretchLeft |
+| `eye_closed_left` | 43 | eyeBlinkLeft | `mouth_stretch_right` | 20 | mouthStretchRight |
+| `eye_closed_right` | 43 | eyeBlinkRight | `mouth_upper_up_left` | 10 | mouthUpperUpLeft |
+| `cheek_raise_left` | 6 | cheekSquintLeft | `mouth_upper_up_right` | 10 | mouthUpperUpRight |
+| `cheek_raise_right` | 6 | cheekSquintRight | `mouth_lower_down_left` | 16 | mouthLowerDownLeft |
+| `cheek_puff` | 34 | cheekPuff | `mouth_lower_down_right` | 16 | mouthLowerDownRight |
+| `nose_sneer_left` | 9 | noseSneerLeft | `jaw_open` | 26 | jawOpen |
+| `nose_sneer_right` | 9 | noseSneerRight | `jaw_left` | — | jawLeft |
+| `tongue_out` | 19 | tongueOut | `jaw_right` | — | jawRight |
+| | | | `jaw_forward` | 29 | jawForward |
+
+AU 45 (blink) aliases AU 43 (eyes closed) — both command the eyelid controls.
+
+## Reaching the vocabulary in code
+
+`vizij-arora-host`'s `standard` module exposes the constants and the path
+helpers (`expression_path`, `viseme_path`, `face_path`), plus
+`controls_for_au(code)` (the lateralized pair or single control an AU drives)
+and `control_for_arkit(name)`. Callers should build paths through these rather
+than hand-format strings.
+
+## See also
+
+- [The ROS4HRI profile](ros4hri.md) — the built-in mapping that fills this
+  vocabulary from ROS4HRI's topics.
+- [`vizij-bundle`](../crates/tools/vizij-bundle/README.md) — the tool that
+  reports which tiers a face covers (`validate`) and embeds a standard profile
+  into a face GLB (`add-standard`).

--- a/docs/ros4hri.md
+++ b/docs/ros4hri.md
@@ -1,0 +1,116 @@
+# ROS4HRI support
+
+Vizij ships official support for [ROS4HRI](https://wiki.ros.org/hri), the ROS 2
+human-robot-interaction standard, as a **built-in profile**: a graph that maps
+the ROS4HRI face vocabulary onto the [Vizij face standard](face-standard.md), so
+a ROS4HRI face command drives any compliant Vizij face.
+
+This is **topic-level** support. Vizij consumes the ROS4HRI face-command
+vocabulary (expressions, action units, gaze, and — as a Vizij extension —
+visemes); it does not (yet) speak ROS4HRI's services or actions.
+
+## How it fits together
+
+```
+ROS4HRI topics ──(a ROS bridge)──▶ standard/ros4hri/* store keys
+                                          │
+                                   ros4hri profile graph
+                                          │
+                                   standard/vizij/* controls
+                                          │
+                                   the face's own rig graph ──▶ morphs / bones
+```
+
+The profile is one layer in that chain: it reads the `standard/ros4hri/*` keys a
+bridge writes and produces `standard/vizij/*` controls. It is
+asset-independent — it only writes standard control paths; what an expression or
+a viseme *looks like* stays with the face.
+
+> **The ROS bridge that writes `standard/ros4hri/*` from live ROS 2 topics is
+> the `arora-bridge-ros2` side, not this repo.** The ROS4HRI message vocabulary
+> (`hri_msgs/Expression`, `FacialActionUnits`, `Gaze`, …) is available as typed
+> ROS 2 messages in
+> [`arora-msgs-ros2`](https://github.com/semio-ai/arora-sdk/tree/main/crates/arora-msgs-ros2);
+> the typed-topic exposure that lands those onto these keys is a planned
+> bridge feature. Until then, drive the keys directly (any behavior or test can
+> write them) — the profile behaves identically regardless of who writes them.
+
+## The `standard/ros4hri/*` key contract
+
+What a bridge (or a test) writes:
+
+| Key | Type | ROS4HRI source | Meaning |
+|---|---|---|---|
+| `standard/ros4hri/expression/name` | string | `hri_msgs/Expression.expression` | one-hots the named expression weight |
+| `standard/ros4hri/expression/valence` | f32 `[-1,1]` | `hri_msgs/Expression.valence` | blends named weights by circumplex proximity when no name is set |
+| `standard/ros4hri/expression/arousal` | f32 `[-1,1]` | `hri_msgs/Expression.arousal` | as above |
+| `standard/ros4hri/gaze/target` | vec3 (m) | a look-at point (face frame: x forward, y left, z up) | per-eye gaze with vergence |
+| `standard/ros4hri/au/<code>` | f32 `[0,1]` | `hri_msgs/FacialActionUnits` | FACS action-unit intensity → muscle controls |
+| `standard/ros4hri/viseme/<shape>` | f32 `[0,1]` | *Vizij extension* (ROS4HRI has no viseme topic) | viseme weight, pass-through |
+
+## Per-channel behaviour
+
+- **Expression** — a non-empty `expression/name` one-hots the named weight.
+  Otherwise `valence`/`arousal` blend the named weights by proximity to each
+  expression's circumplex anchor. Weights are smoothed and written to
+  `standard/vizij/expression/<name>`.
+- **Gaze** — `gaze/target` maps to per-eye positions with vergence, the
+  incumbent ±0.78 rad → ±1 normalization, and a center fallback for targets at
+  or behind the face plane (x ≤ 0.1 m).
+- **Action units** — `au/<code>` intensities route to the muscle-tier controls
+  ([`FACE_CONTROLS`](face-standard.md#muscle-tier)); the eyes-closed unit also
+  drives the eyelids, and jaw-open additionally drives the de-facto
+  `mouth/morph/jaw_open` control.
+- **Visemes** — `viseme/<shape>` weights pass through, smoothed, to
+  `standard/vizij/viseme/<shape>`. ROS4HRI defines no viseme channel; this is a
+  Vizij extension fed by a lipsync source.
+- **Blink** — an idle generator (≈8 s cycle, deterministically jittered, 0.2 s
+  parabolic pulse) drives the eyelids, inhibited while the eyes are commanded
+  closed or the face is asleep.
+
+All continuous channels pass through a ~200 ms exponential smoother — the
+incumbent ROS4HRI face's dynamics.
+
+## Enabling it
+
+The profile composes between a face's own graphs and any playing program, so a
+performance overrides it (last-writer-wins).
+
+- **From the `vizij` binary** it is **on by default**; opt out with
+  `--no-ros4hri`.
+- **From a library** it is opt-in: `vizij_arora_host::ros4hri::ros4hri_source(rig_prefix)`
+  returns the composable graph source, or embed it into a face GLB so it travels
+  with the asset (see below).
+
+## Embedding and editing the profile
+
+The profile graph is a canonical JSON asset,
+[`profiles/ros4hri.json`](../crates/interop/vizij-arora-host/profiles/ros4hri.json).
+Rust reads it (and regenerates it from the node-graph builder; a test fails if
+the committed file drifts), so it is programmatically available *and* separately
+editable and exportable.
+
+- **Bundle it into a face** with
+  [`vizij-bundle`](../crates/tools/vizij-bundle/README.md):
+  `vizij-bundle add-standard face.glb --standard ros4hri -o out.glb` grafts the
+  profile under a stable id (`standard::ros4hri`), re-runnable to update in
+  place.
+- **From the web** the same asset is served by
+  [`@vizij/runtime`](../npm/@vizij/runtime/README.md): `standardProfiles()`
+  lists the shipped profiles (the introspectable menu of what a face may opt
+  into), and `standardProfile("ros4hri", rigPrefix)` returns the profile graph
+  as an object for an authoring app to embed.
+
+## Progressive compliance
+
+A face implements the standard tiers it covers, and the profile degrades to
+them: gaze & lids (L0), expressions (L1), visemes (L2), muscle/AU (L3).
+`vizij-bundle validate --min-level <n>` reports and gates a face's coverage.
+
+## See also
+
+- [The Vizij face standard](face-standard.md) — the target vocabulary.
+- [`vizij-bundle`](../crates/tools/vizij-bundle/README.md) — bundle, validate,
+  and export profiles.
+- [`arora-msgs-ros2`](https://github.com/semio-ai/arora-sdk/tree/main/crates/arora-msgs-ros2) —
+  the ROS4HRI (`hri_msgs`) message vocabulary as typed ROS 2 messages.

--- a/npm/@vizij/runtime/README.md
+++ b/npm/@vizij/runtime/README.md
@@ -33,6 +33,25 @@ A host with its own clock skips `run()` and calls `runtime.step(dtMs)` per
 frame instead (e.g. from `requestAnimationFrame` timestamps); `step()`
 becomes unavailable once `run()` has taken the runtime.
 
+### Standard profiles
+
+Vizij ships built-in standard profiles — graphs that map an external face
+standard onto Vizij's own (currently the [ROS4HRI face
+standard](https://github.com/vizij-ai/vizij-rs/blob/main/docs/ros4hri.md)). An
+authoring app can list them and embed one into a face:
+
+```ts
+import { standardProfiles, standardProfile } from "@vizij/runtime";
+
+standardProfiles();                       // [{ id, title, description }] — the menu
+const graph = standardProfile("ros4hri", "rig/<faceId>/"); // the profile graph as an object
+```
+
+`standardProfiles()` is the introspectable list of what a face may opt into.
+`standardProfile(id, rigPrefix)` returns the profile's node-graph (its output
+paths prefixed for the target face), ready to compose into a graph spec or embed
+into a GLB via the bundle tool.
+
 Values cross the boundary in the normalized `ValueJSON` vocabulary from
 [`@vizij/value-json`](https://www.npmjs.com/package/@vizij/value-json);
 `setValue`/`writeValues` accept its `ValueInput` shorthands.


### PR DESCRIPTION
Spreads the specs #83 shipped into the READMEs and two reference pages. Docs-only; no code changes.

## What
- **`docs/face-standard.md`** — the `standard/vizij/*` control vocabulary: the three tiers (gaze & lids, semantic expressions/visemes, the FACS⊕ARKit muscle tier) with the full tables, mirrored from the `standard` module.
- **`docs/ros4hri.md`** — the built-in ROS4HRI profile: its `standard/ros4hri/*` key contract, the mapping to ROS4HRI's `hri_msgs` topics, per-channel behaviour, `--no-ros4hri` opt-out, and bundling/serving the profile asset.
- **`README.md`** — a *Face Standard & ROS4HRI* section; the Workspace Layout tree now includes `crates/vizij`, `crates/tools/vizij-bundle`, and `crates/interop/vizij-arora-host` (all were missing); new guides under Reference Documentation.
- **`crates/vizij/README.md`** — documents the binary's flags (`--no-ros4hri`, `--graphs`, the `--ros2`/`--studio` bridge flags, …) and corrects the now-stale "Not yet here" section (animation module, bridges, headless frames all landed; egui was dropped).
- **`npm/@vizij/runtime/README.md`** — documents `standardProfiles()` / `standardProfile(id, rigPrefix)`.

## Accuracy note
`docs/ros4hri.md` states plainly that the ROS→store **typed-topic** bridge (landing live `hri_msgs` topics onto the `standard/ros4hri/*` keys) is the `arora-bridge-ros2` side and is **planned** — the profile consumes those keys regardless of who writes them. So the docs describe the shipped vocabulary + mapping without overclaiming end-to-end topic ingestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)