### PR TITLE
feat(skills): the skills registry on the runtime surface (VIZ-96)

### DIFF
--- a/crates/interop/vizij-arora-host/src/lib.rs
+++ b/crates/interop/vizij-arora-host/src/lib.rs
@@ -50,6 +50,12 @@ pub struct Bundle {
     /// shipped mapping: [`compose`](Bundle::compose) loads it and suppresses
     /// the built-in profile of the same id.
     pub standard_profiles: Vec<(String, Json)>,
+    /// Skill fragments embedded in the face, `(skill id, spec)` — the `skill`
+    /// graph entries (ids `skill::<function>`, prefix stripped). An embedded
+    /// copy is the author's pinned override of the shipped behavior: the
+    /// device registers it as the function's task fragment instead of the
+    /// built-in. Never composed — a fragment grafts per run.
+    pub skills: Vec<(String, Json)>,
     /// The motiongraph programs, `(id, spec)` — the graphs the face can play on
     /// top of its rig (e.g. Quori's "Speaks").
     pub programs: Vec<(String, Json)>,
@@ -97,6 +103,7 @@ impl Bundle {
         let mut graphs = Vec::new();
         let mut programs = Vec::new();
         let mut standard_profiles = Vec::new();
+        let mut skills = Vec::new();
         for entry in bundle
             .get("graphs")
             .and_then(Json::as_array)
@@ -126,6 +133,15 @@ impl Bundle {
                 standard_profiles.push((profile_id.to_string(), spec.clone()));
                 continue;
             }
+            // Embedded skill fragments are held apart by skill id: they never
+            // compose (a fragment grafts per run) — the device registers them
+            // as task fragments, overriding the built-in of the same id.
+            if kind == skills::SKILL_KIND {
+                let id = entry.get("id").and_then(Json::as_str).unwrap_or_default();
+                let skill_id = id.strip_prefix("skill::").unwrap_or(id);
+                skills.push((skill_id.to_string(), spec.clone()));
+                continue;
+            }
             graphs.push((kind, spec.clone()));
         }
 
@@ -149,6 +165,7 @@ impl Bundle {
         Bundle {
             graphs,
             standard_profiles,
+            skills,
             programs,
             active_program_id,
             neutral_inputs,

--- a/crates/interop/vizij-arora-host/src/skills.rs
+++ b/crates/interop/vizij-arora-host/src/skills.rs
@@ -213,6 +213,74 @@ pub fn look_at_source() -> Json {
     serde_json::from_str(LOOK_AT_JSON).expect("skills/look_at.json parses")
 }
 
+/// The bundle graph kind under which a skill fragment embeds in a GLB — the
+/// override a face ships of a built-in skill's behavior.
+pub const SKILL_KIND: &str = "skill";
+
+/// A skill in the shipped registry: its identity, the contract's parameter
+/// names, and the fragment asset behind it.
+pub struct Skill {
+    /// Registry id — the described function name, also the id everywhere a
+    /// user opts in (bundle graph ids, npm lookups).
+    pub id: &'static str,
+    pub title: &'static str,
+    pub description: &'static str,
+    /// The described signature's parameter names, in declared order — the
+    /// fragment's `task/<param>` inputs.
+    pub parameters: &'static [&'static str],
+    /// The canonical fragment asset, verbatim JSON.
+    pub asset_json: &'static str,
+}
+
+/// Every skill Vizij ships.
+pub const SKILLS: [Skill; 1] = [Skill {
+    id: LOOK_AT_FUNCTION,
+    title: "Look At",
+    description: "The ROS4HRI gaze skill (interaction_skills/LookAt on /skill/look_at): \
+                  tracks a target on the standard gaze surface until cancelled, holds a \
+                  glance/reset fixation then succeeds, and answers ROS_ENOTSUP for the \
+                  social/random policies.",
+    parameters: &LOOK_AT_PARAMS,
+    asset_json: LOOK_AT_JSON,
+}];
+
+/// Look a skill up by id.
+pub fn skill(id: &str) -> Option<&'static Skill> {
+    SKILLS.iter().find(|s| s.id == id)
+}
+
+/// The bundle graph id under which `skill_id` embeds in a GLB — stable, so
+/// re-adding replaces rather than duplicates.
+pub fn embedded_graph_id(skill_id: &str) -> String {
+    format!("skill::{skill_id}")
+}
+
+/// A skill's canonical fragment as JSON — face-independent by construction
+/// (placeholder `task/*` paths), so unlike a profile source it takes no rig
+/// prefix. `None` for an unknown id.
+pub fn skill_source(id: &str) -> Option<Json> {
+    let skill = skill(id)?;
+    serde_json::from_str(skill.asset_json).ok()
+}
+
+/// The registry as JSON — what CLIs print and the web runtime serves for
+/// pickers (authoring's Skills menu, the standalone's actions view).
+pub fn skills_json() -> Json {
+    Json::Array(
+        SKILLS
+            .iter()
+            .map(|s| {
+                json!({
+                    "id": s.id,
+                    "title": s.title,
+                    "description": s.description,
+                    "parameters": s.parameters,
+                })
+            })
+            .collect(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -229,6 +297,17 @@ mod tests {
             generate_look_at(),
             "skills/look_at.json is stale"
         );
+    }
+
+    #[test]
+    fn registry_lists_look_at() {
+        let listed = skills_json();
+        assert_eq!(listed[0]["id"], "look_at");
+        assert_eq!(listed[0]["parameters"][1], "target");
+        assert!(skill("look_at").is_some());
+        assert!(skill("nope").is_none());
+        assert_eq!(embedded_graph_id("look_at"), "skill::look_at");
+        assert_eq!(skill_source("look_at"), Some(look_at_source()));
     }
 
     /// The fragment holds the placeholder contract the interpreter grafts

--- a/crates/interop/vizij-arora-web/src/lib.rs
+++ b/crates/interop/vizij-arora-web/src/lib.rs
@@ -400,6 +400,34 @@ pub fn standard_profile(id: &str, rig_prefix: &str) -> Result<JsValue, JsValue> 
     }
 }
 
+/// The skills Vizij ships (the look_at gaze skill, …) as a JS array of
+/// `{ id, title, description, parameters }` — the introspectable list an
+/// authoring app's Skills menu and a device's actions view offer.
+#[wasm_bindgen(js_name = skills)]
+pub fn skills() -> Result<JsValue, JsValue> {
+    let list = vizij_arora_host::skills::skills_json();
+    let json =
+        serde_json::to_string(&list).map_err(|e| JsValue::from_str(&format!("skills: {e}")))?;
+    js_sys::JSON::parse(&json)
+}
+
+/// A skill's canonical fragment graph as a JS object, ready to embed as the
+/// face's `skill::<id>` override. Face-independent by construction (its
+/// placeholder `task/*` paths are rewritten per run at graft time), so unlike
+/// a profile it takes no rig prefix. `null` for an unknown id (see
+/// [`skills`]).
+#[wasm_bindgen(js_name = skillSource)]
+pub fn skill_source(id: &str) -> Result<JsValue, JsValue> {
+    match vizij_arora_host::skills::skill_source(id) {
+        Some(spec) => {
+            let json = serde_json::to_string(&spec)
+                .map_err(|e| JsValue::from_str(&format!("skill {id}: {e}")))?;
+            js_sys::JSON::parse(&json)
+        }
+        None => Ok(JsValue::NULL),
+    }
+}
+
 /// The composed behavior graph of a face bundle — the composition the native
 /// `vizij` app deploys: the bundle's base graphs, its embedded standard
 /// profiles (each suppressing the built-in of the same id — an embedded copy

--- a/crates/vizij/src/device.rs
+++ b/crates/vizij/src/device.rs
@@ -221,7 +221,7 @@ pub fn start(glb: &Path, config: FaceConfig, bridges: BridgeConfig, mode: Mode) 
                     if config.stage_neutral {
                         stage_neutral_pose(&store, &meta);
                     }
-                    let Some(builder) = builder_for(&spec, rig, store) else {
+                    let Some(builder) = builder_for(&spec, rig, store, &meta.bundle.skills) else {
                         return;
                     };
                     match builder.build() {
@@ -250,6 +250,7 @@ pub(crate) fn builder_for(
     spec: &str,
     rig: RigHal,
     store: BlackboardStore,
+    embedded_skills: &[(String, serde_json::Value)],
 ) -> Option<arora::AroraBuilder> {
     let spec = match parse_spec(spec) {
         Ok(spec) => spec,
@@ -269,8 +270,12 @@ pub(crate) fn builder_for(
     // in-process transport call) to the host module registered below.
     graph.set_function_modules(animation::function_modules());
     // The gaze skill: the described contract rides the gaze module; the
-    // behavior is the shipped fragment the interpreter grafts per goal.
-    graph.set_task_fragment(gaze::look_at_id(), gaze::look_at_fragment());
+    // behavior is the shipped fragment the interpreter grafts per goal — or
+    // the face's embedded override.
+    graph.set_task_fragment(
+        gaze::look_at_id(),
+        gaze::look_at_fragment_from(embedded_skills),
+    );
     Some(
         arora::Arora::builder()
             .with_hal(Box::new(rig))
@@ -334,7 +339,7 @@ fn supervise(
         if config.stage_neutral {
             stage_neutral_pose(&store, &meta);
         }
-        let Some(builder) = builder_for(&spec, rig, store) else {
+        let Some(builder) = builder_for(&spec, rig, store, &meta.bundle.skills) else {
             return;
         };
         let (stop_tx, stop_rx) = futures::channel::oneshot::channel();
@@ -440,7 +445,7 @@ mod tests {
         let spec = compose_sources(&[animations_source()])
             .expect("compose the animation source")
             .to_string();
-        let mut arora = builder_for(&spec, RigHal::new(), BlackboardStore::new())
+        let mut arora = builder_for(&spec, RigHal::new(), BlackboardStore::new(), &[])
             .expect("build the device over the loaded animation module")
             .build()
             .expect("build arora");
@@ -491,6 +496,7 @@ mod tests {
             r#"{ "nodes": [], "edges": [] }"#,
             RigHal::new(),
             BlackboardStore::new(),
+            &[],
         )
         .expect("build the device")
         .with_host_module(gaze)
@@ -553,6 +559,7 @@ mod tests {
             r#"{ "nodes": [], "edges": [] }"#,
             RigHal::new(),
             BlackboardStore::new(),
+            &[],
         )
         .expect("build the device")
         .build()
@@ -617,6 +624,73 @@ mod tests {
         );
     }
 
+    /// A face's bundle-embedded `skill::look_at` fragment overrides the
+    /// shipped behavior — the `standard::<id>` precedence, applied to the
+    /// skill plane. The override here redirects the gaze write to a marker
+    /// key, proving the embedded copy (not the built-in) serves the run.
+    #[test]
+    fn the_face_embedded_skill_fragment_overrides_the_built_in() {
+        use arora_behavior::{interpreter_module, RunPolicy};
+        use arora_types::call::Call;
+        use arora_types::gen_uuid_from_str;
+        use arora_types::value::StructureField;
+        use vizij_arora_host::skills;
+
+        use crate::gaze;
+
+        let edited =
+            skills::LOOK_AT_JSON.replace(ros4hri::GAZE_TARGET_KEY, "test/edited/gaze/target");
+        let embedded = vec![(
+            "look_at".to_string(),
+            serde_json::from_str(&edited).expect("the edited fragment parses"),
+        )];
+
+        let mut arora = builder_for(
+            r#"{ "nodes": [], "edges": [] }"#,
+            RigHal::new(),
+            BlackboardStore::new(),
+            &embedded,
+        )
+        .expect("build the device")
+        .build()
+        .expect("build arora");
+
+        let look_at = Call {
+            module_id: Some(gaze::module_id()),
+            id: gaze::look_at_id(),
+            args: vec![StructureField {
+                id: gen_uuid_from_str("target"),
+                value: Box::new(Value::ArrayF32(vec![7.0, 8.0, 9.0])),
+            }],
+        };
+        arora
+            .call(interpreter_module::encode_spawn(
+                &look_at,
+                RunPolicy::Concurrent,
+            ))
+            .expect("SPAWN dispatches through the engine");
+        arora.step(Duration::from_millis(16)).expect("step");
+
+        let read = |key: &str| {
+            arora
+                .store()
+                .read(std::slice::from_ref(&Key::from(key)))
+                .into_iter()
+                .next()
+                .flatten()
+        };
+        assert_eq!(
+            read("test/edited/gaze/target"),
+            Some(Value::ArrayF32(vec![7.0, 8.0, 9.0])),
+            "the embedded fragment's redirected write serves"
+        );
+        assert_eq!(
+            read(ros4hri::GAZE_TARGET_KEY),
+            None,
+            "the built-in fragment's write does not"
+        );
+    }
+
     use vizij_api_core::value::{as_float, text, vec3, Value};
     use vizij_arora_host::ros4hri::{self, ros4hri_source};
     use vizij_arora_host::standard;
@@ -628,7 +702,7 @@ mod tests {
         let spec = compose_sources(&[ros4hri_source("")])
             .expect("compose the ros4hri profile")
             .to_string();
-        builder_for(&spec, RigHal::new(), BlackboardStore::new())
+        builder_for(&spec, RigHal::new(), BlackboardStore::new(), &[])
             .expect("build the device over the profile")
             .build()
             .expect("build arora")
@@ -692,7 +766,7 @@ mod tests {
             )
             .expect("compose the face with its embedded profile")
             .to_string();
-        let mut arora = builder_for(&spec, RigHal::new(), BlackboardStore::new())
+        let mut arora = builder_for(&spec, RigHal::new(), BlackboardStore::new(), &[])
             .expect("build the device over the composed face")
             .build()
             .expect("build arora");
@@ -864,7 +938,7 @@ mod tests {
         let (_, meta, spec) = load_face(&path, &config).expect("load the adapted face");
         let store = BlackboardStore::new();
         stage_neutral_pose(&store, &meta);
-        let mut arora = builder_for(&spec, RigHal::new(), store)
+        let mut arora = builder_for(&spec, RigHal::new(), store, &[])
             .expect("build the device")
             .build()
             .expect("build arora");

--- a/crates/vizij/src/gaze.rs
+++ b/crates/vizij/src/gaze.rs
@@ -35,11 +35,37 @@ pub fn look_at_id() -> Uuid {
 /// The look_at task fragment, parsed from the shipped asset — what the
 /// device's interpreter grafts per goal.
 pub fn look_at_fragment() -> TaskFragment {
-    let parameters: HashMap<Uuid, String> = skills::LOOK_AT_PARAMS
+    TaskFragment::parse(skills::LOOK_AT_JSON, look_at_parameters())
+        .expect("the shipped look_at asset parses")
+}
+
+/// The look_at fragment the device registers, honoring the face's pinned
+/// override: a bundle-embedded `skill::look_at` fragment replaces the shipped
+/// behavior (the `standard::<id>` precedence, applied to the skill plane). An
+/// embedded fragment that does not hold the task contract is refused loudly
+/// and the built-in serves.
+pub fn look_at_fragment_from(embedded: &[(String, serde_json::Value)]) -> TaskFragment {
+    if let Some((_, spec)) = embedded
+        .iter()
+        .find(|(id, _)| id == skills::LOOK_AT_FUNCTION)
+    {
+        match TaskFragment::parse(&spec.to_string(), look_at_parameters()) {
+            Ok(fragment) => {
+                log::info!("look_at: the face's embedded skill fragment overrides the built-in");
+                return fragment;
+            }
+            Err(e) => log::warn!("embedded look_at fragment refused ({e}); the built-in serves"),
+        }
+    }
+    look_at_fragment()
+}
+
+/// The parameter `id → name` map shared by the fragment and the signature.
+fn look_at_parameters() -> HashMap<Uuid, String> {
+    skills::LOOK_AT_PARAMS
         .iter()
         .map(|name| (gen_uuid_from_str(name), name.to_string()))
-        .collect();
-    TaskFragment::parse(skills::LOOK_AT_JSON, parameters).expect("the shipped look_at asset parses")
+        .collect()
 }
 
 /// The described look_at signature: `(policy, target, frame)` returning the

--- a/crates/vizij/src/ros2_tests.rs
+++ b/crates/vizij/src/ros2_tests.rs
@@ -154,6 +154,7 @@ async fn the_look_at_skill_serves_the_standard_contract_on_the_vizij_device() {
         r#"{ "nodes": [], "edges": [] }"#,
         RigHal::new(),
         store.clone(),
+        &[],
     )
     .expect("build the device")
     .with_host_module(speak_module())

--- a/npm/@vizij/runtime/package.json
+++ b/npm/@vizij/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vizij/runtime",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Run a Vizij runtime in the browser as an Arora device: wasm bindings over arora-web's BrowserRuntime.",
   "license": "MIT",
   "repository": {

--- a/npm/@vizij/runtime/src/index.ts
+++ b/npm/@vizij/runtime/src/index.ts
@@ -45,6 +45,21 @@ export interface StandardProfile {
 }
 
 /**
+ * A skill Vizij ships — a spawnable task-run behavior (a graph fragment the
+ * device grafts per goal), served to ROS as a standard action (e.g. the
+ * look_at gaze skill behind `/skill/look_at`). Listed by {@link skills}; its
+ * canonical fragment is fetched with {@link skillSource}.
+ */
+export interface Skill {
+  id: string;
+  title: string;
+  description: string;
+  /** The skill's parameter names, in declared order — the fragment's
+   * `task/<param>` inputs and the described signature's arguments. */
+  parameters: string[];
+}
+
+/**
  * A spec-level graph edit — `{ upsert_nodes, remove_nodes, upsert_edges,
  * remove_edges }` in the Vizij spec vocabulary, or a JSON string of the same.
  * Every edge incident to an upserted node must appear in `upsert_edges`.
@@ -98,6 +113,8 @@ interface WasmBindings {
   };
   standardProfiles(): StandardProfile[];
   standardProfile(id: string, rig_prefix: string): object | null;
+  skills(): Skill[];
+  skillSource(id: string): object | null;
   composeFace(gltf_json: string, options_json?: string): object;
 }
 
@@ -380,6 +397,28 @@ export async function standardProfile(
 ): Promise<object | null> {
   await init(input);
   return bindingCache.current!.standardProfile(id, rigPrefix);
+}
+
+/**
+ * The skills Vizij ships (the look_at gaze skill, …) — the introspectable
+ * list an authoring app's Skills menu and a device's actions view offer.
+ * Calls {@link init} if it has not run yet.
+ */
+export async function skills(input?: InitInput): Promise<Skill[]> {
+  await init(input);
+  return bindingCache.current!.skills();
+}
+
+/**
+ * A skill's canonical fragment graph as a spec object, ready to embed into a
+ * face GLB as its `skill::<id>` override of the shipped behavior. Skill
+ * fragments are face-independent by construction (their placeholder `task/*`
+ * paths are rewritten per run), so there is no rig prefix to apply or strip.
+ * `null` for an unknown id (see {@link skills}).
+ */
+export async function skillSource(id: string, input?: InitInput): Promise<object | null> {
+  await init(input);
+  return bindingCache.current!.skillSource(id);
 }
 
 /** Options for {@link composeFace}; every field falls back to the native


### PR DESCRIPTION
The vizij-rs half of [VIZ-96](https://linear.app/semio-ai/issue/VIZ-96/skills-join-the-profile-surface-standalone-authoring-access-and): skills join the profile surface, so the authoring app and the standalone can list, fetch, and override them exactly like standard profiles.

- **`vizij-arora-host::skills` gains the registry** the profiles module has: `Skill { id, title, description, parameters }`, `skills_json()` for pickers, `skill_source(id)` for the canonical fragment, `SKILL_KIND`/`embedded_graph_id` (`skill::<id>`).
- **`Bundle` recognizes the `skill` graph-entry kind** — a face's pinned override of a shipped behavior, held apart from the composed graphs (a fragment grafts per run, it never composes).
- **The native device honors the override**: `builder_for` takes the bundle's embedded skills and registers a face's `skill::look_at` fragment in place of the built-in — refused loudly (and the built-in serves) when it does not hold the task contract. Proven by `the_face_embedded_skill_fragment_overrides_the_built_in`: an embedded fragment with a redirected gaze write serves the run, the built-in's write does not appear.
- **The wasm runtime exports `skills()` / `skillSource(id)`** beside `standardProfiles()`, and **`@vizij/runtime` 2.4.0** wraps them. Skill fragments are face-independent by construction (placeholder `task/*` paths, rewritten per run) — no rig prefix to apply or strip.

The vizij-web half (authoring's File → Skills submenu + editor session, the standalone actions view) follows on this API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)