### PR TITLE
feat(web): composeFace — deploy a face bundle's composition from JS (VIZ-93)

### DIFF
--- a/.changeset/runtime-compose-face.md
+++ b/.changeset/runtime-compose-face.md
@@ -1,0 +1,5 @@
+---
+"@vizij/runtime": minor
+---
+
+Add `composeFace(gltf, options?)`: the composed behavior graph of a face bundle — base graphs, embedded standard profiles (each suppressing the built-in of the same id), the built-in ROS4HRI profile unless opted out, and the selected program — exactly as the native `vizij` app deploys it. The returned spec feeds `startRuntime`/`Runtime.loadGraph`, so an exported GLB can be deployed and verified in JS without the native app (VIZ-93's autonomous verification loop).

--- a/crates/interop/vizij-arora-web/src/lib.rs
+++ b/crates/interop/vizij-arora-web/src/lib.rs
@@ -400,6 +400,74 @@ pub fn standard_profile(id: &str, rig_prefix: &str) -> Result<JsValue, JsValue> 
     }
 }
 
+/// The composed behavior graph of a face bundle — the composition the native
+/// `vizij` app deploys: the bundle's base graphs, its embedded standard
+/// profiles (each suppressing the built-in of the same id — an embedded copy
+/// is the author's pinned override), the built-in ROS4HRI profile unless
+/// opted out, then the selected program. The returned spec is ready for
+/// [`startRuntime`]'s graph slot or [`loadGraph`](VizijArora::load_graph),
+/// so an exported GLB can be deployed and verified without the native app.
+///
+/// `gltf_json` is the GLB's glTF JSON document (its `VIZIJ_bundle` read from
+/// the root or a node extension). `options_json`, all fields optional:
+/// - `graphs`: base kinds to compose — default `rig`, `pose-driver`, `pose`,
+///   `standard-adaptation` (the native default);
+/// - `program`: `"auto"` (default), `"none"`, or a program id;
+/// - `ros4hri`: offer the built-in ROS4HRI profile — default `true`;
+/// - `animations`: compose the animation source — default `false`, because it
+///   dispatches to the animation module and belongs only in a device that
+///   loads that module.
+#[wasm_bindgen(js_name = composeFace)]
+pub fn compose_face(gltf_json: &str, options_json: Option<String>) -> Result<JsValue, JsValue> {
+    use vizij_arora_host::{ros4hri, Bundle, ProgramSelect};
+
+    let gltf: serde_json::Value = serde_json::from_str(gltf_json)
+        .map_err(|e| JsValue::from_str(&format!("glTF JSON: {e}")))?;
+    let bundle = Bundle::from_gltf_json(&gltf)
+        .ok_or_else(|| JsValue::from_str("the document carries no VIZIJ_bundle"))?;
+
+    let options: serde_json::Value = match options_json.as_deref() {
+        None | Some("") => serde_json::Value::Null,
+        Some(json) => serde_json::from_str(json)
+            .map_err(|e| JsValue::from_str(&format!("options JSON: {e}")))?,
+    };
+    let wanted: Vec<String> = match options.get("graphs").and_then(serde_json::Value::as_array) {
+        Some(kinds) => kinds
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .map(str::to_string)
+            .collect(),
+        None => ["rig", "pose-driver", "pose", "standard-adaptation"]
+            .map(str::to_string)
+            .to_vec(),
+    };
+    let wanted: Vec<&str> = wanted.iter().map(String::as_str).collect();
+    let program = match options.get("program").and_then(serde_json::Value::as_str) {
+        None | Some("auto") => ProgramSelect::Auto,
+        Some("none") => ProgramSelect::None,
+        Some(id) => ProgramSelect::Id(id.to_string()),
+    };
+    let mut profiles = Vec::new();
+    if options
+        .get("ros4hri")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(true)
+    {
+        profiles.push(ros4hri::ros4hri_source(&bundle.rig_prefix()));
+    }
+    let with_animations = options
+        .get("animations")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+
+    let spec = bundle
+        .compose(&wanted, &program, with_animations, &profiles)
+        .map_err(|e| JsValue::from_str(&format!("compose: {e}")))?;
+    let json = serde_json::to_string(&spec)
+        .map_err(|e| JsValue::from_str(&format!("composed spec: {e}")))?;
+    js_sys::JSON::parse(&json)
+}
+
 /// The passthrough proof graph (`input` path → `output` path), as spec JSON.
 fn passthrough_json(input: &str, output: &str) -> String {
     serde_json::json!({

--- a/npm/@vizij/runtime/package.json
+++ b/npm/@vizij/runtime/package.json
@@ -36,7 +36,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsc -p tsconfig.json && node ../../../scripts/copy-wasm-pkg.mjs runtime",
-    "test": "pnpm run build && node tests/smoke.mjs && node tests/apply-graph-edits.mjs && node tests/animation-module.mjs",
+    "test": "pnpm run build && node tests/smoke.mjs && node tests/apply-graph-edits.mjs && node tests/animation-module.mjs && node tests/compose-face.mjs",
     "prepack": "pnpm run build",
     "prepublishOnly": "node -e \"const fs=require('fs');if(!fs.existsSync('pkg')){console.error('Missing pkg/. Run wasm-pack build.');process.exit(1);}\""
   },

--- a/npm/@vizij/runtime/src/index.ts
+++ b/npm/@vizij/runtime/src/index.ts
@@ -98,6 +98,7 @@ interface WasmBindings {
   };
   standardProfiles(): StandardProfile[];
   standardProfile(id: string, rig_prefix: string): object | null;
+  composeFace(gltf_json: string, options_json?: string): object;
 }
 
 const bindingCache: { current: WasmBindings | null } = { current: null };
@@ -379,6 +380,44 @@ export async function standardProfile(
 ): Promise<object | null> {
   await init(input);
   return bindingCache.current!.standardProfile(id, rigPrefix);
+}
+
+/** Options for {@link composeFace}; every field falls back to the native
+ * `vizij` app's deploy default. */
+export interface ComposeFaceOptions {
+  /** Base bundle graph kinds to compose. Default: `rig`, `pose-driver`,
+   * `pose`, `standard-adaptation`. */
+  graphs?: string[];
+  /** `"auto"` (the bundle's active program — default), `"none"`, or a
+   * program id. */
+  program?: string;
+  /** Offer the built-in ROS4HRI profile (an embedded copy still wins).
+   * Default `true`. */
+  ros4hri?: boolean;
+  /** Compose the animation source — only for a device that loads the
+   * animation module. Default `false`. */
+  animations?: boolean;
+}
+
+/**
+ * The composed behavior graph of a face bundle — the composition the native
+ * `vizij` app deploys: the bundle's base graphs, its embedded standard
+ * profiles (each suppressing the built-in of the same id — an embedded copy
+ * is the author's pinned override), the built-in ROS4HRI profile unless opted
+ * out, then the selected program. `gltf` is the GLB's glTF JSON document. The
+ * returned spec feeds {@link startRuntime} or {@link Runtime.loadGraph}, so an
+ * exported GLB can be deployed and verified without the native app.
+ */
+export async function composeFace(
+  gltf: object,
+  options?: ComposeFaceOptions,
+  input?: InitInput,
+): Promise<object> {
+  await init(input);
+  return bindingCache.current!.composeFace(
+    JSON.stringify(gltf),
+    options ? JSON.stringify(options) : undefined,
+  );
 }
 
 export { toValueJSON } from "@vizij/value-json";

--- a/npm/@vizij/runtime/tests/compose-face.mjs
+++ b/npm/@vizij/runtime/tests/compose-face.mjs
@@ -1,0 +1,73 @@
+// An exported face GLB deploys through composeFace: the bundle's embedded
+// (here: modified) standard profile composes and wins over the built-in —
+// the VIZ-92 precedence, proven on the wasm runtime anywhere Node runs.
+import assert from "node:assert/strict";
+import { composeFace, startRuntime } from "../dist/runtime/src/index.js";
+
+// A modified ros4hri copy: valence rides verbatim onto the happy weight (no
+// smoothing, no blending, name ignored) — a mapping the built-in never
+// produces.
+const modifiedProfile = {
+  nodes: [
+    {
+      id: "v",
+      type: "input",
+      params: { path: "standard/ros4hri/expression/valence", value: 0.0 },
+    },
+    {
+      id: "o",
+      type: "output",
+      params: { path: "standard/vizij/expression/happy" },
+    },
+  ],
+  edges: [{ from: { node_id: "v" }, to: { node_id: "o", input: "in" } }],
+};
+const gltf = {
+  nodes: [
+    {
+      extensions: {
+        VIZIJ_bundle: {
+          version: 1,
+          graphs: [
+            {
+              id: "standard::ros4hri",
+              kind: "standard-profile",
+              spec: modifiedProfile,
+            },
+          ],
+        },
+      },
+    },
+  ],
+};
+
+const spec = await composeFace(gltf, { program: "none" });
+const ids = spec.nodes.map((node) => node.id);
+assert.ok(
+  ids.some((id) => id.startsWith("standard::ros4hri::")),
+  "the embedded profile composes under its stable id",
+);
+assert.ok(
+  !ids.some((id) => id.startsWith("ros4hri::")),
+  "the built-in of the same id is suppressed",
+);
+
+// Deploy the composed face and drive it over the ROS4HRI keys.
+const runtime = await startRuntime();
+await runtime.loadGraph(spec);
+runtime.setValue("standard/ros4hri/expression/name", { text: "sad" });
+runtime.setValue("standard/ros4hri/expression/valence", { f32: 0.8 });
+for (let i = 0; i < 5; i += 1) {
+  runtime.step(16);
+}
+const happy = runtime.readValues(["standard/vizij/expression/happy"])[
+  "standard/vizij/expression/happy"
+];
+// The built-in would have one-hotted "sad" (happy ≈ 0, smoothed); the
+// embedded verbatim mapping ignores the name and rides valence through.
+assert.ok(
+  happy && Math.abs(happy.f32 - 0.8) < 1e-6,
+  `embedded mapping wins, got ${JSON.stringify(happy)}`,
+);
+
+console.log("compose-face: ok");


### PR DESCRIPTION
The enabling seam for [VIZ-93](https://linear.app/semio-ai/issue/VIZ-93/profile-edition)'s autonomous verification loop: `composeFace(gltf, options?)` on `@vizij/runtime` returns **the composition the native `vizij` app deploys** — base graph kinds (native defaults), embedded standard profiles with their built-in-suppressing precedence ([#89](https://github.com/vizij-ai/vizij-rs/pull/89)), the built-in ROS4HRI profile unless opted out, and the selected program — straight from a GLB's glTF JSON.

The returned spec feeds `startRuntime`/`Runtime.loadGraph`, so **an authored GLB can be deployed and verified in plain Node** (no native binary): the vizij-web e2e will export a GLB from the UI, compose it, run it on the wasm runtime, and assert the mapping.

Options (`graphs`, `program`, `ros4hri`, `animations`) all default to the native deploy semantics, except `animations: false` — the animation source dispatches to the animation module and belongs only in a device that loads it.

**Test** (`tests/compose-face.mjs`, wired into the package test chain): a bundle embedding a modified ros4hri copy (valence riding verbatim onto happy) composes under `standard::ros4hri`, the built-in is suppressed, and the composed graph running on the wasm runtime yields `happy == 0.8` with `name = "sad"` staged — the precedence proof on the wasm side. All four package tests green.

Changeset: `@vizij/runtime` minor (→ 2.3.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)