### PR TITLE
feat(host): embedded standard profiles override the built-in (VIZ-92)

### DIFF
--- a/.changeset/runtime-standard-profiles.md
+++ b/.changeset/runtime-standard-profiles.md
@@ -1,0 +1,5 @@
+---
+"@vizij/runtime": minor
+---
+
+Expose the standard-profile registry to JS: `standardProfiles()` lists the shipped profiles (`{ id, title, description }` — currently `ros4hri`) and `standardProfile(id, rigPrefix)` returns a profile's graph with the face's rig prefix applied, ready to compose or to embed into a GLB as a `standard-profile` bundle graph (`standard::<id>`). The API an authoring app's opt-in picker consumes (VIZ-92).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10850,7 +10850,7 @@ dependencies = [
 
 [[package]]
 name = "vizij-graph-core"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "arora-behavior",

--- a/crates/interop/vizij-arora-host/src/lib.rs
+++ b/crates/interop/vizij-arora-host/src/lib.rs
@@ -42,6 +42,12 @@ pub enum ProgramSelect {
 pub struct Bundle {
     /// Graph entries, `(kind, spec)` — `rig`, `pose-driver`, `motiongraph`, ….
     pub graphs: Vec<(String, Json)>,
+    /// Standard profiles embedded in the face, `(profile id, spec)` — the
+    /// `standard-profile` graph entries (ids `standard::<profile>`, prefix
+    /// stripped). An embedded copy is the author's pinned override of the
+    /// shipped mapping: [`compose`](Bundle::compose) loads it and suppresses
+    /// the built-in profile of the same id.
+    pub standard_profiles: Vec<(String, Json)>,
     /// The motiongraph programs, `(id, spec)` — the graphs the face can play on
     /// top of its rig (e.g. Quori's "Speaks").
     pub programs: Vec<(String, Json)>,
@@ -88,6 +94,7 @@ impl Bundle {
 
         let mut graphs = Vec::new();
         let mut programs = Vec::new();
+        let mut standard_profiles = Vec::new();
         for entry in bundle
             .get("graphs")
             .and_then(Json::as_array)
@@ -103,11 +110,19 @@ impl Bundle {
                 continue;
             };
             // Motiongraphs are the playable programs, addressed by id; the base
-            // graphs (rig, pose-driver) compose by kind.
+            // graphs (rig, pose-driver) compose by kind. Embedded standard
+            // profiles are held apart, by profile id — they compose always and
+            // suppress their built-in (see `compose`), never selected by kind.
             if kind == "motiongraph" {
                 if let Some(id) = entry.get("id").and_then(Json::as_str) {
                     programs.push((id.to_string(), spec.clone()));
                 }
+            }
+            if kind == "standard-profile" {
+                let id = entry.get("id").and_then(Json::as_str).unwrap_or_default();
+                let profile_id = id.strip_prefix("standard::").unwrap_or(id);
+                standard_profiles.push((profile_id.to_string(), spec.clone()));
+                continue;
             }
             graphs.push((kind, spec.clone()));
         }
@@ -131,6 +146,7 @@ impl Bundle {
 
         Bundle {
             graphs,
+            standard_profiles,
             programs,
             active_program_id,
             neutral_inputs,
@@ -159,13 +175,19 @@ impl Bundle {
     }
 
     /// Compose the device's behavior: the base graphs whose kind is in `wanted`,
-    /// then the given standard `profiles` (e.g. [`ros4hri::ros4hri_source`]),
-    /// then the chosen program, then (when `with_animations`) the animation
-    /// source — each **last** wins over the earlier ones on any store path they
-    /// share (the web composes the same way, for the same last-writer-wins
-    /// reason). So a profile overrides the base rig's resting writes, a playing
-    /// program overrides the profile, and a playing clip overrides everything.
-    /// Returns the composed graph spec.
+    /// then the standard profiles, then the chosen program, then (when
+    /// `with_animations`) the animation source — each **last** wins over the
+    /// earlier ones on any store path they share (the web composes the same
+    /// way, for the same last-writer-wins reason). So a profile overrides the
+    /// base rig's resting writes, a playing program overrides the profile, and
+    /// a playing clip overrides everything. Returns the composed graph spec.
+    ///
+    /// Profiles come from two places: the face's own embedded copies
+    /// ([`standard_profiles`](Bundle::standard_profiles)), always composed,
+    /// and the built-in `profiles` the host passes (e.g.
+    /// [`ros4hri::ros4hri_source`]) — skipped for any id the face embeds,
+    /// because an embedded copy is the author's pinned override of the shipped
+    /// mapping.
     ///
     /// Pass `with_animations` when the device has the animation module loaded;
     /// [`animations_source`] dispatches to it, so composing it without the module
@@ -183,7 +205,19 @@ impl Bundle {
             .filter(|(kind, _)| wanted.contains(&kind.as_str()))
             .map(|(kind, spec)| (kind.clone(), spec.clone()))
             .collect();
-        sources.extend_from_slice(profiles);
+        // The face's own embedded profiles compose unconditionally, and each
+        // suppresses the built-in profile of the same id: an embedded copy is
+        // the author's pinned override of the shipped mapping.
+        for (id, spec) in &self.standard_profiles {
+            sources.push((format!("standard::{id}"), spec.clone()));
+        }
+        for (id, spec) in profiles {
+            if self.standard_profiles.iter().any(|(e, _)| e == id) {
+                log::info!("embedded standard profile {id} overrides the built-in");
+                continue;
+            }
+            sources.push((id.clone(), spec.clone()));
+        }
         if let Some((id, spec)) = self.program(select) {
             log::info!("autoplaying program {id}");
             sources.push((format!("program::{id}"), spec.clone()));
@@ -539,6 +573,66 @@ mod tests {
             .unwrap()
             .iter()
             .any(|n| n["id"].as_str().unwrap().starts_with("ros4hri::")));
+    }
+
+    /// `bundle_json()` with an embedded copy of a `ros4hri` standard profile:
+    /// one input node under the graph id VIZ-92 pins (`standard::ros4hri`).
+    fn bundle_json_with_embedded_ros4hri() -> Json {
+        let mut bundle = bundle_json();
+        bundle["graphs"].as_array_mut().unwrap().push(json!({
+            "id": "standard::ros4hri",
+            "kind": "standard-profile",
+            "spec": graph(
+                json!([{ "id": "mine", "type": "input",
+                         "params": { "path": "standard/ros4hri/expression/valence" } }]),
+                json!([]),
+            ),
+        }));
+        bundle
+    }
+
+    #[test]
+    fn bundle_reads_embedded_standard_profiles() {
+        let b = Bundle::from_bundle_json(&bundle_json_with_embedded_ros4hri());
+        // The entry lands under its bare profile id (`standard::` stripped)…
+        assert_eq!(b.standard_profiles.len(), 1);
+        assert_eq!(b.standard_profiles[0].0, "ros4hri");
+        // …and is held apart from the kind-selectable base graphs.
+        assert!(b.graphs.iter().all(|(kind, _)| kind != "standard-profile"));
+    }
+
+    #[test]
+    fn embedded_profile_composes_and_suppresses_its_built_in() {
+        let b = Bundle::from_bundle_json(&bundle_json_with_embedded_ros4hri());
+        let other_builtin = (
+            "gaze_only".to_string(),
+            graph(
+                json!([{ "id": "g", "type": "input",
+                         "params": { "path": "standard/gaze_only/target" } }]),
+                json!([]),
+            ),
+        );
+        let composed = b
+            .compose(
+                &["rig"],
+                &ProgramSelect::None,
+                false,
+                &[ros4hri::ros4hri_source("rig/f/"), other_builtin],
+            )
+            .unwrap();
+        let ids: Vec<&str> = composed["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|n| n["id"].as_str().unwrap())
+            .collect();
+        // The embedded copy composes under its stable graph id…
+        assert!(ids.contains(&"standard::ros4hri::mine"));
+        // …the built-in of the same id is not composed at all…
+        assert!(ids.iter().all(|id| !id.starts_with("ros4hri::")));
+        // …and built-ins the face does not embed are untouched (the
+        // suppression is per profile id, not a global kill switch).
+        assert!(ids.contains(&"gaze_only::g"));
     }
 
     #[test]

--- a/crates/vizij/src/device.rs
+++ b/crates/vizij/src/device.rs
@@ -568,6 +568,55 @@ mod tests {
         }
     }
 
+    /// A face that embeds its own modified `ros4hri` copy runs that copy
+    /// INSTEAD of the built-in — VIZ-92's precedence: an embedded profile is
+    /// the author's pinned override of the shipped mapping. The embedded graph
+    /// here maps valence verbatim onto the happy weight (no smoothing, no
+    /// blending, name ignored), which the built-in never produces.
+    #[test]
+    fn embedded_profile_wins_over_the_built_in() {
+        let bundle = vizij_arora_host::Bundle::from_bundle_json(&serde_json::json!({
+            "graphs": [{
+                "id": "standard::ros4hri",
+                "kind": "standard-profile",
+                "spec": {
+                    "nodes": [
+                        { "id": "v", "type": "input",
+                          "params": { "path": ros4hri::EXPRESSION_VALENCE_KEY, "value": 0.0 } },
+                        { "id": "o", "type": "output",
+                          "params": { "path": standard::expression_path("happy") } },
+                    ],
+                    "edges": [
+                        { "from": { "node_id": "v" }, "to": { "node_id": "o", "input": "in" } },
+                    ],
+                },
+            }]
+        }));
+        let spec = bundle
+            .compose(
+                &["rig"],
+                &vizij_arora_host::ProgramSelect::None,
+                false,
+                &[ros4hri_source("")],
+            )
+            .expect("compose the face with its embedded profile")
+            .to_string();
+        let mut arora = builder_for(&spec, RigHal::new(), BlackboardStore::new())
+            .expect("build the device over the composed face")
+            .build()
+            .expect("build arora");
+        // The built-in would one-hot "sad" (happy ≈ 0, smoothed); the embedded
+        // verbatim mapping ignores the name and rides valence straight through.
+        stage(&arora, ros4hri::EXPRESSION_NAME_KEY, text("sad"));
+        stage(&arora, ros4hri::EXPRESSION_VALENCE_KEY, float(0.8));
+        settle(&mut arora);
+        let happy = read_f32(&arora, &standard::expression_path("happy"));
+        assert!(
+            (happy - 0.8).abs() < 1e-6,
+            "embedded mapping must win verbatim, got happy={happy}"
+        );
+    }
+
     #[test]
     fn ros4hri_profile_rests_neutral() {
         let mut arora = ros4hri_device();

--- a/docs/ros4hri.md
+++ b/docs/ros4hri.md
@@ -81,6 +81,11 @@ performance overrides it (last-writer-wins).
 - **From a library** it is opt-in: `vizij_arora_host::ros4hri::ros4hri_source(rig_prefix)`
   returns the composable graph source, or embed it into a face GLB so it travels
   with the asset (see below).
+- **A face that embeds its own copy** (`standard::ros4hri`, see below) runs
+  that copy instead: the embedded profile is the author's pinned override of
+  the shipped mapping, always composed, and the built-in of the same id is not
+  composed for that face. Other profiles are unaffected — the suppression is
+  per profile id.
 
 ## Embedding and editing the profile
 


### PR DESCRIPTION
The runtime half of [VIZ-92](https://linear.app/semio-ai/issue/VIZ-92/profile-import-in-glb-when-authoring): a face GLB that **embeds** a standard profile (`kind: standard-profile`, id `standard::<profile>`, as `vizij-bundle add-standard` writes) now **runs that copy instead of the built-in** at deploy.

Until now the embedded entry was inert: not in the default graph-kind list, and the built-in composed regardless. Now:

- `Bundle` holds embedded profiles apart from the kind-selectable graphs (`standard_profiles: Vec<(profile id, spec)>`, `standard::` prefix stripped on parse).
- `Bundle::compose` always composes the embedded copies, and **skips the built-in profile of any id the face embeds** — an embedded copy is the author's pinned override of the shipped mapping. Suppression is per profile id; other built-ins are unaffected.
- Faces without embedded profiles behave exactly as before (all 14 existing device tests + 18 host tests untouched and green).

**Proof at the behavior level** — `embedded_profile_wins_over_the_built_in`: a face embedding a modified `ros4hri` copy (valence riding verbatim onto the happy weight, name ignored) is deployed with the built-in offered; staging `name="sad", valence=0.8` yields `happy == 0.8` exactly — the built-in would have one-hotted "sad" and smoothed.

Also ships a changeset: **@vizij/runtime minor (→2.2.0)** so `standardProfiles()` / `standardProfile(id, rigPrefix)` finally publish to npm — the API the authoring app's profile picker consumes ([VIZ-92]'s vizij-web half builds on it). Docs: `ros4hri.md` states the precedence rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)