### PR TITLE
feat(skills): the look_at gaze skill as a spawnable graph fragment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "arora-bridge-ros2"
-version = "3.2.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1f687abdfbe5037b3758d336296950799f5c94a6f734a45309ad72bd268e0da"
+checksum = "cacc94fb7b58235535651cfd8100ff89ea9073a9cb8804124d41fa08173142ab"
 dependencies = [
  "arora-behavior-tree-types",
  "arora-bridge",
@@ -490,7 +490,7 @@ dependencies = [
  "async-trait",
  "futures",
  "log",
- "ros2-client-multi-rmw",
+ "ros2-client-multi-rmw 0.12.0",
  "serde",
  "serde_json",
  "tokio",
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "arora-msgs-ros2"
-version = "0.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6833cfbcd415843d6b5477fa32219ea2731a7c8dc1cc5d6270c64e49b1b23425"
+checksum = "a1833ed79fe0375bce005c8dc3f66d1a18433c050a72de34bd122e973a8083fc"
 dependencies = [
  "arora-types",
  "proc-macro2",
@@ -8621,6 +8621,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "ros2-client-multi-rmw"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c88980573e47852ffc5f152dbb1cc63ba7536f19f3da4dac9931f416bbba55"
+dependencies = [
+ "async-channel",
+ "bstr",
+ "bytes",
+ "cdr-encoding-size",
+ "chrono",
+ "clap 4.5.53",
+ "futures",
+ "itertools 0.14.0",
+ "lazy_static",
+ "libc",
+ "log",
+ "mio 0.6.23",
+ "mio-extras",
+ "nom 8.0.0",
+ "pin-utils",
+ "rustdds",
+ "serde",
+ "serde_repr",
+ "sha2",
+ "tracing",
+ "uuid",
+ "widestring",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9815,7 +9846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -10396,7 +10427,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.3",
  "static_assertions",
 ]
 
@@ -10663,7 +10694,7 @@ dependencies = [
  "image",
  "log",
  "rand 0.9.5",
- "ros2-client-multi-rmw",
+ "ros2-client-multi-rmw 0.11.0",
  "serde",
  "serde_json",
  "tokio",
@@ -10771,6 +10802,7 @@ dependencies = [
  "serde_json",
  "uuid",
  "vizij-api-core",
+ "vizij-arora-host",
  "vizij-graph-core",
 ]
 
@@ -10793,8 +10825,10 @@ name = "vizij-arora-host"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "arora-behavior",
  "log",
  "serde_json",
+ "uuid",
  "vizij-api-core",
 ]
 

--- a/crates/interop/vizij-arora-behavior/Cargo.toml
+++ b/crates/interop/vizij-arora-behavior/Cargo.toml
@@ -16,3 +16,6 @@ vizij-graph-core = { path = "../../node-graph/vizij-graph-core" }
 
 [dev-dependencies]
 arora-simple-data-store = "2"
+# The real skill fragments, so the graft path is proven against the shipped
+# look_at asset rather than a synthetic one.
+vizij-arora-host = { path = "../vizij-arora-host" }

--- a/crates/interop/vizij-arora-behavior/src/lib.rs
+++ b/crates/interop/vizij-arora-behavior/src/lib.rs
@@ -110,10 +110,50 @@ impl NodeFunctions for CallBridgeFunctions<'_> {
 /// graph and which status key it reports on. The run itself is graph
 /// structure — these are the coordinates for pruning and sweeping it.
 struct GraphRun {
-    run_node: String,
-    status_node: String,
-    args_node: String,
+    /// Every node the run grafted, removed together when it ends.
+    nodes: Vec<String>,
     status_key: Key,
+}
+
+/// A spawnable skill fragment: the implementation of a task-run function as
+/// graph content. When one is registered for a function
+/// ([`ProcessingGraph::set_task_fragment`]), SPAWN grafts a copy of it
+/// instead of the generic module-call wrapper — the behavior is data,
+/// introspectable and editable like the rest of the graph, not host code.
+///
+/// The fragment speaks a placeholder-path convention, rewritten to the run's
+/// key prefix at graft time: an `output` on `task/status` (required) reports
+/// the run's `Status`; `task/result` and `task/feedback` land on the handle's
+/// result and feedback keys; every other `task/<name>` input is a parameter,
+/// its spawn-time argument staged as the input's default and live-updatable
+/// through the run's update key of the same name.
+#[derive(Clone)]
+pub struct TaskFragment {
+    spec: GraphSpec,
+    /// The function's parameters: id → the placeholder input name each feeds.
+    parameters: HashMap<Uuid, String>,
+}
+
+impl TaskFragment {
+    /// Parse a fragment from its asset JSON and the `parameter id → input
+    /// name` map of the function it implements. Refused when the spec does
+    /// not parse or declares no `task/status` output — a fragment that
+    /// cannot report its lifecycle is not a task.
+    pub fn parse(json: &str, parameters: HashMap<Uuid, String>) -> Result<Self, String> {
+        let spec = parse_spec(json)?;
+        let reports_status = spec.nodes.iter().any(|node| {
+            matches!(node.kind, NodeType::Output)
+                && node
+                    .params
+                    .path
+                    .as_ref()
+                    .is_some_and(|path| path.to_string() == "task/status")
+        });
+        if !reports_status {
+            return Err("a task fragment must declare an output on task/status".to_string());
+        }
+        Ok(Self { spec, parameters })
+    }
 }
 
 /// A Vizij node graph as an Arora behavior interpreter.
@@ -141,6 +181,9 @@ pub struct ProcessingGraph {
     /// a grafted fragment in [`graph`](Self::graph); this index holds its
     /// pruning coordinates and status key.
     runs: HashMap<TaskId, GraphRun>,
+    /// Registered skill fragments by function id: what SPAWN grafts for these
+    /// functions instead of the generic module-call wrapper.
+    fragments: HashMap<Uuid, TaskFragment>,
     /// Halts requested since the last tick; applied by the next tick, which
     /// owns the store.
     pending_halts: Vec<TaskId>,
@@ -218,8 +261,16 @@ impl ProcessingGraph {
             inputs: Vec::new(),
             function_modules: HashMap::new(),
             runs: HashMap::new(),
+            fragments: HashMap::new(),
             pending_halts: Vec::new(),
         })
+    }
+
+    /// Register the skill fragment SPAWN grafts for `function` — asset
+    /// content implementing the method, in place of the generic module-call
+    /// wrapper.
+    pub fn set_task_fragment(&mut self, function: Uuid, fragment: TaskFragment) {
+        self.fragments.insert(function, fragment);
     }
 
     /// The retained shared-model graph — the editable source of truth,
@@ -234,11 +285,7 @@ impl ProcessingGraph {
     /// removes structure, not state.
     fn prune_run(&mut self, run: &GraphRun) -> Result<(), BehaviorError> {
         let diff = graph_codec::GraphSpecDiff {
-            remove_nodes: vec![
-                run.run_node.clone(),
-                run.status_node.clone(),
-                run.args_node.clone(),
-            ],
+            remove_nodes: run.nodes.clone(),
             ..graph_codec::GraphSpecDiff::default()
         };
         let diff = graph_codec::spec_diff_to_graph_diff(&diff)
@@ -389,6 +436,176 @@ impl ProcessingGraph {
     }
 }
 
+/// The generic run graft: an input on the run's update key (defaulting to
+/// the spawn-time argument bundle) feeding a [`NodeType::TaskRun`] node that
+/// calls the module function each tick, over an [`NodeType::Output`] on the
+/// run's status key. Returns the diff, the grafted node ids, and the run's
+/// update keys.
+fn wrapper_graft(
+    task: TaskId,
+    prefix: &str,
+    call: &Call,
+) -> Result<(graph_codec::GraphSpecDiff, Vec<String>, Vec<Key>), BehaviorError> {
+    let status_path = TypedPath::parse(&format!("{prefix}/status")).map_err(|e| BehaviorError {
+        message: format!("the status key does not parse as a path: {e}"),
+    })?;
+    let update_path = TypedPath::parse(&format!("{prefix}/update")).map_err(|e| BehaviorError {
+        message: format!("the update key does not parse as a path: {e}"),
+    })?;
+
+    let run_node = format!("task/{}/run", task.0);
+    let status_node = format!("task/{}/status", task.0);
+    let args_node = format!("task/{}/args", task.0);
+    // The spawn-time argument bundle: a structure of the call's args, the
+    // default the args input serves until a live update lands on the run's
+    // update key.
+    let args_bundle = Value::Structure(Structure {
+        id: call.id,
+        fields: call.args.clone(),
+    });
+    let diff = graph_codec::GraphSpecDiff {
+        upsert_nodes: vec![
+            // The run's args source: an input on the update key, defaulting
+            // to the spawn-time bundle. A caller (the ROS bridge on a live
+            // goal) writes new args to the update key; the next tick stages
+            // them here and the run picks them up — no graph edit per update.
+            NodeSpec {
+                id: args_node.clone(),
+                kind: NodeType::Input,
+                params: NodeParams {
+                    path: Some(update_path),
+                    value: Some(args_bundle),
+                    ..NodeParams::default()
+                },
+                output_shapes: Default::default(),
+                input_defaults: Default::default(),
+            },
+            NodeSpec {
+                id: run_node.clone(),
+                kind: NodeType::TaskRun,
+                params: NodeParams {
+                    module: call.module_id,
+                    function: Some(call.id),
+                    ..NodeParams::default()
+                },
+                output_shapes: Default::default(),
+                input_defaults: Default::default(),
+            },
+            NodeSpec {
+                id: status_node.clone(),
+                kind: NodeType::Output,
+                params: NodeParams {
+                    path: Some(status_path),
+                    ..NodeParams::default()
+                },
+                output_shapes: Default::default(),
+                input_defaults: Default::default(),
+            },
+        ],
+        upsert_edges: vec![
+            EdgeSpec {
+                from: EdgeOutputEndpoint {
+                    node_id: args_node.clone(),
+                    output: "out".to_string(),
+                },
+                to: EdgeInputEndpoint {
+                    node_id: run_node.clone(),
+                    input: "args".to_string(),
+                },
+                selector: None,
+            },
+            EdgeSpec {
+                from: EdgeOutputEndpoint {
+                    node_id: run_node.clone(),
+                    output: "out".to_string(),
+                },
+                to: EdgeInputEndpoint {
+                    node_id: status_node.clone(),
+                    input: "in".to_string(),
+                },
+                selector: None,
+            },
+        ],
+        ..graph_codec::GraphSpecDiff::default()
+    };
+    Ok((
+        diff,
+        vec![args_node, run_node, status_node],
+        vec![Key::from(format!("{prefix}/update"))],
+    ))
+}
+
+/// The skill graft: a copy of the registered [`TaskFragment`], node ids
+/// namespaced under `task/<run id>/`, placeholder `task/…` paths rewritten to
+/// the run's key prefix, and each parameter input's default replaced by the
+/// spawn-time argument it names. Returns the diff, the grafted node ids, and
+/// the run's per-parameter update keys.
+fn fragment_graft(
+    fragment: &TaskFragment,
+    task: TaskId,
+    prefix: &str,
+    call: &Call,
+) -> Result<(graph_codec::GraphSpecDiff, Vec<String>, Vec<Key>), BehaviorError> {
+    // The spawn-time arguments by the placeholder input name each feeds.
+    let mut arguments: HashMap<&str, &Value> = HashMap::new();
+    for argument in &call.args {
+        if let Some(name) = fragment.parameters.get(&argument.id) {
+            arguments.insert(name.as_str(), argument.value.as_ref());
+        }
+    }
+    let grafted_id = |id: &str| format!("task/{}/{}", task.0, id);
+
+    let mut upsert_nodes = Vec::with_capacity(fragment.spec.nodes.len());
+    for node in &fragment.spec.nodes {
+        let mut node = node.clone();
+        if let Some(path) = &node.params.path {
+            let path = path.to_string();
+            if let Some(placeholder) = path.strip_prefix("task/") {
+                let run_path = format!("{prefix}/{placeholder}");
+                node.params.path =
+                    Some(TypedPath::parse(&run_path).map_err(|e| BehaviorError {
+                        message: format!("'{run_path}' does not parse as a path: {e}"),
+                    })?);
+                if matches!(node.kind, NodeType::Input) {
+                    if let Some(value) = arguments.get(placeholder) {
+                        node.params.value = Some((*value).clone());
+                    }
+                }
+            }
+        }
+        node.id = grafted_id(&node.id);
+        upsert_nodes.push(node);
+    }
+    let upsert_edges = fragment
+        .spec
+        .edges
+        .iter()
+        .map(|edge| {
+            let mut edge = edge.clone();
+            edge.from.node_id = grafted_id(&edge.from.node_id);
+            edge.to.node_id = grafted_id(&edge.to.node_id);
+            edge
+        })
+        .collect();
+
+    let nodes: Vec<String> = upsert_nodes.iter().map(|node| node.id.clone()).collect();
+    let mut names: Vec<&String> = fragment.parameters.values().collect();
+    names.sort();
+    let update = names
+        .into_iter()
+        .map(|name| Key::from(format!("{prefix}/{name}")))
+        .collect();
+    Ok((
+        graph_codec::GraphSpecDiff {
+            upsert_nodes,
+            upsert_edges,
+            ..graph_codec::GraphSpecDiff::default()
+        },
+        nodes,
+        update,
+    ))
+}
+
 impl BehaviorInterpreter for ProcessingGraph {
     fn tick(&mut self, ctx: &mut BehaviorContext) -> Result<BehaviorStatus, BehaviorError> {
         let dt = built_in_dt_seconds(ctx.store);
@@ -430,13 +647,15 @@ impl BehaviorInterpreter for ProcessingGraph {
     }
 
     /// Spawn `call` as a concurrent task run — the interpreter module's SPAWN
-    /// entry point. The run grafts into the running graph as a two-node
-    /// fragment: a [`NodeType::TaskRun`] node carrying the whole call in its
-    /// params (module, function, args bundle) over an [`NodeType::Output`] on
-    /// the run's status key. The graph's ordinary evaluation then advances the
-    /// run once per tick and the Output convention publishes its `Status` —
-    /// the run is structure, introspectable through [`graph`](Self::graph)
-    /// like everything else, and pruned when it ends.
+    /// entry point. The run grafts into the running graph: a registered
+    /// [`TaskFragment`] verbatim (its placeholder paths rewritten to the
+    /// run's key prefix, its parameter inputs defaulted from the spawn-time
+    /// arguments), or the generic two-node wrapper — a [`NodeType::TaskRun`]
+    /// node carrying the whole call over an [`NodeType::Output`] on the run's
+    /// status key. The graph's ordinary evaluation then advances the run once
+    /// per tick and the Output convention publishes its `Status` — the run is
+    /// structure, introspectable through [`graph`](Self::graph) like
+    /// everything else, and pruned when it ends.
     fn spawn(&mut self, call: Call, policy: RunPolicy) -> Result<TaskHandle, BehaviorError> {
         // v1 runs every task concurrently — the graph's ordinary semantics
         // (overlapping actuation writes are last-write-wins). Richer
@@ -450,99 +669,17 @@ impl BehaviorInterpreter for ProcessingGraph {
             .unwrap_or_else(|| "none".to_string());
         let prefix = format!("arora/tasks/{module}/{}/{}", call.id, task.0);
         let status_key = Key::from(format!("{prefix}/status"));
-        let status_path =
-            TypedPath::parse(&format!("{prefix}/status")).map_err(|e| BehaviorError {
-                message: format!("the status key does not parse as a path: {e}"),
-            })?;
 
-        let update_path =
-            TypedPath::parse(&format!("{prefix}/update")).map_err(|e| BehaviorError {
-                message: format!("the update key does not parse as a path: {e}"),
-            })?;
-
-        let run_node = format!("task/{}/run", task.0);
-        let status_node = format!("task/{}/status", task.0);
-        let args_node = format!("task/{}/args", task.0);
-        // The spawn-time argument bundle: a structure of the call's args, the
-        // default the args input serves until a live update lands on the run's
-        // update key.
-        let args_bundle = Value::Structure(Structure {
-            id: call.id,
-            fields: call.args.clone(),
-        });
-        let diff = graph_codec::GraphSpecDiff {
-            upsert_nodes: vec![
-                // The run's args source: an input on the update key, defaulting
-                // to the spawn-time bundle. A caller (the ROS bridge on a live
-                // goal) writes new args to the update key; the next tick stages
-                // them here and the run picks them up — no graph edit per update.
-                NodeSpec {
-                    id: args_node.clone(),
-                    kind: NodeType::Input,
-                    params: NodeParams {
-                        path: Some(update_path),
-                        value: Some(args_bundle),
-                        ..NodeParams::default()
-                    },
-                    output_shapes: Default::default(),
-                    input_defaults: Default::default(),
-                },
-                NodeSpec {
-                    id: run_node.clone(),
-                    kind: NodeType::TaskRun,
-                    params: NodeParams {
-                        module: call.module_id,
-                        function: Some(call.id),
-                        ..NodeParams::default()
-                    },
-                    output_shapes: Default::default(),
-                    input_defaults: Default::default(),
-                },
-                NodeSpec {
-                    id: status_node.clone(),
-                    kind: NodeType::Output,
-                    params: NodeParams {
-                        path: Some(status_path),
-                        ..NodeParams::default()
-                    },
-                    output_shapes: Default::default(),
-                    input_defaults: Default::default(),
-                },
-            ],
-            upsert_edges: vec![
-                EdgeSpec {
-                    from: EdgeOutputEndpoint {
-                        node_id: args_node.clone(),
-                        output: "out".to_string(),
-                    },
-                    to: EdgeInputEndpoint {
-                        node_id: run_node.clone(),
-                        input: "args".to_string(),
-                    },
-                    selector: None,
-                },
-                EdgeSpec {
-                    from: EdgeOutputEndpoint {
-                        node_id: run_node.clone(),
-                        output: "out".to_string(),
-                    },
-                    to: EdgeInputEndpoint {
-                        node_id: status_node.clone(),
-                        input: "in".to_string(),
-                    },
-                    selector: None,
-                },
-            ],
-            ..graph_codec::GraphSpecDiff::default()
+        let (diff, nodes, update) = match self.fragments.get(&call.id) {
+            Some(fragment) => fragment_graft(fragment, task, &prefix, &call)?,
+            None => wrapper_graft(task, &prefix, &call)?,
         };
         let diff = graph_codec::spec_diff_to_graph_diff(&diff)
             .map_err(|message| BehaviorError { message })?;
         self.runs.insert(
             task,
             GraphRun {
-                run_node,
-                status_node,
-                args_node,
+                nodes,
                 status_key: status_key.clone(),
             },
         );
@@ -562,7 +699,7 @@ impl BehaviorInterpreter for ProcessingGraph {
             status: status_key,
             feedback: vec![Key::from(format!("{prefix}/feedback"))],
             result: vec![Key::from(format!("{prefix}/result"))],
-            update: vec![Key::from(format!("{prefix}/update"))],
+            update,
         })
     }
 
@@ -1089,5 +1226,120 @@ mod tests {
             bridge.calls.last().expect("a call").args[0].value.as_ref(),
             &float(0.9),
         );
+    }
+
+    /// The skill path: a registered fragment — the real look_at asset from
+    /// `vizij-arora-host` — implements the spawned run as graph content, no
+    /// module call anywhere. Tracking writes the gaze surface, steers on a
+    /// live parameter update, and runs until halted; a glance settles to
+    /// Success; an unsupported policy fails with the `std_skills` ENOTSUP
+    /// errno on the result key.
+    #[test]
+    fn a_registered_fragment_implements_the_spawned_run() {
+        use arora_types::gen_uuid_from_str;
+        use vizij_arora_host::skills;
+
+        let parameters: HashMap<Uuid, String> = skills::LOOK_AT_PARAMS
+            .iter()
+            .map(|name| (gen_uuid_from_str(name), name.to_string()))
+            .collect();
+        let fragment =
+            TaskFragment::parse(skills::LOOK_AT_JSON, parameters).expect("the asset parses");
+
+        let store = SimpleDataStore::new();
+        let mut graph =
+            ProcessingGraph::from_spec(passthrough("sensor/x", "actuator/y")).expect("from_spec");
+        graph.set_task_fragment(gen_uuid_from_str("look_at"), fragment);
+        let mut bridge = NoopBridge;
+        store
+            .write(StateChange::set("sensor/x", float(0.75)))
+            .unwrap();
+
+        let look_at = |policy: &str, target: [f32; 3], frame: &str| Call {
+            module_id: Some(gen_uuid_from_str("gaze-module")),
+            id: gen_uuid_from_str("look_at"),
+            args: vec![
+                StructureField {
+                    id: gen_uuid_from_str("policy"),
+                    value: Box::new(Value::String(policy.to_string())),
+                },
+                StructureField {
+                    id: gen_uuid_from_str("target"),
+                    value: Box::new(Value::ArrayF32(target.to_vec())),
+                },
+                StructureField {
+                    id: gen_uuid_from_str("frame"),
+                    value: Box::new(Value::String(frame.to_string())),
+                },
+            ],
+        };
+
+        // Tracking: the goal lands on the gaze surface and the run stays
+        // Running — the halt is the exit. The handle's update keys are per
+        // parameter.
+        let handle = graph
+            .spawn(
+                look_at("", [1.0, 2.0, 3.0], "sellion_link"),
+                RunPolicy::Concurrent,
+            )
+            .expect("spawn");
+        let target_key = handle
+            .update
+            .iter()
+            .find(|key| key.path.ends_with("/target"))
+            .expect("a target update key")
+            .clone();
+        graph.tick_store(&store, &mut bridge, 0.05).expect("tick");
+        assert_eq!(
+            read(&store, "standard/ros4hri/gaze/target"),
+            Some(Value::ArrayF32(vec![1.0, 2.0, 3.0])),
+        );
+        assert_eq!(
+            read(&store, "standard/ros4hri/gaze/frame"),
+            Some(Value::String("sellion_link".to_string())),
+        );
+        assert_eq!(read_key(&store, &handle.status), Some(task::running()));
+
+        // A live update on the parameter key steers the running fragment.
+        let mut change = StateChange::new();
+        change
+            .set
+            .insert(target_key, Some(Value::ArrayF32(vec![4.0, 5.0, 6.0])));
+        store.write(change).unwrap();
+        graph.tick_store(&store, &mut bridge, 0.05).expect("tick");
+        assert_eq!(
+            read(&store, "standard/ros4hri/gaze/target"),
+            Some(Value::ArrayF32(vec![4.0, 5.0, 6.0])),
+        );
+
+        // The halt ends the run as Failure (the cancel semantics) and prunes
+        // the whole grafted fragment.
+        graph.halt(handle.id).expect("halt");
+        graph.tick_store(&store, &mut bridge, 0.05).expect("tick");
+        assert_eq!(read_key(&store, &handle.status), Some(task::failure()));
+
+        // A glance holds its fixation, then succeeds on its own.
+        let handle = graph
+            .spawn(
+                look_at("glance", [0.5, 0.0, 0.5], ""),
+                RunPolicy::Concurrent,
+            )
+            .expect("spawn");
+        for _ in 0..6 {
+            graph.tick_store(&store, &mut bridge, 0.2).expect("tick");
+        }
+        assert_eq!(read_key(&store, &handle.status), Some(task::success()));
+
+        // An unsupported policy fails with the ENOTSUP errno on the result
+        // key — the value the ROS action plane answers verbatim.
+        let handle = graph
+            .spawn(
+                look_at("social", [0.0, 0.0, 0.0], ""),
+                RunPolicy::Concurrent,
+            )
+            .expect("spawn");
+        graph.tick_store(&store, &mut bridge, 0.05).expect("tick");
+        assert_eq!(read_key(&store, &handle.status), Some(task::failure()));
+        assert_eq!(read_key(&store, &handle.result[0]), Some(Value::U8(134)));
     }
 }

--- a/crates/interop/vizij-arora-host/Cargo.toml
+++ b/crates/interop/vizij-arora-host/Cargo.toml
@@ -10,3 +10,7 @@ vizij-api-core = { path = "../../api/vizij-api-core" }
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 log = "0.4"
+# The behavior `Status` ids the skill fragments' status constants carry —
+# from the crate declaring the enumeration, so the encoding cannot drift.
+arora-behavior = "8"
+uuid = "1"

--- a/crates/interop/vizij-arora-host/skills/look_at.json
+++ b/crates/interop/vizij-arora-host/skills/look_at.json
@@ -1,0 +1,551 @@
+{
+  "nodes": [
+    {
+      "id": "in-policy",
+      "type": "input",
+      "params": {
+        "path": "task/policy",
+        "value": ""
+      }
+    },
+    {
+      "id": "in-target",
+      "type": "input",
+      "params": {
+        "path": "task/target",
+        "value": {
+          "x": 10.0,
+          "y": 0.0,
+          "z": 0.0
+        }
+      }
+    },
+    {
+      "id": "in-frame",
+      "type": "input",
+      "params": {
+        "path": "task/frame",
+        "value": ""
+      }
+    },
+    {
+      "id": "rest-target",
+      "type": "constant",
+      "params": {
+        "value": {
+          "x": 10.0,
+          "y": 0.0,
+          "z": 0.0
+        }
+      }
+    },
+    {
+      "id": "face-frame",
+      "type": "constant",
+      "params": {
+        "value": ""
+      }
+    },
+    {
+      "id": "n1",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "reset"
+        ]
+      }
+    },
+    {
+      "id": "o2",
+      "type": "output",
+      "params": {
+        "path": "standard/ros4hri/gaze/target"
+      }
+    },
+    {
+      "id": "n3",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "reset"
+        ]
+      }
+    },
+    {
+      "id": "o4",
+      "type": "output",
+      "params": {
+        "path": "standard/ros4hri/gaze/frame"
+      }
+    },
+    {
+      "id": "clock",
+      "type": "time",
+      "params": {}
+    },
+    {
+      "id": "in-start",
+      "type": "input",
+      "params": {
+        "path": "task/start",
+        "value": 0.0
+      }
+    },
+    {
+      "id": "c5",
+      "type": "constant",
+      "params": {
+        "value": 0.0
+      }
+    },
+    {
+      "id": "n6",
+      "type": "greaterthan",
+      "params": {}
+    },
+    {
+      "id": "n7",
+      "type": "if",
+      "params": {}
+    },
+    {
+      "id": "o8",
+      "type": "output",
+      "params": {
+        "path": "task/start"
+      }
+    },
+    {
+      "id": "n9",
+      "type": "subtract",
+      "params": {}
+    },
+    {
+      "id": "c10",
+      "type": "constant",
+      "params": {
+        "value": 0.6
+      }
+    },
+    {
+      "id": "n11",
+      "type": "greaterthan",
+      "params": {}
+    },
+    {
+      "id": "st-running",
+      "type": "constant",
+      "params": {
+        "value": {
+          "enum": {
+            "id": "325a5767-e344-4532-860e-0749bcf2e428",
+            "variant_id": "acd79ec6-0c44-401a-82f8-5da5422d3eec",
+            "value": "unit"
+          }
+        }
+      }
+    },
+    {
+      "id": "st-success",
+      "type": "constant",
+      "params": {
+        "value": {
+          "enum": {
+            "id": "325a5767-e344-4532-860e-0749bcf2e428",
+            "variant_id": "766e9e9a-446d-4e46-83e6-14b7ca101169",
+            "value": "unit"
+          }
+        }
+      }
+    },
+    {
+      "id": "st-failure",
+      "type": "constant",
+      "params": {
+        "value": {
+          "enum": {
+            "id": "325a5767-e344-4532-860e-0749bcf2e428",
+            "variant_id": "2468f46c-bb60-425c-9a4d-9ad326ccc7e2",
+            "value": "unit"
+          }
+        }
+      }
+    },
+    {
+      "id": "n12",
+      "type": "if",
+      "params": {}
+    },
+    {
+      "id": "n13",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "",
+          "track",
+          "glance",
+          "reset"
+        ]
+      }
+    },
+    {
+      "id": "o14",
+      "type": "output",
+      "params": {
+        "path": "task/status"
+      }
+    },
+    {
+      "id": "no-errno",
+      "type": "constant",
+      "params": {
+        "value": ""
+      }
+    },
+    {
+      "id": "errno-enotsup",
+      "type": "constant",
+      "params": {
+        "value": {
+          "u8": 134
+        }
+      }
+    },
+    {
+      "id": "n15",
+      "type": "case",
+      "params": {
+        "case_labels": [
+          "",
+          "track",
+          "glance",
+          "reset"
+        ]
+      }
+    },
+    {
+      "id": "o16",
+      "type": "output",
+      "params": {
+        "path": "task/result"
+      }
+    }
+  ],
+  "edges": [
+    {
+      "from": {
+        "node_id": "in-policy"
+      },
+      "to": {
+        "node_id": "n1",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "rest-target"
+      },
+      "to": {
+        "node_id": "n1",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-target"
+      },
+      "to": {
+        "node_id": "n1",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n1"
+      },
+      "to": {
+        "node_id": "o2",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-policy"
+      },
+      "to": {
+        "node_id": "n3",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "face-frame"
+      },
+      "to": {
+        "node_id": "n3",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-frame"
+      },
+      "to": {
+        "node_id": "n3",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n3"
+      },
+      "to": {
+        "node_id": "o4",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-start"
+      },
+      "to": {
+        "node_id": "n6",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c5"
+      },
+      "to": {
+        "node_id": "n6",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n6"
+      },
+      "to": {
+        "node_id": "n7",
+        "input": "cond"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-start"
+      },
+      "to": {
+        "node_id": "n7",
+        "input": "then"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clock"
+      },
+      "to": {
+        "node_id": "n7",
+        "input": "else"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n7"
+      },
+      "to": {
+        "node_id": "o8",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "clock"
+      },
+      "to": {
+        "node_id": "n9",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n7"
+      },
+      "to": {
+        "node_id": "n9",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n9"
+      },
+      "to": {
+        "node_id": "n11",
+        "input": "lhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "c10"
+      },
+      "to": {
+        "node_id": "n11",
+        "input": "rhs"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n11"
+      },
+      "to": {
+        "node_id": "n12",
+        "input": "cond"
+      }
+    },
+    {
+      "from": {
+        "node_id": "st-success"
+      },
+      "to": {
+        "node_id": "n12",
+        "input": "then"
+      }
+    },
+    {
+      "from": {
+        "node_id": "st-running"
+      },
+      "to": {
+        "node_id": "n12",
+        "input": "else"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-policy"
+      },
+      "to": {
+        "node_id": "n13",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "st-running"
+      },
+      "to": {
+        "node_id": "n13",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "st-running"
+      },
+      "to": {
+        "node_id": "n13",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n12"
+      },
+      "to": {
+        "node_id": "n13",
+        "input": "operand_2"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n12"
+      },
+      "to": {
+        "node_id": "n13",
+        "input": "operand_3"
+      }
+    },
+    {
+      "from": {
+        "node_id": "st-failure"
+      },
+      "to": {
+        "node_id": "n13",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n13"
+      },
+      "to": {
+        "node_id": "o14",
+        "input": "in"
+      }
+    },
+    {
+      "from": {
+        "node_id": "in-policy"
+      },
+      "to": {
+        "node_id": "n15",
+        "input": "selector"
+      }
+    },
+    {
+      "from": {
+        "node_id": "no-errno"
+      },
+      "to": {
+        "node_id": "n15",
+        "input": "operand_0"
+      }
+    },
+    {
+      "from": {
+        "node_id": "no-errno"
+      },
+      "to": {
+        "node_id": "n15",
+        "input": "operand_1"
+      }
+    },
+    {
+      "from": {
+        "node_id": "no-errno"
+      },
+      "to": {
+        "node_id": "n15",
+        "input": "operand_2"
+      }
+    },
+    {
+      "from": {
+        "node_id": "no-errno"
+      },
+      "to": {
+        "node_id": "n15",
+        "input": "operand_3"
+      }
+    },
+    {
+      "from": {
+        "node_id": "errno-enotsup"
+      },
+      "to": {
+        "node_id": "n15",
+        "input": "default"
+      }
+    },
+    {
+      "from": {
+        "node_id": "n15"
+      },
+      "to": {
+        "node_id": "o16",
+        "input": "in"
+      }
+    }
+  ]
+}

