### PR TITLE
refactor(graph): Status ids from arora-behavior, dropping the behavior-tree-types dep (ARORA-82)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,11 +418,12 @@ dependencies = [
 
 [[package]]
 name = "arora-behavior"
-version = "8.3.0"
+version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "facca7a131265b20c789bded78833b09f9925a9e9e72f7412839f99eaba0646a"
+checksum = "f86d18b53a934aa302e725cdc9918ef7370b5eb8e5b3262ce05b794235b57169"
 dependencies = [
  "arora-types",
+ "semver",
  "serde",
  "uuid",
 ]
@@ -738,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "arora-types-derive"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b31c1d60113291de5628f20a60cebd0238ea6496cb3a32d48d071c3a24c0728"
+checksum = "0622342550b0cc1e349e3c09c0c8c374bbe4d5a5c4c4938d40abe076a7c53d51"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9814,7 +9815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -10395,7 +10396,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.3",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 
@@ -10849,10 +10850,10 @@ dependencies = [
 
 [[package]]
 name = "vizij-graph-core"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
- "arora-behavior-tree-types",
+ "arora-behavior",
  "criterion",
  "hashbrown 0.17.1",
  "k",

--- a/crates/node-graph/vizij-graph-core/CHANGELOG.md
+++ b/crates/node-graph/vizij-graph-core/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `vizij-graph-core`. The format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.3.0] - 2026-07-30
+
+### Changed
+
+- The behavior `Status` ids the `task` module speaks now come from
+  `arora-behavior` (where `Status` moved, ARORA-82) instead of
+  `arora-behavior-tree-types` — the node graph no longer depends on a
+  behavior-*tree* crate for the cross-interpreter run-status contract. Same
+  ids, same wire form.
+
 ## [1.2.0] - 2026-07-30
 
 ### Added

--- a/crates/node-graph/vizij-graph-core/Cargo.toml
+++ b/crates/node-graph/vizij-graph-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "vizij-graph-core"
-version = "1.2.0"
+version = "1.3.0"
 edition     = "2021"
 license     = "MIT OR Apache-2.0"
 description = "Core node‑graph engine used by Vizij."
@@ -19,8 +19,8 @@ hashbrown  = { workspace = true }
 anyhow     = { workspace = true }
 vizij-api-core = { version = "1", path = "../../api/vizij-api-core" }
 # Declares the behavior `Status` enumeration (type + variant ids) a task run
-# speaks; types only, no interpreter.
-arora-behavior-tree-types = "1"
+# speaks — the cross-interpreter run-status contract.
+arora-behavior = "8.4"
 uuid = { version = "1", features = ["serde"] }
 k = { version = "0.32", optional = true, default-features = false }
 urdf-rs = { version = "0.9", optional = true }

--- a/crates/node-graph/vizij-graph-core/src/task.rs
+++ b/crates/node-graph/vizij-graph-core/src/task.rs
@@ -4,12 +4,13 @@
 //! A run's lifecycle travels as the behavior `Status` enumeration — `Running` /
 //! `Success` / `Failure` over unit payloads — the value an interpreter writes to
 //! a run's status key and the one the ROS action plane maps to a goal status.
-//! The type and variant ids come from `arora-behavior-tree-types`, the crate
-//! declaring the enumeration, so the encoding cannot drift from the rest of the
-//! Arora ecosystem. The graph core only constructs these values and recognizes
-//! terminality; it never interprets the payloads.
+//! The type and variant ids come from `arora-behavior`, the crate declaring the
+//! enumeration (`Status` is the cross-interpreter run-status contract), so the
+//! encoding cannot drift from the rest of the Arora ecosystem. The graph core
+//! only constructs these values and recognizes terminality; it never interprets
+//! the payloads.
 
-use arora_behavior_tree_types::{
+use arora_behavior::{
     STATUS_ENUMERATION_ID, STATUS_FAILURE_VARIANT_ID, STATUS_RUNNING_VARIANT_ID,
     STATUS_SUCCESS_VARIANT_ID,
 };


### PR DESCRIPTION
The vizij side of [ARORA-82](https://linear.app/semio-ai/issue/ARORA-82). `Status` — the cross-interpreter run-status contract — moved to `arora-behavior` ([arora-sdk #208](https://github.com/semio-ai/arora-sdk/pull/208), published as arora-behavior 8.4.0). `vizij-graph-core`'s `task` module now imports the id constants from `arora-behavior` instead of `arora-behavior-tree-types`, so the **node graph no longer depends on a behavior-*tree* crate** for a type neither interpreter should own — the whole point of the ticket.

Same ids (`325a5767-…` + variants), same `Value::Enumeration` wire form, so the task-run scaffold, the interpreter tests (20/20), and graph-core (65/65) are unchanged and green.

vizij-graph-core **1.3.0**; pins arora-behavior 8.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)