### PR TITLE
feat(graph): live goal updates for task runs — args ride the update key (ARORA-84)

### DIFF
--- a/crates/interop/vizij-arora-behavior/src/lib.rs
+++ b/crates/interop/vizij-arora-behavior/src/lib.rs
@@ -112,6 +112,7 @@ impl NodeFunctions for CallBridgeFunctions<'_> {
 struct GraphRun {
     run_node: String,
     status_node: String,
+    args_node: String,
     status_key: Key,
 }
 
@@ -233,7 +234,11 @@ impl ProcessingGraph {
     /// removes structure, not state.
     fn prune_run(&mut self, run: &GraphRun) -> Result<(), BehaviorError> {
         let diff = graph_codec::GraphSpecDiff {
-            remove_nodes: vec![run.run_node.clone(), run.status_node.clone()],
+            remove_nodes: vec![
+                run.run_node.clone(),
+                run.status_node.clone(),
+                run.args_node.clone(),
+            ],
             ..graph_codec::GraphSpecDiff::default()
         };
         let diff = graph_codec::spec_diff_to_graph_diff(&diff)
@@ -450,20 +455,44 @@ impl BehaviorInterpreter for ProcessingGraph {
                 message: format!("the status key does not parse as a path: {e}"),
             })?;
 
+        let update_path =
+            TypedPath::parse(&format!("{prefix}/update")).map_err(|e| BehaviorError {
+                message: format!("the update key does not parse as a path: {e}"),
+            })?;
+
         let run_node = format!("task/{}/run", task.0);
         let status_node = format!("task/{}/status", task.0);
+        let args_node = format!("task/{}/args", task.0);
+        // The spawn-time argument bundle: a structure of the call's args, the
+        // default the args input serves until a live update lands on the run's
+        // update key.
+        let args_bundle = Value::Structure(Structure {
+            id: call.id,
+            fields: call.args.clone(),
+        });
         let diff = graph_codec::GraphSpecDiff {
             upsert_nodes: vec![
+                // The run's args source: an input on the update key, defaulting
+                // to the spawn-time bundle. A caller (the ROS bridge on a live
+                // goal) writes new args to the update key; the next tick stages
+                // them here and the run picks them up — no graph edit per update.
+                NodeSpec {
+                    id: args_node.clone(),
+                    kind: NodeType::Input,
+                    params: NodeParams {
+                        path: Some(update_path),
+                        value: Some(args_bundle),
+                        ..NodeParams::default()
+                    },
+                    output_shapes: Default::default(),
+                    input_defaults: Default::default(),
+                },
                 NodeSpec {
                     id: run_node.clone(),
                     kind: NodeType::TaskRun,
                     params: NodeParams {
                         module: call.module_id,
                         function: Some(call.id),
-                        value: Some(Value::Structure(Structure {
-                            id: call.id,
-                            fields: call.args.clone(),
-                        })),
                         ..NodeParams::default()
                     },
                     output_shapes: Default::default(),
@@ -480,17 +509,30 @@ impl BehaviorInterpreter for ProcessingGraph {
                     input_defaults: Default::default(),
                 },
             ],
-            upsert_edges: vec![EdgeSpec {
-                from: EdgeOutputEndpoint {
-                    node_id: run_node.clone(),
-                    output: "out".to_string(),
+            upsert_edges: vec![
+                EdgeSpec {
+                    from: EdgeOutputEndpoint {
+                        node_id: args_node.clone(),
+                        output: "out".to_string(),
+                    },
+                    to: EdgeInputEndpoint {
+                        node_id: run_node.clone(),
+                        input: "args".to_string(),
+                    },
+                    selector: None,
                 },
-                to: EdgeInputEndpoint {
-                    node_id: status_node.clone(),
-                    input: "in".to_string(),
+                EdgeSpec {
+                    from: EdgeOutputEndpoint {
+                        node_id: run_node.clone(),
+                        output: "out".to_string(),
+                    },
+                    to: EdgeInputEndpoint {
+                        node_id: status_node.clone(),
+                        input: "in".to_string(),
+                    },
+                    selector: None,
                 },
-                selector: None,
-            }],
+            ],
             ..graph_codec::GraphSpecDiff::default()
         };
         let diff = graph_codec::spec_diff_to_graph_diff(&diff)
@@ -500,6 +542,7 @@ impl BehaviorInterpreter for ProcessingGraph {
             GraphRun {
                 run_node,
                 status_node,
+                args_node,
                 status_key: status_key.clone(),
             },
         );
@@ -893,7 +936,8 @@ mod tests {
         let handle = graph
             .spawn(look_at(), RunPolicy::Concurrent)
             .expect("spawn");
-        assert_eq!(graph.graph().nodes.len(), nodes_before + 2);
+        // The fragment is three nodes: args input, taskrun leaf, status output.
+        assert_eq!(graph.graph().nodes.len(), nodes_before + 3);
         assert!(handle.status.path.starts_with("arora/tasks/"));
 
         let mut bridge = RunBridge::new(Vec::new());
@@ -999,5 +1043,51 @@ mod tests {
         assert_eq!(read_key(&store, &first.status), Some(task::running()));
         assert_eq!(read_key(&store, &second.status), Some(task::running()));
         assert_eq!(bridge.calls.len(), 2);
+    }
+
+    /// A live goal update reaches the running call: writing new args to the
+    /// run's update key makes the next tick invoke the call with them, with no
+    /// graph edit per update — the run's args ride an `input` on the update key
+    /// (ARORA-84).
+    #[test]
+    fn a_live_update_reaches_the_running_call() {
+        let store = SimpleDataStore::new();
+        let mut graph =
+            ProcessingGraph::from_spec(passthrough("sensor/x", "actuator/y")).expect("from_spec");
+        store
+            .write(StateChange::set("sensor/x", float(0.75)))
+            .unwrap();
+        let arg_id = Uuid::from_u128(0x7861);
+
+        let handle = graph
+            .spawn(look_at(), RunPolicy::Concurrent)
+            .expect("spawn");
+        let mut bridge = RunBridge::new(Vec::new());
+
+        // First tick: the run invokes with the spawn-time args (0.5).
+        graph.tick_store(&store, &mut bridge, 0.016).expect("tick");
+        assert_eq!(
+            bridge.calls.last().expect("a call").args[0].value.as_ref(),
+            &float(0.5),
+        );
+
+        // The caller pushes a moving target: new args on the update key.
+        let update = Value::Structure(Structure {
+            id: look_at().id,
+            fields: vec![StructureField {
+                id: arg_id,
+                value: Box::new(float(0.9)),
+            }],
+        });
+        let mut change = StateChange::new();
+        change.set.insert(handle.update[0].clone(), Some(update));
+        store.write(change).unwrap();
+
+        // Next tick: the run invokes with the updated args (0.9) — no re-spawn.
+        graph.tick_store(&store, &mut bridge, 0.016).expect("tick");
+        assert_eq!(
+            bridge.calls.last().expect("a call").args[0].value.as_ref(),
+            &float(0.9),
+        );
     }
 }

--- a/crates/node-graph/vizij-graph-core/CHANGELOG.md
+++ b/crates/node-graph/vizij-graph-core/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `vizij-graph-core`. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.2.0] - 2026-07-30
+
+### Added
+
+- `TaskRun` gains an optional `args` input: when wired it supplies the call's
+  argument bundle (overriding the `value` param), so a live goal update on a
+  running task's update key flows into the call each tick — the node-graph
+  side of ARORA-84.
+
 ## [1.1.0] - 2026-07-29
 
 ### Added

--- a/crates/node-graph/vizij-graph-core/Cargo.toml
+++ b/crates/node-graph/vizij-graph-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "vizij-graph-core"
-version = "1.1.0"
+version = "1.2.0"
 edition     = "2021"
 license     = "MIT OR Apache-2.0"
 description = "Core node‑graph engine used by Vizij."

--- a/crates/node-graph/vizij-graph-core/src/eval/eval_node.rs
+++ b/crates/node-graph/vizij-graph-core/src/eval/eval_node.rs
@@ -387,13 +387,14 @@ fn evaluate_kind_inner(
         NodeType::Input => eval_input_node(rt, spec, outputs),
         NodeType::Output => eval_output(inputs, outputs),
         NodeType::ExternalFunction => eval_external_function(params, inputs, outputs, functions),
-        NodeType::TaskRun => eval_task_run(rt, spec, outputs, functions),
+        NodeType::TaskRun => eval_task_run(rt, spec, inputs, outputs, functions),
     }
 }
 
 fn eval_task_run(
     rt: &mut GraphRuntime,
     spec: &NodeSpec,
+    inputs: &InputSlots,
     outputs: &mut OutputSlots,
     functions: Option<&mut dyn NodeFunctions>,
 ) -> Result<(), String> {
@@ -415,8 +416,15 @@ fn eval_task_run(
         "TaskRun node evaluated without a function host (graph run outside a host)".to_string()
     })?;
 
-    // The argument bundle: one structure whose fields are the call's args.
-    let args: Vec<(Uuid, Value)> = match &spec.params.value {
+    // The argument bundle is one structure whose fields are the call's args.
+    // It comes from the `args` input when wired — how a live goal update on the
+    // run's update key reaches the call each tick — falling back to the `value`
+    // param, which the interpreter seeds with the spawn-time args.
+    let bundle = inputs
+        .get("args")
+        .map(|port| &port.value)
+        .or(spec.params.value.as_ref());
+    let args: Vec<(Uuid, Value)> = match bundle {
         Some(Value::Structure(bundle)) => bundle
             .fields
             .iter()

--- a/crates/node-graph/vizij-graph-core/src/schema.rs
+++ b/crates/node-graph/vizij-graph-core/src/schema.rs
@@ -2726,10 +2726,19 @@ pub fn registry() -> Registry {
         type_id: TaskRun,
         name: "Task Run",
         category: "Functions",
-        doc: "Hosts one task run: invokes its module function (module, function and argument \
-              bundle are params) each evaluation and emits the run's behavior Status, latched \
-              once terminal. Grafted per spawned run by the interpreter.",
-        inputs: vec![],
+        doc: "Hosts one task run: invokes its module function (module and function are params) \
+              each evaluation and emits the run's behavior Status, latched once terminal. The \
+              argument bundle comes from the `args` input when wired (so a live goal update on \
+              the run's update key flows in each tick), else from the `value` param. Grafted per \
+              spawned run by the interpreter.",
+        inputs: vec![PortSpec {
+            id: "args",
+            ty: PortType::Any,
+            label: "Args",
+            doc: "The call's argument bundle (a structure of the call args). Overrides the \
+                  `value` param when present — how a live goal update reaches a running task.",
+            optional: true,
+        }],
         variadic_inputs: None,
         outputs: vec![PortSpec {
             id: "out",

--- a/npm/@vizij/node-graph/src/metadata/registry.json
+++ b/npm/@vizij/node-graph/src/metadata/registry.json
@@ -3145,8 +3145,16 @@
       "type_id": "taskrun",
       "name": "Task Run",
       "category": "Functions",
-      "doc": "Hosts one task run: invokes its module function (module, function and argument bundle are params) each evaluation and emits the run's behavior Status, latched once terminal. Grafted per spawned run by the interpreter.",
-      "inputs": [],
+      "doc": "Hosts one task run: invokes its module function (module and function are params) each evaluation and emits the run's behavior Status, latched once terminal. The argument bundle comes from the `args` input when wired (so a live goal update on the run's update key flows in each tick), else from the `value` param. Grafted per spawned run by the interpreter.",
+      "inputs": [
+        {
+          "id": "args",
+          "ty": "any",
+          "label": "Args",
+          "doc": "The call's argument bundle (a structure of the call args). Overrides the `value` param when present — how a live goal update reaches a running task.",
+          "optional": true
+        }
+      ],
       "outputs": [
         {
           "id": "out",

--- a/npm/@vizij/node-graph/src/metadata/registry.ts
+++ b/npm/@vizij/node-graph/src/metadata/registry.ts
@@ -3148,8 +3148,16 @@ const registry: Registry = {
       "type_id": "taskrun",
       "name": "Task Run",
       "category": "Functions",
-      "doc": "Hosts one task run: invokes its module function (module, function and argument bundle are params) each evaluation and emits the run's behavior Status, latched once terminal. Grafted per spawned run by the interpreter.",
-      "inputs": [],
+      "doc": "Hosts one task run: invokes its module function (module and function are params) each evaluation and emits the run's behavior Status, latched once terminal. The argument bundle comes from the `args` input when wired (so a live goal update on the run's update key flows in each tick), else from the `value` param. Grafted per spawned run by the interpreter.",
+      "inputs": [
+        {
+          "id": "args",
+          "ty": "any",
+          "label": "Args",
+          "doc": "The call's argument bundle (a structure of the call args). Overrides the `value` param when present — how a live goal update reaches a running task.",
+          "optional": true
+        }
+      ],
       "outputs": [
         {
           "id": "out",


### PR DESCRIPTION
Closes [ARORA-84](https://linear.app/semio-ai/issue/ARORA-84/live-goal-updates-rebind-a-task-runs-update-keys-into-its-running) — the last unimplemented field of the `TaskHandle` contract on the node-graph host.

## What changes

A spawned run's argument bundle now flows through an `input` node on the run's **update key**, wired into a new optional `args` input on the `taskrun` node. The input **defaults to the spawn-time bundle**, so the run works from tick 1 with no update present. When a caller — the ROS bridge on a live goal — writes new args to `arora/tasks/<module>/<function>/<run_id>/update`, the next tick stages them through the input and the run invokes its call with the new args — **no graph edit per update**, the running graph just picks up the new store value each tick.

This is the model the ticket preferred ("wiring the run's params from `input` nodes on the update keys at spawn time so the graph picks them up each tick without an edit").

## Pieces

- `vizij-graph-core` **1.2.0**: `TaskRun` gains an optional `args` input; `eval_task_run` prefers it over the `value` param. Registry regenerated.
- `vizij-arora-behavior`: `spawn` grafts a 3-node fragment now (args input → taskrun → status output); `prune_run` sweeps all three.

## Tests

- `a_live_update_reaches_the_running_call`: spawn, tick (invokes with spawn-time args 0.5), write new args to the update key, tick (invokes with 0.9) — no re-spawn.
- All existing spawn/halt/coexistence tests updated for the 3-node fragment and green; the device-level `a_look_at_run_advances_and_halts_through_the_device` passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)