--- a/crates/interop/vizij-arora-host/src/graph_builder.rs
+++ b/crates/interop/vizij-arora-host/src/graph_builder.rs
@@ -1,0 +1,86 @@
+//! A small JSON graph-spec builder shared by the crate's generated assets
+//! (the ROS4HRI profile, the skill fragments): node/edge lists in the exact
+//! form `normalize_graph_spec_value` accepts, with scratch ids for the
+//! anonymous math in between.
+
+use serde_json::{json, Value as Json};
+
+/// Incrementally builds a graph spec's node/edge lists.
+pub(crate) struct GraphBuilder {
+    pub(crate) nodes: Vec<Json>,
+    pub(crate) edges: Vec<Json>,
+    scratch: u32,
+}
+
+impl GraphBuilder {
+    pub(crate) fn new() -> Self {
+        Self {
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            scratch: 0,
+        }
+    }
+
+    pub(crate) fn node(&mut self, id: &str, ty: &str, params: Json) -> String {
+        self.nodes
+            .push(json!({ "id": id, "type": ty, "params": params }));
+        id.to_string()
+    }
+
+    pub(crate) fn edge(&mut self, from: &str, to: &str, input: &str) {
+        self.edges
+            .push(json!({ "from": { "node_id": from }, "to": { "node_id": to, "input": input } }));
+    }
+
+    /// A fresh constant node holding `value`.
+    pub(crate) fn constant(&mut self, value: f64) -> String {
+        self.scratch += 1;
+        let id = format!("c{}", self.scratch);
+        self.node(&id, "constant", json!({ "value": value }))
+    }
+
+    /// A scratch node wired from `inputs` (port name → source node).
+    pub(crate) fn op(&mut self, ty: &str, params: Json, inputs: &[(&str, &str)]) -> String {
+        self.scratch += 1;
+        let id = format!("n{}", self.scratch);
+        self.node(&id, ty, params);
+        for (port, from) in inputs {
+            self.edge(from, &id, port);
+        }
+        id
+    }
+
+    pub(crate) fn sub(&mut self, lhs: &str, rhs: &str) -> String {
+        self.op("subtract", json!({}), &[("lhs", lhs), ("rhs", rhs)])
+    }
+    pub(crate) fn mul(&mut self, a: &str, b: &str) -> String {
+        self.op("multiply", json!({}), &[("operand_0", a), ("operand_1", b)])
+    }
+    pub(crate) fn div(&mut self, lhs: &str, rhs: &str) -> String {
+        self.op("divide", json!({}), &[("lhs", lhs), ("rhs", rhs)])
+    }
+    pub(crate) fn add2(&mut self, a: &str, b: &str) -> String {
+        self.op("add", json!({}), &[("operand_0", a), ("operand_1", b)])
+    }
+    pub(crate) fn max2(&mut self, a: &str, b: &str) -> String {
+        self.op("max", json!({}), &[("operand_0", a), ("operand_1", b)])
+    }
+
+    /// Exponential smoothing with the given half-life (seconds).
+    pub(crate) fn damp(&mut self, from: &str, half_life: f64) -> String {
+        self.op("damp", json!({ "half_life": half_life }), &[("in", from)])
+    }
+
+    /// An input node reading `path`, defaulting to `value` until staged.
+    pub(crate) fn input(&mut self, id: &str, path: &str, value: Json) -> String {
+        self.node(id, "input", json!({ "path": path, "value": value }))
+    }
+
+    /// An output node writing `path`.
+    pub(crate) fn output(&mut self, from: &str, path: String) {
+        self.scratch += 1;
+        let id = format!("o{}", self.scratch);
+        self.node(&id, "output", json!({ "path": path }));
+        self.edge(from, &id, "in");
+    }
+}

--- a/crates/interop/vizij-arora-host/src/lib.rs
+++ b/crates/interop/vizij-arora-host/src/lib.rs
@@ -16,8 +16,10 @@
 //! This is only the logic both hosts would otherwise write twice, once in Rust
 //! and once in TypeScript.
 
+mod graph_builder;
 pub mod profiles;
 pub mod ros4hri;
+pub mod skills;
 pub mod standard;
 
 use std::collections::HashMap;

--- a/crates/interop/vizij-arora-host/src/ros4hri.rs
+++ b/crates/interop/vizij-arora-host/src/ros4hri.rs
@@ -32,6 +32,7 @@
 
 use serde_json::{json, Value as Json};
 
+use crate::graph_builder::GraphBuilder;
 use crate::standard::{self, EXPRESSION_NAMES, FACE_CONTROLS, VISEME_SHAPES};
 
 /// Source id of the composed profile (node ids get `ros4hri::` prefixes).
@@ -45,6 +46,7 @@ pub const EXPRESSION_NAME_KEY: &str = "standard/ros4hri/expression/name";
 pub const EXPRESSION_VALENCE_KEY: &str = "standard/ros4hri/expression/valence";
 pub const EXPRESSION_AROUSAL_KEY: &str = "standard/ros4hri/expression/arousal";
 pub const GAZE_TARGET_KEY: &str = "standard/ros4hri/gaze/target";
+pub const GAZE_FRAME_KEY: &str = "standard/ros4hri/gaze/frame";
 
 /// The key carrying a FACS action-unit intensity, [0, 1].
 pub fn au_key(code: u8) -> String {
@@ -100,106 +102,26 @@ const HALF_IOD: f64 = 0.03;
 /// The incumbent's gaze normalization: ±0.78 rad maps to ±1.
 const GAZE_RANGE_RAD: f64 = 0.78;
 
-/// Incrementally builds the profile's node/edge lists.
-struct GraphBuilder {
-    nodes: Vec<Json>,
-    edges: Vec<Json>,
-    scratch: u32,
-}
-
-impl GraphBuilder {
-    fn new() -> Self {
-        Self {
-            nodes: Vec::new(),
-            edges: Vec::new(),
-            scratch: 0,
-        }
-    }
-
-    fn node(&mut self, id: &str, ty: &str, params: Json) -> String {
-        self.nodes
-            .push(json!({ "id": id, "type": ty, "params": params }));
-        id.to_string()
-    }
-
-    fn edge(&mut self, from: &str, to: &str, input: &str) {
-        self.edges
-            .push(json!({ "from": { "node_id": from }, "to": { "node_id": to, "input": input } }));
-    }
-
-    /// A fresh constant node holding `value`.
-    fn constant(&mut self, value: f64) -> String {
-        self.scratch += 1;
-        let id = format!("c{}", self.scratch);
-        self.node(&id, "constant", json!({ "value": value }))
-    }
-
-    /// A scratch node wired from `inputs` (port name → source node).
-    fn op(&mut self, ty: &str, params: Json, inputs: &[(&str, &str)]) -> String {
-        self.scratch += 1;
-        let id = format!("n{}", self.scratch);
-        self.node(&id, ty, params);
-        for (port, from) in inputs {
-            self.edge(from, &id, port);
-        }
-        id
-    }
-
-    fn sub(&mut self, lhs: &str, rhs: &str) -> String {
-        self.op("subtract", json!({}), &[("lhs", lhs), ("rhs", rhs)])
-    }
-    fn mul(&mut self, a: &str, b: &str) -> String {
-        self.op("multiply", json!({}), &[("operand_0", a), ("operand_1", b)])
-    }
-    fn div(&mut self, lhs: &str, rhs: &str) -> String {
-        self.op("divide", json!({}), &[("lhs", lhs), ("rhs", rhs)])
-    }
-    fn add2(&mut self, a: &str, b: &str) -> String {
-        self.op("add", json!({}), &[("operand_0", a), ("operand_1", b)])
-    }
-    fn max2(&mut self, a: &str, b: &str) -> String {
-        self.op("max", json!({}), &[("operand_0", a), ("operand_1", b)])
-    }
-
-    /// ~200 ms exponential smoothing.
-    fn damp(&mut self, from: &str) -> String {
-        self.op("damp", json!({ "half_life": HALF_LIFE }), &[("in", from)])
-    }
-
-    /// An input node reading `path`, defaulting to `value` until staged.
-    fn input(&mut self, id: &str, path: &str, value: Json) -> String {
-        self.node(id, "input", json!({ "path": path, "value": value }))
-    }
-
-    /// An output node writing `path`.
-    fn output(&mut self, from: &str, path: String) {
-        self.scratch += 1;
-        let id = format!("o{}", self.scratch);
-        self.node(&id, "output", json!({ "path": path }));
-        self.edge(from, &id, "in");
-    }
-
-    /// `atan(num / den)` via the rational approximation `r / (1 + 0.28 r²)`
-    /// (≤1 % error inside the clamped gaze range), normalized by the
-    /// incumbent's ±0.78 rad → ±1 and clamped.
-    fn gaze_angle(&mut self, num: &str, den: &str) -> String {
-        let r = self.div(num, den);
-        let r2 = self.mul(&r, &r);
-        let k = self.constant(0.28);
-        let kr2 = self.mul(&r2, &k);
-        let one = self.constant(1.0);
-        let d = self.add2(&kr2, &one);
-        let atan = self.div(&r, &d);
-        let range = self.constant(GAZE_RANGE_RAD);
-        let norm = self.div(&atan, &range);
-        let lo = self.constant(-1.0);
-        let hi = self.constant(1.0);
-        self.op(
-            "clamp",
-            json!({}),
-            &[("in", &norm), ("min", &lo), ("max", &hi)],
-        )
-    }
+/// `atan(num / den)` via the rational approximation `r / (1 + 0.28 r²)`
+/// (≤1 % error inside the clamped gaze range), normalized by the
+/// incumbent's ±0.78 rad → ±1 and clamped.
+fn gaze_angle(g: &mut GraphBuilder, num: &str, den: &str) -> String {
+    let r = g.div(num, den);
+    let r2 = g.mul(&r, &r);
+    let k = g.constant(0.28);
+    let kr2 = g.mul(&r2, &k);
+    let one = g.constant(1.0);
+    let d = g.add2(&kr2, &one);
+    let atan = g.div(&r, &d);
+    let range = g.constant(GAZE_RANGE_RAD);
+    let norm = g.div(&atan, &range);
+    let lo = g.constant(-1.0);
+    let hi = g.constant(1.0);
+    g.op(
+        "clamp",
+        json!({}),
+        &[("in", &norm), ("min", &lo), ("max", &hi)],
+    )
 }
 
 /// The composable ROS4HRI profile source: the canonical profile asset
@@ -334,7 +256,7 @@ fn build(rig_prefix: &str) -> (String, Json) {
         };
         let blended = g.mul(&no_name, &va);
         let w = g.add2(&named, &blended);
-        let smooth = g.damp(&w);
+        let smooth = g.damp(&w, HALF_LIFE);
         if *expr == "asleep" {
             asleep_weight = Some(smooth.clone());
         }
@@ -362,9 +284,9 @@ fn build(rig_prefix: &str) -> (String, Json) {
     let iod = g.constant(HALF_IOD);
     let y_left = g.add2(&gy, &iod);
     let y_right = g.sub(&gy, &iod);
-    let yaw_l = g.gaze_angle(&y_left, &gx);
-    let yaw_r = g.gaze_angle(&y_right, &gx);
-    let pitch = g.gaze_angle(&gz, &gx);
+    let yaw_l = gaze_angle(g, &y_left, &gx);
+    let yaw_r = gaze_angle(g, &y_right, &gx);
+    let pitch = gaze_angle(g, &gz, &gx);
 
     for (angle, path_x, path_y) in [
         (&yaw_l, standard::LEFT_EYE_POS_X, standard::LEFT_EYE_POS_Y),
@@ -380,8 +302,8 @@ fn build(rig_prefix: &str) -> (String, Json) {
             json!({}),
             &[("cond", &valid), ("then", &pitch), ("else", &zero)],
         );
-        let sx = g.damp(&gated_x);
-        let sy = g.damp(&gated_y);
+        let sx = g.damp(&gated_x, HALF_LIFE);
+        let sy = g.damp(&gated_y, HALF_LIFE);
         g.output(&sx, out(path_x.to_string()));
         g.output(&sy, out(path_y.to_string()));
     }
@@ -394,7 +316,7 @@ fn build(rig_prefix: &str) -> (String, Json) {
     for code in au_codes {
         let input_id = format!("in-au-{code}");
         let raw = g.input(&input_id, &au_key(code), json!(0.0));
-        let smooth = g.damp(&raw);
+        let smooth = g.damp(&raw, HALF_LIFE);
         if code == 43 {
             eyes_closed = smooth.clone();
         }
@@ -415,7 +337,7 @@ fn build(rig_prefix: &str) -> (String, Json) {
     for shape in VISEME_SHAPES {
         let input_id = format!("in-vis-{shape}");
         let raw = g.input(&input_id, &viseme_key(shape), json!(0.0));
-        let smooth = g.damp(&raw);
+        let smooth = g.damp(&raw, HALF_LIFE);
         g.output(&smooth, out(standard::viseme_path(shape)));
     }
 

--- a/crates/interop/vizij-arora-host/src/skills.rs
+++ b/crates/interop/vizij-arora-host/src/skills.rs
@@ -1,0 +1,263 @@
+//! Spawnable skill fragments: task-run behavior as graph data.
+//!
+//! A skill fragment is the *implementation* of a device task-run method as
+//! asset content — a graph spec the interpreter grafts per run
+//! (`vizij-arora-behavior`'s task-fragment registry) instead of calling host
+//! code. The exterior contract (the method's described signature, and the
+//! ROS 2 action an exposure profile binds it to) lives with the device and
+//! the bridge; this module owns only the behavior.
+//!
+//! Fragments speak a placeholder-path convention the interpreter rewrites to
+//! each run's key prefix at graft time:
+//!
+//! - `task/<param>` inputs are the method's parameters, served from the
+//!   spawn-time arguments and live-updatable through the run's update keys;
+//! - the `task/status` output is the run's lifecycle — the behavior `Status`
+//!   enumeration, `Running` until the run ends;
+//! - a `task/result` output carries the run's result; an integer there is
+//!   the `std_skills` errno the ROS action plane answers verbatim.
+//!
+//! One skill ships today: **look_at**, the gaze skill behind the ROS4HRI
+//! `/skill/look_at` action (`interaction_skills/LookAt`).
+
+use arora_behavior::{
+    STATUS_ENUMERATION_ID, STATUS_FAILURE_VARIANT_ID, STATUS_RUNNING_VARIANT_ID,
+    STATUS_SUCCESS_VARIANT_ID,
+};
+use serde_json::{json, Value as Json};
+use uuid::Uuid;
+use vizij_api_core::value::{Enumeration, Value};
+
+use crate::graph_builder::GraphBuilder;
+use crate::ros4hri::{GAZE_FRAME_KEY, GAZE_TARGET_KEY};
+
+/// The look_at method's parameters, in declared order — the fragment's
+/// placeholder inputs and the described signature's parameter names, from one
+/// list so the contract and the behavior cannot drift.
+pub const LOOK_AT_PARAMS: [&str; 3] = ["policy", "target", "frame"];
+
+/// The look_at method's name, as the device describes it.
+pub const LOOK_AT_FUNCTION: &str = "look_at";
+
+/// How long a `glance`/`reset` fixation holds before the run succeeds,
+/// seconds.
+const SETTLE_SECONDS: f64 = 0.6;
+
+/// The `std_skills/Result` "not supported" error code, answered for gaze
+/// policies this skill does not implement (`social`, `random`, `auto`, and
+/// anything unknown).
+const ROS_ENOTSUP: u8 = 134;
+
+/// The canonical fragment asset, verbatim: the behavior as data. Edit it by
+/// regenerating (`vizij-bundle export-skill look_at`) — a test keeps it in
+/// sync with [`generate_look_at`].
+pub const LOOK_AT_JSON: &str = include_str!("../skills/look_at.json");
+
+/// Regenerate the look_at fragment from first principles — the export path
+/// behind the canonical asset.
+///
+/// The behavior, per the `interaction_skills/LookAt` policies:
+///
+/// - empty policy or `track`: write the goal target (and frame) onto the
+///   ROS4HRI gaze keys and stay `Running` — tracking ends when the goal is
+///   cancelled or replaced (the halt is the exit);
+/// - `glance` / `reset`: write the target (`reset` recenters on the profile's
+///   far-ahead rest), hold the fixation for [`SETTLE_SECONDS`], then
+///   `Success`;
+/// - anything else (`social`, `random`, `auto`, unknown): `Failure`, with
+///   the `ROS_ENOTSUP` errno on the result key.
+pub fn generate_look_at() -> Json {
+    let status = |variant: Uuid| -> Json {
+        serde_json::to_value(Value::Enumeration(Enumeration {
+            id: STATUS_ENUMERATION_ID,
+            variant_id: variant,
+            value: Box::new(Value::Unit),
+        }))
+        .expect("a status value serializes")
+    };
+
+    let g = &mut GraphBuilder::new();
+
+    // The method's parameters, staged from the run's keys (the spawn-time
+    // arguments become these inputs' defaults at graft time).
+    let policy = g.input("in-policy", "task/policy", json!(""));
+    let target = g.input(
+        "in-target",
+        "task/target",
+        json!({ "x": 10.0, "y": 0.0, "z": 0.0 }),
+    );
+    let frame = g.input("in-frame", "task/frame", json!(""));
+
+    // Gaze: `reset` recenters on the profile's far-ahead rest target (the
+    // unverged straight-ahead), every other policy tracks the goal. The
+    // written keys are the same standard surface the topic plane feeds — the
+    // ROS4HRI profile turns them into eye pose.
+    let rest = g.node(
+        "rest-target",
+        "constant",
+        json!({ "value": { "x": 10.0, "y": 0.0, "z": 0.0 } }),
+    );
+    let face_frame = g.node("face-frame", "constant", json!({ "value": "" }));
+    let gaze = g.op(
+        "case",
+        json!({ "case_labels": ["reset"] }),
+        &[
+            ("selector", &policy),
+            ("operand_0", &rest),
+            ("default", &target),
+        ],
+    );
+    g.output(&gaze, GAZE_TARGET_KEY.to_string());
+    let gaze_frame = g.op(
+        "case",
+        json!({ "case_labels": ["reset"] }),
+        &[
+            ("selector", &policy),
+            ("operand_0", &face_frame),
+            ("default", &frame),
+        ],
+    );
+    g.output(&gaze_frame, GAZE_FRAME_KEY.to_string());
+
+    // The fixation clock: the graph clock, latched through the store on the
+    // run's first tick (`task/start` reads back what it wrote), so elapsed
+    // time is measured from the spawn.
+    let now = g.node("clock", "time", json!({}));
+    let start_in = g.input("in-start", "task/start", json!(0.0));
+    let zero = g.constant(0.0);
+    let started = g.op(
+        "greaterthan",
+        json!({}),
+        &[("lhs", &start_in), ("rhs", &zero)],
+    );
+    let start = g.op(
+        "if",
+        json!({}),
+        &[("cond", &started), ("then", &start_in), ("else", &now)],
+    );
+    g.output(&start, "task/start".to_string());
+    let elapsed = g.sub(&now, &start);
+    let dwell = g.constant(SETTLE_SECONDS);
+    let settled = g.op(
+        "greaterthan",
+        json!({}),
+        &[("lhs", &elapsed), ("rhs", &dwell)],
+    );
+
+    // The lifecycle: tracking runs until halted; a fixation succeeds once
+    // settled; unimplemented policies fail.
+    let running = g.node(
+        "st-running",
+        "constant",
+        json!({ "value": status(STATUS_RUNNING_VARIANT_ID) }),
+    );
+    let success = g.node(
+        "st-success",
+        "constant",
+        json!({ "value": status(STATUS_SUCCESS_VARIANT_ID) }),
+    );
+    let failure = g.node(
+        "st-failure",
+        "constant",
+        json!({ "value": status(STATUS_FAILURE_VARIANT_ID) }),
+    );
+    let fixation = g.op(
+        "if",
+        json!({}),
+        &[("cond", &settled), ("then", &success), ("else", &running)],
+    );
+    let lifecycle = g.op(
+        "case",
+        json!({ "case_labels": ["", "track", "glance", "reset"] }),
+        &[
+            ("selector", &policy),
+            ("operand_0", &running),
+            ("operand_1", &running),
+            ("operand_2", &fixation),
+            ("operand_3", &fixation),
+            ("default", &failure),
+        ],
+    );
+    g.output(&lifecycle, "task/status".to_string());
+
+    // The errno: unsupported policies answer ROS_ENOTSUP. On every
+    // implemented path the run stays silent — an empty text the action plane
+    // ignores, so the goal's lifecycle decides the errno (success, cancel,
+    // preemption).
+    let silent = g.node("no-errno", "constant", json!({ "value": "" }));
+    let enotsup = g.node(
+        "errno-enotsup",
+        "constant",
+        json!({ "value": { "u8": ROS_ENOTSUP } }),
+    );
+    let errno = g.op(
+        "case",
+        json!({ "case_labels": ["", "track", "glance", "reset"] }),
+        &[
+            ("selector", &policy),
+            ("operand_0", &silent),
+            ("operand_1", &silent),
+            ("operand_2", &silent),
+            ("operand_3", &silent),
+            ("default", &enotsup),
+        ],
+    );
+    g.output(&errno, "task/result".to_string());
+
+    json!({ "nodes": g.nodes, "edges": g.edges })
+}
+
+/// The parsed canonical asset — what the device registers as the look_at
+/// task fragment.
+pub fn look_at_source() -> Json {
+    serde_json::from_str(LOOK_AT_JSON).expect("skills/look_at.json parses")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The committed asset must equal what the generator produces — otherwise
+    /// `export-skill` was not re-run after editing the builder. Regenerate
+    /// with `vizij-bundle export-skill look_at -o
+    /// crates/interop/vizij-arora-host/skills/look_at.json`.
+    #[test]
+    fn committed_asset_matches_the_generator() {
+        let committed: Json = serde_json::from_str(LOOK_AT_JSON).expect("asset parses");
+        assert_eq!(
+            committed,
+            generate_look_at(),
+            "skills/look_at.json is stale"
+        );
+    }
+
+    /// The fragment holds the placeholder contract the interpreter grafts
+    /// against: one input per method parameter, the status output, the errno
+    /// result output, and the gaze writes.
+    #[test]
+    fn the_fragment_speaks_the_placeholder_contract() {
+        let spec = generate_look_at();
+        let nodes = spec["nodes"].as_array().unwrap();
+        let paths_of = |ty: &str| -> Vec<&str> {
+            nodes
+                .iter()
+                .filter(|n| n["type"] == ty)
+                .filter_map(|n| n["params"]["path"].as_str())
+                .collect()
+        };
+        let inputs = paths_of("input");
+        for param in LOOK_AT_PARAMS {
+            let path = format!("task/{param}");
+            assert!(inputs.contains(&path.as_str()), "missing input {path}");
+        }
+        let outputs = paths_of("output");
+        for path in [
+            "task/status",
+            "task/result",
+            GAZE_TARGET_KEY,
+            GAZE_FRAME_KEY,
+        ] {
+            assert!(outputs.contains(&path), "missing output {path}");
+        }
+    }
+}

--- a/crates/tools/vizij-bundle/src/main.rs
+++ b/crates/tools/vizij-bundle/src/main.rs
@@ -23,7 +23,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use anyhow::{anyhow, bail, Context, Result};
-use vizij_arora_host::{profiles, ros4hri};
+use vizij_arora_host::{profiles, ros4hri, skills};
 
 struct Args {
     command: String,
@@ -47,7 +47,8 @@ const USAGE: &str = "usage: vizij-bundle <command> …
   add-standard   <face.glb> --standard <profile> -o <out.glb>
   validate       <face.glb> [--min-level <0-3>]
   profiles
-  export-profile <profile> [-o <file.json>]";
+  export-profile <profile> [-o <file.json>]
+  export-skill   <skill>   [-o <file.json>]";
 
 fn parse_args() -> Result<Args> {
     let mut args = std::env::args().skip(1);
@@ -112,6 +113,23 @@ fn run_assets(args: &Args) -> Result<Option<ExitCode>> {
             let spec = match id {
                 "ros4hri" => ros4hri::generate(),
                 _ => unreachable!("registered profiles have generators"),
+            };
+            let text = vizij_bundle::to_sidecar(&spec)?;
+            match &args.output {
+                Some(path) => std::fs::write(path, text)
+                    .with_context(|| format!("write {}", path.display()))?,
+                None => print!("{text}"),
+            }
+            Ok(Some(ExitCode::SUCCESS))
+        }
+        "export-skill" => {
+            let id = args
+                .target
+                .as_deref()
+                .ok_or_else(|| anyhow!("export-skill needs a skill id\n{USAGE}"))?;
+            let spec = match id {
+                "look_at" => skills::generate_look_at(),
+                _ => return Err(anyhow!("unknown skill {id}")),
             };
             let text = vizij_bundle::to_sidecar(&spec)?;
             match &args.output {

--- a/crates/vizij/Cargo.toml
+++ b/crates/vizij/Cargo.toml
@@ -32,8 +32,11 @@ bevy = "0.19"
 arora = "9.10"
 # The ROS 2 bridge, attached under `--ros2` (feature `ros2`). Heavy (ros2-client
 # + a DDS/Zenoh backend), so opt-in; the Studio bridge rides arora's own
-# `studio-bridge` feature instead (`--studio`).
-arora-bridge-ros2 = { version = "3.2", optional = true }
+# `studio-bridge` feature instead (`--studio`). 5 adds the skill plane the
+# ros4hri exposure profile binds `/skill/look_at` through.
+arora-bridge-ros2 = { version = "5", optional = true }
+# The Status enumeration ids the gaze contract marks its action shape with.
+arora-behavior-tree-types = "1"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 # The command pump's async plumbing: the TUI command stream and the per-run
 # stop signal.
@@ -69,8 +72,6 @@ arora-behavior = "8"
 # The bundler, for the Quori integration test (grafts the standard-adaptation
 # sidecar into the demo GLB before driving it over the ROS4HRI keys).
 vizij-bundle = { path = "../tools/vizij-bundle" }
-# The Status enumeration ids the gaze signature marks its action shape with.
-arora-behavior-tree-types = "1"
 # The typed ROS 2 peer of the live action E2E (the semio-ai ros2-client fork;
 # the library imports as `ros2_client`).
 ros2-client = { package = "ros2-client-multi-rmw", version = "0.11.0", default-features = false, features = ["jazzy", "dds"] }

--- a/crates/vizij/src/device.rs
+++ b/crates/vizij/src/device.rs
@@ -18,7 +18,6 @@ use vizij_arora_store::BlackboardStore;
 
 use crate::animation;
 use crate::gaze;
-use crate::tts;
 use crate::meta::FaceMeta;
 
 /// A running face device. Both handles share storage with the device's own
@@ -278,8 +277,7 @@ pub(crate) fn builder_for(
             .with_data_store(Box::new(store))
             .with_behavior_interpreter(Box::new(graph))
             .with_host_module(animation::host_module())
-            .with_host_module(gaze::host_module())
-            .with_host_module(tts::host_module()),
+            .with_host_module(gaze::host_module()),
     )
 }
 

--- a/crates/vizij/src/device.rs
+++ b/crates/vizij/src/device.rs
@@ -17,6 +17,8 @@ pub use vizij_arora_host::ProgramSelect;
 use vizij_arora_store::BlackboardStore;
 
 use crate::animation;
+use crate::gaze;
+use crate::tts;
 use crate::meta::FaceMeta;
 
 /// A running face device. Both handles share storage with the device's own
@@ -110,7 +112,11 @@ async fn attach_bridges(
     }
     #[cfg(feature = "ros2")]
     if let Some((namespace, domain)) = &bridges.ros2 {
-        let config = arora_bridge_ros2::Ros2BridgeConfig::new(namespace.clone(), *domain);
+        // The ROS4HRI exposure profile: typed face topics fanning onto the
+        // standard keys, and the `/skill/look_at` action bound to the gaze
+        // skill the device describes.
+        let config = arora_bridge_ros2::Ros2BridgeConfig::new(namespace.clone(), *domain)
+            .with_profile(arora_bridge_ros2::ExposureProfile::ros4hri());
         builder = builder.with_bridge(Box::new(arora_bridge_ros2::Ros2Bridge::new(config).await));
         log::info!("serving the ROS 2 bridge (namespace {namespace:?}, domain {domain})");
     }
@@ -263,12 +269,17 @@ pub(crate) fn builder_for(
     // Route the animation source's `step`/`player_states` handles (and any
     // in-process transport call) to the host module registered below.
     graph.set_function_modules(animation::function_modules());
+    // The gaze skill: the described contract rides the gaze module; the
+    // behavior is the shipped fragment the interpreter grafts per goal.
+    graph.set_task_fragment(gaze::look_at_id(), gaze::look_at_fragment());
     Some(
         arora::Arora::builder()
             .with_hal(Box::new(rig))
             .with_data_store(Box::new(store))
             .with_behavior_interpreter(Box::new(graph))
-            .with_host_module(animation::host_module()),
+            .with_host_module(animation::host_module())
+            .with_host_module(gaze::host_module())
+            .with_host_module(tts::host_module()),
     )
 }
 
@@ -524,6 +535,88 @@ mod tests {
             .expect("the handle's stop call dispatches");
         arora.step(Duration::from_millis(16)).expect("step");
         assert_eq!(status(&arora), Some(task::failure()), "halted");
+    }
+
+    /// The production gaze skill through the device: SPAWN on the described
+    /// `look_at` grafts the shipped fragment (`builder_for` registers it) —
+    /// asset content, no module call — so the goal target lands on the
+    /// standard gaze surface and the run reports `Running` until halted.
+    #[test]
+    fn the_gaze_skill_runs_the_shipped_fragment_through_the_device() {
+        use arora_behavior::{interpreter_module, RunPolicy};
+        use arora_types::call::Call;
+        use arora_types::gen_uuid_from_str;
+        use arora_types::value::StructureField;
+        use vizij_arora_behavior::task;
+
+        use crate::gaze;
+
+        let mut arora = builder_for(
+            r#"{ "nodes": [], "edges": [] }"#,
+            RigHal::new(),
+            BlackboardStore::new(),
+        )
+        .expect("build the device")
+        .build()
+        .expect("build arora");
+
+        let look_at = Call {
+            module_id: Some(gaze::module_id()),
+            id: gaze::look_at_id(),
+            args: vec![
+                StructureField {
+                    id: gen_uuid_from_str("policy"),
+                    value: Box::new(Value::String(String::new())),
+                },
+                StructureField {
+                    id: gen_uuid_from_str("target"),
+                    value: Box::new(Value::ArrayF32(vec![1.0, 2.0, 3.0])),
+                },
+                StructureField {
+                    id: gen_uuid_from_str("frame"),
+                    value: Box::new(Value::String("sellion_link".to_string())),
+                },
+            ],
+        };
+        let spawned = arora
+            .call(interpreter_module::encode_spawn(
+                &look_at,
+                RunPolicy::Concurrent,
+            ))
+            .expect("SPAWN dispatches through the engine");
+        let handle =
+            interpreter_module::decode_spawn_result(&spawned.ret).expect("a TaskHandle comes back");
+
+        let read = |arora: &arora::Arora, key: &arora_types::data::Key| {
+            arora
+                .store()
+                .read(std::slice::from_ref(key))
+                .into_iter()
+                .next()
+                .flatten()
+        };
+
+        arora.step(Duration::from_millis(16)).expect("step");
+        assert_eq!(
+            read(&arora, &Key::from(ros4hri::GAZE_TARGET_KEY)),
+            Some(Value::ArrayF32(vec![1.0, 2.0, 3.0])),
+            "the fragment writes the goal onto the gaze surface"
+        );
+        assert_eq!(
+            read(&arora, &Key::from(ros4hri::GAZE_FRAME_KEY)),
+            Some(Value::String("sellion_link".to_string())),
+        );
+        assert_eq!(read(&arora, &handle.status), Some(task::running()));
+
+        arora
+            .call(handle.stop.clone())
+            .expect("the handle's stop call dispatches");
+        arora.step(Duration::from_millis(16)).expect("step");
+        assert_eq!(
+            read(&arora, &handle.status),
+            Some(task::failure()),
+            "halted"
+        );
     }
 
     use vizij_api_core::value::{as_float, text, vec3, Value};

--- a/crates/vizij/src/gaze.rs
+++ b/crates/vizij/src/gaze.rs
@@ -1,0 +1,97 @@
+//! The gaze skill's exterior contract: the described `look_at` method the
+//! device registers, and the fragment that implements it.
+//!
+//! The behavior is data — `vizij-arora-host`'s look_at skill fragment,
+//! grafted per run by the interpreter ([`TaskFragment`]) — so the module
+//! here carries only the contract: the described signature a bridge
+//! discovers (DescribeMethods) and an exposure profile binds to the ROS4HRI
+//! `/skill/look_at` action (`interaction_skills/LookAt`). Signature and
+//! fragment derive from one parameter list ([`skills::LOOK_AT_PARAMS`]), so
+//! they cannot drift.
+
+use std::collections::HashMap;
+
+use arora::{HostModule, ModuleBuilder};
+use arora_behavior_tree_types::STATUS_ENUMERATION_ID;
+use arora_types::call::CallResult;
+use arora_types::gen_uuid_from_str;
+use arora_types::record::module::frozen::{Function, Parameter};
+use arora_types::record::ty::{FrozenScalar, FrozenTy, PrimitiveKind};
+use arora_types::record::{FrozenReference, Version};
+use uuid::Uuid;
+use vizij_arora_behavior::{task, TaskFragment};
+use vizij_arora_host::skills;
+
+/// The gaze module's id on the device.
+pub fn module_id() -> Uuid {
+    gen_uuid_from_str("gaze-module")
+}
+
+/// The look_at function's id.
+pub fn look_at_id() -> Uuid {
+    gen_uuid_from_str(skills::LOOK_AT_FUNCTION)
+}
+
+/// The look_at task fragment, parsed from the shipped asset — what the
+/// device's interpreter grafts per goal.
+pub fn look_at_fragment() -> TaskFragment {
+    let parameters: HashMap<Uuid, String> = skills::LOOK_AT_PARAMS
+        .iter()
+        .map(|name| (gen_uuid_from_str(name), name.to_string()))
+        .collect();
+    TaskFragment::parse(skills::LOOK_AT_JSON, parameters).expect("the shipped look_at asset parses")
+}
+
+/// The described look_at signature: `(policy, target, frame)` returning the
+/// behavior `Status` — the task-run marker a bridge exposes as an action.
+fn look_at_signature() -> Function {
+    let kinds = [
+        PrimitiveKind::String,   // policy
+        PrimitiveKind::ArrayF32, // target (vec3, meters, face frame)
+        PrimitiveKind::String,   // frame
+    ];
+    let mut parameters = HashMap::new();
+    let mut parameter_ordering = Vec::new();
+    for (name, kind) in skills::LOOK_AT_PARAMS.iter().zip(kinds) {
+        let id = gen_uuid_from_str(name);
+        parameter_ordering.push(id);
+        parameters.insert(
+            id,
+            Parameter {
+                name: name.to_string(),
+                ty: FrozenTy::from(kind),
+                mutable: false,
+            },
+        );
+    }
+    Function {
+        parameters,
+        parameter_ordering,
+        return_ty: FrozenTy::FrozenScalar(FrozenScalar {
+            reference: FrozenReference {
+                id: STATUS_ENUMERATION_ID,
+                version: Version::parse("1.0.0").expect("a valid version"),
+            },
+        }),
+    }
+}
+
+/// The gaze module: the look_at contract, described so bridges discover it.
+/// The closure is only reached when the device did not register the fragment
+/// (a misconfiguration) — it fails the run rather than pretending to gaze.
+pub fn host_module() -> HostModule {
+    ModuleBuilder::new(module_id())
+        .described_function(
+            look_at_id(),
+            skills::LOOK_AT_FUNCTION,
+            look_at_signature(),
+            |_call| {
+                log::warn!("look_at invoked as a module call: no task fragment is registered");
+                Ok(CallResult {
+                    ret: task::failure(),
+                    mutated: Vec::new(),
+                })
+            },
+        )
+        .build()
+}

--- a/crates/vizij/src/main.rs
+++ b/crates/vizij/src/main.rs
@@ -15,6 +15,7 @@ use clap::Parser;
 mod animation;
 mod device;
 mod frames;
+mod gaze;
 mod meta;
 #[cfg(all(test, feature = "ros2"))]
 mod ros2_tests;

--- a/crates/vizij/src/ros2_tests.rs
+++ b/crates/vizij/src/ros2_tests.rs
@@ -1,81 +1,95 @@
-//! Live ROS 2 end-to-end: a typed action client drives a LookAt task run on
-//! the real vizij device over DDS.
+//! Live ROS 2 end-to-end: a typed `interaction_skills/LookAt` client drives
+//! the gaze skill on the real vizij device over DDS.
 //!
 //! The whole production chain is under test — discovery (`DescribeMethods`
-//! over the described gaze host module), the bridge's action synthesis, SPAWN
-//! into the node-graph interpreter (the run grafts as graph structure and
-//! reports on its status key), cancel → halt → `CANCELED`. The only scripted
-//! piece is the gaze skill itself, which tracks indefinitely (`Running` every
-//! invocation) like the real LookAt.
+//! over the device's gaze module), the ros4hri exposure profile's
+//! `/skill/look_at` action binding, SPAWN into the node-graph interpreter
+//! (the shipped look_at fragment grafts as graph structure, writes the
+//! `standard/ros4hri/gaze/*` surface, and reports on its status key),
+//! cancel → halt → `CANCELED` with the `std_skills` errno, and an
+//! unsupported policy answering `ROS_ENOTSUP` straight from the fragment.
+//! The only test double is a `speak` module probing the method-service
+//! plane — the discriminator between "raw services are broken live" and
+//! "the skill assembly is at fault".
 
 use std::time::Duration;
 
-use arora_behavior_tree_types::STATUS_ENUMERATION_ID;
 use arora_types::call::CallResult;
+use arora_types::data::{DataStore, Key};
 use arora_types::gen_uuid_from_str;
 use arora_types::record::module::frozen::{Function, Parameter};
-use arora_types::record::ty::{FrozenScalar, FrozenTy, PrimitiveKind};
-use arora_types::record::{FrozenReference, Version};
+use arora_types::record::ty::{FrozenTy, PrimitiveKind};
 use arora_types::value::Value;
 use rand::Rng;
 use ros2_client::action_msgs::GoalStatusEnum;
 use ros2_client::{Context, ContextOptions, Message, Name, NodeName, NodeOptions, ServiceMapping};
 use serde::{Deserialize, Serialize};
-use vizij_arora_behavior::task;
 use vizij_arora_hal::RigHal;
 use vizij_arora_store::BlackboardStore;
 
 use crate::device::builder_for;
 
-// The typed client's view of the action.
+// The typed client's view of `interaction_skills/LookAt` — local mirrors of
+// the standard messages (`ros2_client::Message` is a foreign marker trait).
+#[derive(Serialize, Deserialize, Clone)]
+struct Meta {
+    caller: String,
+    priority: u8,
+}
+#[derive(Serialize, Deserialize, Clone)]
+struct Header {
+    stamp: ros2_client::builtin_interfaces::Time,
+    frame_id: String,
+}
+#[derive(Serialize, Deserialize, Clone)]
+struct Point {
+    x: f64,
+    y: f64,
+    z: f64,
+}
+#[derive(Serialize, Deserialize, Clone)]
+struct PointStamped {
+    header: Header,
+    point: Point,
+}
 #[derive(Serialize, Deserialize, Clone)]
 struct LookAtGoal {
+    meta: Meta,
     policy: String,
-    x: f64,
+    target: PointStamped,
 }
 impl Message for LookAtGoal {}
-/// The run populates no result keys (v1 hosts one call, §2.2.2 of the
-/// task-runs proposal), so the synthesised Result carries the goal status
-/// alone — an empty payload on the typed side.
-#[derive(Serialize, Deserialize, Clone)]
-struct LookAtResult {}
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct SkillResult {
+    error_code: u8,
+    error_msg: String,
+}
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct LookAtResult {
+    result: SkillResult,
+}
 impl Message for LookAtResult {}
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
+struct SkillFeedback {
+    data_bool: bool,
+    data_int: u16,
+    data_float: f32,
+    data_str: String,
+}
+#[derive(Serialize, Deserialize, Clone)]
 struct LookAtFeedback {
-    gaze_error: f32,
+    feedback: SkillFeedback,
 }
 impl Message for LookAtFeedback {}
 
-fn gaze_module() -> arora::HostModule {
-    let look_at_signature = {
-        let mut parameters = std::collections::HashMap::new();
-        let mut parameter_ordering = Vec::new();
-        for (name, kind) in [("policy", PrimitiveKind::String), ("x", PrimitiveKind::F64)] {
-            let id = gen_uuid_from_str(name);
-            parameter_ordering.push(id);
-            parameters.insert(
-                id,
-                Parameter {
-                    name: name.to_string(),
-                    ty: FrozenTy::from(kind),
-                    mutable: false,
-                },
-            );
-        }
-        Function {
-            parameters,
-            parameter_ordering,
-            // The behavior `Status` return is the action marker: the bridge
-            // exposes this method as a ROS 2 action, not a service.
-            return_ty: FrozenTy::FrozenScalar(FrozenScalar {
-                reference: FrozenReference {
-                    id: STATUS_ENUMERATION_ID,
-                    version: Version::parse("1.0.0").expect("a valid version"),
-                },
-            }),
-        }
-    };
-    let speak_signature = {
+const ROS_ECANCELED: u8 = 125;
+const ROS_ENOTSUP: u8 = 134;
+
+/// A plain described method riding the service plane — the test's only
+/// double, probing that raw DDS services work before blaming the skill
+/// assembly.
+fn speak_module() -> arora::HostModule {
+    let signature = {
         let text = gen_uuid_from_str("text");
         let mut parameters = std::collections::HashMap::new();
         parameters.insert(
@@ -92,34 +106,13 @@ fn gaze_module() -> arora::HostModule {
             return_ty: FrozenTy::from(PrimitiveKind::F64),
         }
     };
-    arora::ModuleBuilder::new(gen_uuid_from_str("gaze-module"))
-        // The gaze skill: every invocation steers toward its target and
-        // reports `Running` — indefinite tracking, like the real LookAt.
-        .described_function(
-            gen_uuid_from_str("look_at"),
-            "look_at",
-            look_at_signature,
-            |_call| {
-                Ok(CallResult {
-                    ret: task::running(),
-                    mutated: Vec::new(),
-                })
-            },
-        )
-        // A plain method: it rides the service plane in the same run — the
-        // discriminator between "raw services are broken live" and "the
-        // action assembly is at fault".
-        .described_function(
-            gen_uuid_from_str("speak"),
-            "speak",
-            speak_signature,
-            |_call| {
-                Ok(CallResult {
-                    ret: Value::F64(1.0),
-                    mutated: Vec::new(),
-                })
-            },
-        )
+    arora::ModuleBuilder::new(gen_uuid_from_str("speak-module"))
+        .described_function(gen_uuid_from_str("speak"), "speak", signature, |_call| {
+            Ok(CallResult {
+                ret: Value::F64(1.0),
+                mutated: Vec::new(),
+            })
+        })
         .build()
 }
 
@@ -140,25 +133,30 @@ fn create_test_node(domain_id: u16, name_suffix: &str) -> (Context, ros2_client:
               unicast-peer/interface config); this runs on Linux CI. To run locally, ensure an \
               active multicast-capable interface and use --ignored."
 )]
-async fn a_look_at_action_runs_on_the_vizij_device_over_dds() {
+async fn the_look_at_skill_serves_the_standard_contract_on_the_vizij_device() {
     let _ = env_logger::builder()
         .parse_filters("warn")
         .is_test(true)
         .try_init();
     let domain_id: u16 = rand::rng().random_range(1..=200);
 
-    // The real device: node-graph interpreter, gaze host module, ROS 2 bridge.
-    let bridge = arora_bridge_ros2::Ros2Bridge::new(arora_bridge_ros2::Ros2BridgeConfig::new(
-        "robot", domain_id,
-    ))
+    // The real device: node-graph interpreter with the shipped look_at
+    // fragment, the described gaze module, and the ROS 2 bridge exposing the
+    // ros4hri profile. The store clone watches the gaze surface from the
+    // test.
+    let store = BlackboardStore::new();
+    let bridge = arora_bridge_ros2::Ros2Bridge::new(
+        arora_bridge_ros2::Ros2BridgeConfig::new("robot", domain_id)
+            .with_profile(arora_bridge_ros2::ExposureProfile::ros4hri()),
+    )
     .await;
     let mut arora = builder_for(
         r#"{ "nodes": [], "edges": [] }"#,
         RigHal::new(),
-        BlackboardStore::new(),
+        store.clone(),
     )
     .expect("build the device")
-    .with_host_module(gaze_module())
+    .with_host_module(speak_module())
     .with_bridge(Box::new(bridge))
     .build()
     .expect("build arora");
@@ -173,7 +171,7 @@ async fn a_look_at_action_runs_on_the_vizij_device_over_dds() {
     tokio::pin!(device);
 
     let client_flow = async {
-        let (_ctx, mut node) = create_test_node(domain_id, "action_client");
+        let (_ctx, mut node) = create_test_node(domain_id, "skill_client");
         // The reliable service profile ros2-client's own action examples use —
         // the best-effort default drops service requests.
         let service_qos = {
@@ -233,7 +231,7 @@ async fn a_look_at_action_runs_on_the_vizij_device_over_dds() {
             tokio::time::sleep(Duration::from_millis(200)).await;
         }
 
-        // The typed action client on /robot/actions/look_at.
+        // The typed skill client on the profile's absolute action name.
         let qos = ros2_client::action::ActionClientQosPolicies {
             goal_service: service_qos.clone(),
             result_service: service_qos.clone(),
@@ -244,21 +242,36 @@ async fn a_look_at_action_runs_on_the_vizij_device_over_dds() {
         let client = node
             .create_action_client::<ros2_client::Action<LookAtGoal, LookAtResult, LookAtFeedback>>(
                 ServiceMapping::Enhanced,
-                &Name::parse("/robot/actions/look_at").expect("a valid action name"),
-                &ros2_client::ActionTypeName::new("arora", "look_at"),
+                &Name::parse("/skill/look_at").expect("a valid action name"),
+                &ros2_client::ActionTypeName::new("interaction_skills", "LookAt"),
                 qos,
             )
-            .expect("the action client creates");
+            .expect("the skill client creates");
 
-        // Send the goal until the graph connects and the server accepts. The
-        // accepted goal SPAWNs a run into the device's node graph.
-        let goal = LookAtGoal {
-            policy: "track".to_string(),
-            x: 1.5,
+        let goal = |policy: &str| LookAtGoal {
+            meta: Meta {
+                caller: "test".to_string(),
+                priority: 128,
+            },
+            policy: policy.to_string(),
+            target: PointStamped {
+                header: Header {
+                    stamp: ros2_client::builtin_interfaces::Time::ZERO,
+                    frame_id: "sellion_link".to_string(),
+                },
+                point: Point {
+                    x: 0.5,
+                    y: -0.25,
+                    z: 1.0,
+                },
+            },
         };
-        eprintln!("[client] sending goal");
+
+        // A tracking goal: accepted, SPAWNed, and the shipped fragment
+        // writes the goal onto the standard gaze surface.
+        eprintln!("[client] sending the tracking goal");
         let goal_id = loop {
-            match tokio::time::timeout(Duration::from_secs(2), client.async_send_goal(goal.clone()))
+            match tokio::time::timeout(Duration::from_secs(2), client.async_send_goal(goal("")))
                 .await
             {
                 Ok(Ok((goal_id, response))) if response.accepted => break goal_id,
@@ -268,29 +281,65 @@ async fn a_look_at_action_runs_on_the_vizij_device_over_dds() {
                 }
             }
         };
-        eprintln!("[client] goal accepted — the run is live in the graph");
+        eprintln!("[client] goal accepted — the fragment is live in the graph");
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            let gaze = store
+                .read(&[Key::from("standard/ros4hri/gaze/target")])
+                .into_iter()
+                .next()
+                .flatten();
+            if gaze == Some(Value::ArrayF32(vec![0.5, -0.25, 1.0])) {
+                let frame = store
+                    .read(&[Key::from("standard/ros4hri/gaze/frame")])
+                    .into_iter()
+                    .next()
+                    .flatten();
+                assert_eq!(frame, Some(Value::String("sellion_link".to_string())));
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "the gaze surface never took the goal target (got {gaze:?})"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        eprintln!("[client] the gaze surface tracks the goal");
 
-        // The run tracks indefinitely; cancel ends it. The bridge halts the
-        // run (its status key goes terminal) and reports CANCELED — it is the
-        // party that issued the halt.
-        tokio::time::sleep(Duration::from_millis(300)).await;
-        eprintln!("[client] canceling");
+        // Cancel: the bridge halts the run and answers CANCELED with the
+        // std_skills errno in the standard Result message.
         client
             .async_cancel_goal(goal_id, ros2_client::builtin_interfaces::Time::ZERO)
             .await
             .expect("cancel round-trips");
-        eprintln!("[client] cancel answered; requesting result");
-        let (status, LookAtResult {}) = client
+        let (status, result) = client
             .async_request_result(goal_id)
             .await
             .expect("the result arrives");
         assert_eq!(status, GoalStatusEnum::Canceled);
+        assert_eq!(result.result.error_code, ROS_ECANCELED);
+        eprintln!("[client] canceled with ECANCELED");
+
+        // An unimplemented policy: the fragment itself answers ROS_ENOTSUP
+        // on its result key, and the goal aborts.
+        let (goal_id, response) = client
+            .async_send_goal(goal("social"))
+            .await
+            .expect("the social goal sends");
+        assert!(response.accepted);
+        let (status, result) = client
+            .async_request_result(goal_id)
+            .await
+            .expect("the social result arrives");
+        assert_eq!(status, GoalStatusEnum::Aborted);
+        assert_eq!(result.result.error_code, ROS_ENOTSUP);
+        eprintln!("[client] social answered ENOTSUP");
     };
 
     tokio::select! {
         _ = &mut device => unreachable!("the device loop never returns"),
         result = tokio::time::timeout(Duration::from_secs(60), client_flow) => {
-            result.expect("the action lifecycle timed out");
+            result.expect("the skill lifecycle timed out");
         }
     }
 }


### PR DESCRIPTION
Step 3 of the skill-actions plan (A6 track of the [ROS4HRI face proposal](https://github.com/vizij-ai/vizij-docs/blob/main/active_projects/runtime/ros4hri_face/ros4hri_face-proposal.md)), the vizij side of [arora-sdk#214](https://github.com/semio-ai/arora-sdk/pull/214)'s `/skill/look_at` binding: **the skill's behavior ships as graph data, not host code.**

## Task fragments (vizij-arora-behavior)

`ProcessingGraph` gains a task-fragment registry (`TaskFragment`, `set_task_fragment`): SPAWN for a registered function grafts the fragment — node ids namespaced per run, placeholder `task/*` paths rewritten to the run's key prefix, each parameter input's default replaced by its spawn-time argument, and per-parameter update keys on the handle (live goal updates steer the running fragment through the store, no graph edit per update). Unregistered functions keep the existing `Input→TaskRun→Output` wrapper unchanged. The run stays ordinary graph structure — introspectable, halted and pruned exactly as before (`GraphRun` now tracks the whole grafted node set).

## The look_at skill (vizij-arora-host)

`skills/look_at.json` — generated (`vizij-bundle export-skill look_at`), drift-tested like the ros4hri profile — implements the `interaction_skills/LookAt` policies with plain graph vocabulary:

- empty / `track`: the goal target and frame land on `standard/ros4hri/gaze/*` (the same surface the topic plane feeds — the profile turns it into eye pose) and the run stays `Running`; the halt is the exit.
- `glance` / `reset`: a store-latched fixation clock (`time` + `task/start` round-trip), `Success` after the dwell; `reset` recenters on the profile's rest target.
- `social` / `random` / `auto` / unknown: `Failure`, with the `std_skills` `ROS_ENOTSUP` errno written to the result key — the value the bridge's bound action answers verbatim.

The graph-spec builder moves to a shared `graph_builder.rs`; the ros4hri asset stays **byte-identical** (its drift test pins that).

## The contract (crates/vizij)

`gaze.rs` describes `look_at(policy: String, target: vec3, frame: String) → Status` — signature and fragment derive from one parameter list, so they cannot drift; the fallback closure fails the run if the fragment is missing rather than pretending to gaze. `builder_for` registers both; the `--ros2` bridge (now `arora-bridge-ros2` **5**) exposes `ExposureProfile::ros4hri()`, whose binding serves the skill at `/skill/look_at`. `set_expression` stays a topic.

## Tests

- `a_registered_fragment_implements_the_spawned_run` (interpreter, vs the real asset): track → gaze surface, live-update steering, halt → Failure + prune, glance → Success, social → `ENOTSUP`.
- `the_gaze_skill_runs_the_shipped_fragment_through_the_device` (device, in-process, no bridge).
- `the_look_at_skill_serves_the_standard_contract_on_the_vizij_device` (live DDS, **passes locally**): a typed `interaction_skills/LookAt` client → goal accepted → the store's gaze surface takes the target → cancel → `ROS_ECANCELED` → social → `ROS_ENOTSUP`, on the production device wiring end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)