### PR TITLE
feat(vizij): local TTS provider — Piper with phoneme alignments (tts-piper)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2639,6 +2639,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.13.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex 1.3.0",
+ "syn 2.0.119",
+ "which",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2985,7 +3008,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -3028,6 +3051,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
 
 [[package]]
 name = "cfg-if"
@@ -3108,6 +3140,17 @@ dependencies = [
  "crypto-common",
  "inout",
  "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -5380,9 +5423,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.4",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -5773,6 +5818,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -7823,6 +7877,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8484,6 +8548,7 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
  "h2",
@@ -8495,6 +8560,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "mime_guess",
  "percent-encoding",
  "pin-project-lite",
@@ -9300,6 +9366,12 @@ dependencies = [
 
 [[package]]
 name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
@@ -9516,6 +9588,26 @@ dependencies = [
  "rustix 1.1.4",
  "uuid",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "soloud"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acd858ec6a193e50d4b8fe23e4e143f20e72cbfaa30b338d97c53de7f95d9add"
+dependencies = [
+ "bitflags 2.13.0",
+ "paste",
+ "soloud-sys",
+]
+
+[[package]]
+name = "soloud-sys"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e67f2813f8e234bee15d2457e19cd7d7f8c5908b3c85b1a5b3296abb7606ab"
+dependencies = [
+ "cmake",
 ]
 
 [[package]]
@@ -9819,6 +9911,27 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "windows 0.62.2",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -10694,9 +10807,11 @@ dependencies = [
  "image",
  "log",
  "rand 0.9.5",
+ "reqwest",
  "ros2-client-multi-rmw 0.11.0",
  "serde",
  "serde_json",
+ "soloud",
  "tokio",
  "tracing",
  "uuid",
@@ -10709,6 +10824,7 @@ dependencies = [
  "vizij-arora-store",
  "vizij-bundle",
  "vizij-graph-core",
+ "vizij-piper",
 ]
 
 [[package]]
@@ -10921,6 +11037,13 @@ dependencies = [
  "vizij-api-core",
  "vizij-graph-core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "vizij-piper"
+version = "0.0.0"
+dependencies = [
+ "bindgen",
 ]
 
 [[package]]
@@ -11816,6 +11939,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
 name = "wide"
 version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12058,6 +12193,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core 0.62.2",
  "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "crates/interop/vizij-arora-hal",
   "crates/interop/vizij-arora-behavior",
   "crates/interop/vizij-arora-host",
+  "crates/interop/vizij-piper",
   "crates/tools/vizij-bundle",
   "crates/tools/vizij-glb-migrate",
   "crates/vizij",

--- a/crates/interop/vizij-piper/Cargo.toml
+++ b/crates/interop/vizij-piper/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "vizij-piper"
+version = "0.0.0"
+edition = { workspace = true }
+publish = false
+description = "Piper TTS with phoneme alignments, self-provisioning: the build downloads and patches the default voice and builds libpiper, so a consumer needs no configuration."
+# libpiper and espeak-ng are GPLv3: enabling this crate makes the linking binary
+# GPL-affected. The vizij app only links it behind its opt-in `tts-piper`
+# feature, keeping default builds GPL-free.
+license = "GPL-3.0-or-later"
+
+[build-dependencies]
+bindgen = "0.69"

--- a/crates/interop/vizij-piper/Cargo.toml
+++ b/crates/interop/vizij-piper/Cargo.toml
@@ -8,6 +8,10 @@ description = "Piper TTS with phoneme alignments, self-provisioning: the build d
 # GPL-affected. The vizij app only links it behind its opt-in `tts-piper`
 # feature, keeping default builds GPL-free.
 license = "GPL-3.0-or-later"
+# The `links` key opens the DEP_PIPER_* metadata channel: consumers read
+# DEP_PIPER_INSTALL_DIR in their own build script to add the dylib rpath
+# (rustc-link-arg does not propagate across crates).
+links = "piper"
 
 [build-dependencies]
 bindgen = "0.69"

--- a/crates/interop/vizij-piper/build.rs
+++ b/crates/interop/vizij-piper/build.rs
@@ -243,8 +243,7 @@ fn ensure_soname_links(lib_dir: &Path) {
         };
         let link = lib_dir.join(format!("{}.so.{major}", &name[..so_pos]));
         if !link.exists() {
-            std::os::unix::fs::symlink(entry.path(), &link)
-                .expect("create the SONAME symlink");
+            std::os::unix::fs::symlink(entry.path(), &link).expect("create the SONAME symlink");
         }
     }
 }

--- a/crates/interop/vizij-piper/build.rs
+++ b/crates/interop/vizij-piper/build.rs
@@ -53,6 +53,10 @@ fn main() {
         "cargo:rustc-link-arg=-Wl,-rpath,{}",
         install.join("lib").display()
     );
+    // Exported over the DEP_PIPER_* channel (`links = "piper"`): the link-args
+    // above cover only THIS crate's artifacts, so a consumer binary must add
+    // the rpath itself — from DEP_PIPER_INSTALL_DIR in its own build script.
+    println!("cargo:install_dir={}", install.display());
 
     // Baked-in defaults the library falls back to when the env vars are unset.
     println!(

--- a/crates/interop/vizij-piper/build.rs
+++ b/crates/interop/vizij-piper/build.rs
@@ -164,8 +164,56 @@ fn build_libpiper(cache: &Path) -> PathBuf {
         .current_dir(cache)
         .arg("--install")
         .arg(&build));
-    ensure_soname_links(&install.join("lib"));
+    // Guarantee the onnxruntime shared libraries are staged: on some platforms
+    // libpiper's install step does not carry its prebuilt onnxruntime along —
+    // pull any missing ones over from the build tree.
+    copy_missing_onnxruntime(&build, &install.join("lib"));
+    for dir in ["", "lib", "lib64"] {
+        ensure_soname_links(&install.join(dir));
+    }
+    // CI-only layout dump: cargo:warning always prints, so a loader failure in
+    // the workflow log comes with the install layout it failed against.
+    if env::var("CI").is_ok() {
+        for dir in ["", "lib", "lib64"] {
+            if let Ok(entries) = std::fs::read_dir(install.join(dir)) {
+                for entry in entries.flatten() {
+                    println!(
+                        "cargo:warning=piper install: {dir}/{}",
+                        entry.file_name().to_string_lossy()
+                    );
+                }
+            }
+        }
+    }
     install
+}
+
+/// Copy every `libonnxruntime*` shared object found in the build tree into the
+/// install's lib dir, unless a file of that name is already staged.
+fn copy_missing_onnxruntime(build: &Path, lib_dir: &Path) {
+    std::fs::create_dir_all(lib_dir).expect("create the install lib dir");
+    let mut stack = vec![build.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            let name = entry.file_name();
+            let name = name.to_string_lossy().into_owned();
+            if !name.starts_with("libonnxruntime") {
+                continue;
+            }
+            let dest = lib_dir.join(&name);
+            if !dest.exists() {
+                std::fs::copy(&path, &dest).expect("stage an onnxruntime library");
+            }
+        }
+    }
 }
 
 /// The onnxruntime prebuilt installs `libX.so.1.22.0` without the `libX.so.1`
@@ -174,7 +222,7 @@ fn build_libpiper(cache: &Path) -> PathBuf {
 /// macOS, whose dylib naming is complete).
 fn ensure_soname_links(lib_dir: &Path) {
     let Ok(entries) = std::fs::read_dir(lib_dir) else {
-        return;
+        return; // the layout varies by platform; absent dirs are fine
     };
     for entry in entries.flatten() {
         let name = entry.file_name();

--- a/crates/interop/vizij-piper/build.rs
+++ b/crates/interop/vizij-piper/build.rs
@@ -48,6 +48,11 @@ fn main() {
     );
     println!("cargo:rustc-link-lib=dylib=piper");
     println!("cargo:rustc-link-lib=dylib=onnxruntime");
+    // Linux: old-style DT_RPATH (transitive) — RUNPATH would not be searched
+    // when libpiper.so resolves its own libonnxruntime dependency.
+    if target_os == "linux" {
+        println!("cargo:rustc-link-arg=-Wl,--disable-new-dtags");
+    }
     println!("cargo:rustc-link-arg=-Wl,-rpath,{}", install.display());
     println!(
         "cargo:rustc-link-arg=-Wl,-rpath,{}",

--- a/crates/interop/vizij-piper/build.rs
+++ b/crates/interop/vizij-piper/build.rs
@@ -164,7 +164,36 @@ fn build_libpiper(cache: &Path) -> PathBuf {
         .current_dir(cache)
         .arg("--install")
         .arg(&build));
+    ensure_soname_links(&install.join("lib"));
     install
+}
+
+/// The onnxruntime prebuilt installs `libX.so.1.22.0` without the `libX.so.1`
+/// SONAME symlink libpiper's DT_NEEDED references — the loader then fails even
+/// with a correct rpath. Create any missing `libX.so.<major>` links (no-op on
+/// macOS, whose dylib naming is complete).
+fn ensure_soname_links(lib_dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(lib_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy().into_owned();
+        // libfoo.so.MAJOR.MINOR.PATCH -> libfoo.so.MAJOR
+        let Some(so_pos) = name.find(".so.") else {
+            continue;
+        };
+        let version = &name[so_pos + 4..];
+        let mut parts = version.split('.');
+        let (Some(major), Some(_minor)) = (parts.next(), parts.next()) else {
+            continue; // already a major-only name
+        };
+        let link = lib_dir.join(format!("{}.so.{major}", &name[..so_pos]));
+        if !link.exists() {
+            std::os::unix::fs::symlink(entry.path(), &link)
+                .expect("create the SONAME symlink");
+        }
+    }
 }
 
 /// Download the default voice (model + config) and patch the model for

--- a/crates/interop/vizij-piper/build.rs
+++ b/crates/interop/vizij-piper/build.rs
@@ -1,0 +1,468 @@
+//! Self-provisioning build: everything Piper needs, fetched and prepared here so
+//! `cargo build` is the whole setup — no API keys, no env vars, no manual steps.
+//!
+//! 1. Builds `libpiper` (cmake; it fetches espeak-ng and a prebuilt onnxruntime)
+//!    from a pinned piper1-gpl commit.
+//! 2. Downloads the default voice from Hugging Face.
+//! 3. Patches the voice for phoneme alignments — the upstream Python
+//!    `patch_voice_with_alignment` is a one-line graph edit (mark the model's
+//!    single `Ceil` tensor as a graph output), reimplemented below as a minimal
+//!    ONNX-protobuf surgery so the build needs no Python.
+//! 4. Bakes the resulting paths in as compile-time defaults (overridable at run
+//!    time via `PIPER_VOICE` / `PIPER_VOICE_CONFIG` / `PIPER_ESPEAK_DATA`).
+//!
+//! Artifacts land in `~/.cache/vizij-piper` (override: `VIZIJ_PIPER_CACHE`), so
+//! they survive `cargo clean` and are shared across checkouts. Network is needed
+//! only on the first build.
+
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Pinned piper1-gpl commit (the revision validated in the Piper bootstrap
+/// exercise: exact alignment reconciliation on the Python and C APIs).
+const PIPER_COMMIT: &str = "4bfd11c5b5998660c52aaa743c4fa05717104e98";
+
+/// The default voice. Medium-quality US English — the bootstrap baseline voice.
+const VOICE: &str = "en_US-lessac-medium";
+const VOICE_URL_DIR: &str =
+    "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/lessac/medium";
+
+fn main() {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if target_os == "windows" {
+        panic!("vizij-piper: Windows is not supported yet (libpiper build scripting)");
+    }
+
+    let cache = cache_dir();
+    std::fs::create_dir_all(&cache).expect("create the vizij-piper cache dir");
+
+    let install = build_libpiper(&cache);
+    let (voice, voice_config) = provision_voice(&cache);
+
+    // Link + rpath (the dylibs stay in the cache install; rpath finds them).
+    println!("cargo:rustc-link-search=native={}", install.display());
+    println!(
+        "cargo:rustc-link-search=native={}",
+        install.join("lib").display()
+    );
+    println!("cargo:rustc-link-lib=dylib=piper");
+    println!("cargo:rustc-link-lib=dylib=onnxruntime");
+    println!("cargo:rustc-link-arg=-Wl,-rpath,{}", install.display());
+    println!(
+        "cargo:rustc-link-arg=-Wl,-rpath,{}",
+        install.join("lib").display()
+    );
+
+    // Baked-in defaults the library falls back to when the env vars are unset.
+    println!(
+        "cargo:rustc-env=VIZIJ_PIPER_DEFAULT_ESPEAK_DATA={}",
+        install.join("espeak-ng-data").display()
+    );
+    println!(
+        "cargo:rustc-env=VIZIJ_PIPER_DEFAULT_VOICE={}",
+        voice.display()
+    );
+    println!(
+        "cargo:rustc-env=VIZIJ_PIPER_DEFAULT_VOICE_CONFIG={}",
+        voice_config.display()
+    );
+
+    generate_bindings(&install);
+}
+
+fn cache_dir() -> PathBuf {
+    if let Ok(dir) = env::var("VIZIJ_PIPER_CACHE") {
+        return PathBuf::from(dir);
+    }
+    let home = env::var("HOME").expect("HOME (or set VIZIJ_PIPER_CACHE)");
+    PathBuf::from(home).join(".cache/vizij-piper")
+}
+
+/// Build libpiper once per (commit, target); reuse the cached install afterward.
+fn build_libpiper(cache: &Path) -> PathBuf {
+    let target = env::var("TARGET").unwrap();
+    let install = cache.join(format!("libpiper-{}-{target}", &PIPER_COMMIT[..12]));
+    let lib_name = if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        "libpiper.dylib"
+    } else {
+        "libpiper.so"
+    };
+    if install.join(lib_name).exists() && install.join("espeak-ng-data").exists() {
+        return install;
+    }
+
+    // Short directory names on purpose: espeak-ng's data compiler holds paths
+    // in a ~160-byte buffer, and deep build paths get silently truncated
+    // (observed as `Bad vowel file` / truncated file names). Keep the whole
+    // espeak build path comfortably under that.
+    let src = cache.join(format!("src-{}", &PIPER_COMMIT[..12]));
+    if !src.join("libpiper/CMakeLists.txt").exists() {
+        let url = format!("https://github.com/OHF-Voice/piper1-gpl/archive/{PIPER_COMMIT}.tar.gz");
+        run(Command::new("sh").arg("-c").arg(format!(
+            "curl -fsSL '{url}' | tar xz -C '{}'",
+            cache.display()
+        )));
+        let unpacked = cache.join(format!("piper1-gpl-{PIPER_COMMIT}"));
+        std::fs::rename(&unpacked, &src).expect("rename the unpacked piper source");
+        assert!(
+            src.join("libpiper/CMakeLists.txt").exists(),
+            "piper source tarball did not unpack where expected"
+        );
+    }
+    let espeak_build_path_len = src
+        .join("libpiper/build/espeak_ng/src/espeak_ng_external-build")
+        .as_os_str()
+        .len();
+    assert!(
+        espeak_build_path_len < 140,
+        "the build path is too deep for espeak-ng's fixed path buffers \
+         ({espeak_build_path_len} chars) — set VIZIJ_PIPER_CACHE to a shorter directory"
+    );
+
+    let build = src.join("libpiper/build");
+    // current_dir(cache): libpiper's cmake drops a `download/` dir (the
+    // onnxruntime archive) relative to the working directory — keep it in the
+    // cache, never in the crate.
+    run(Command::new("cmake")
+        .current_dir(cache)
+        .arg("-B")
+        .arg(&build)
+        .arg("-S")
+        .arg(src.join("libpiper"))
+        .arg("-DCMAKE_BUILD_TYPE=Release")
+        .arg(format!("-DCMAKE_INSTALL_PREFIX={}", install.display())));
+    // espeak-ng's data compiler resolves `../phsource` / `../dictsource`
+    // relative to ESPEAK_DATA_PATH (the external project's build dir), i.e. one
+    // level ABOVE it — where nothing puts them. Pre-plant symlinks to the
+    // (future) espeak checkout; they dangle until the external project clones,
+    // then resolve. Observed as `phsource/intonation: No such file or
+    // directory` during `Compile intonations` otherwise.
+    let espeak_src = build.join("espeak_ng/src");
+    std::fs::create_dir_all(&espeak_src).expect("create the espeak src dir");
+    for dir in ["phsource", "dictsource"] {
+        let link = espeak_src.join(dir);
+        let target = espeak_src.join("espeak_ng_external").join(dir);
+        let _ = std::fs::remove_file(&link);
+        std::os::unix::fs::symlink(&target, &link).expect("plant the espeak data symlink");
+    }
+    // Sequential on purpose: espeak-ng's data generation is order-sensitive
+    // under a parallel make, and cargo exports its jobserver through MAKEFLAGS
+    // (which would re-parallelize the child make) — scrub it.
+    run(Command::new("cmake")
+        .current_dir(cache)
+        .arg("--build")
+        .arg(&build)
+        .env_remove("MAKEFLAGS")
+        .env_remove("MFLAGS")
+        .env_remove("CARGO_MAKEFLAGS"));
+    run(Command::new("cmake")
+        .current_dir(cache)
+        .arg("--install")
+        .arg(&build));
+    install
+}
+
+/// Download the default voice (model + config) and patch the model for
+/// alignments. Idempotent: the patched model is cached.
+fn provision_voice(cache: &Path) -> (PathBuf, PathBuf) {
+    let voices = cache.join("voices");
+    std::fs::create_dir_all(&voices).expect("create the voices dir");
+    let model = voices.join(format!("{VOICE}.onnx"));
+    let config = voices.join(format!("{VOICE}.onnx.json"));
+    let patched = voices.join(format!("{VOICE}.alignment.onnx"));
+
+    if !config.exists() {
+        download(&format!("{VOICE_URL_DIR}/{VOICE}.onnx.json"), &config);
+    }
+    if !patched.exists() {
+        if !model.exists() {
+            download(&format!("{VOICE_URL_DIR}/{VOICE}.onnx"), &model);
+        }
+        let bytes = std::fs::read(&model).expect("read the downloaded voice model");
+        let out = patch_alignment(&bytes).expect("patch the voice for alignments");
+        std::fs::write(&patched, out).expect("write the patched voice model");
+    }
+    // libpiper resolves `<model>.json` when no config is given; our wrapper
+    // passes the config path explicitly, so the `.alignment.onnx` name is fine.
+    (patched, config)
+}
+
+fn download(url: &str, to: &Path) {
+    let tmp = to.with_extension("part");
+    run(Command::new("curl")
+        .arg("-fsSL")
+        .arg("--retry")
+        .arg("3")
+        .arg("-o")
+        .arg(&tmp)
+        .arg(url));
+    std::fs::rename(&tmp, to).expect("move the downloaded file into place");
+}
+
+fn run(cmd: &mut Command) {
+    let desc = format!("{cmd:?}");
+    let status = cmd.status().unwrap_or_else(|e| panic!("spawn {desc}: {e}"));
+    assert!(status.success(), "command failed: {desc}");
+}
+
+fn generate_bindings(install: &Path) {
+    let bindings = bindgen::Builder::default()
+        .header(install.join("include/piper.h").to_str().unwrap())
+        // macOS's C SDK ships no uchar.h (char32_t); libc++ does — parse the
+        // header as C++. Linux is fine either way.
+        .clang_args(["-x", "c++", "-std=c++17"])
+        .clang_arg(format!("-I{}", install.join("include").display()))
+        .allowlist_function("piper_.*")
+        .allowlist_type("piper_.*")
+        .allowlist_var("PIPER_.*")
+        .generate()
+        .expect("bindgen over piper.h");
+    bindings
+        .write_to_file(PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs"))
+        .expect("write bindings.rs");
+}
+
+// ONNX alignment patch — a minimal protobuf surgery.
+//==============================================================================
+// Upstream's `piper.patch_voice_with_alignment` marks the model's single `Ceil`
+// tensor as a graph output, exposing per-phoneme-id sample counts. In protobuf
+// terms: find GraphProto.node (field 1) with NodeProto.op_type (field 4) ==
+// "Ceil", take its NodeProto.output (field 2), and append a
+// ValueInfoProto { name (field 1) } to GraphProto.output (field 12) inside
+// ModelProto.graph (field 7). Only the two enclosing length prefixes change.
+
+fn patch_alignment(model: &[u8]) -> Result<Vec<u8>, String> {
+    // Locate the graph field (7, length-delimited) among ModelProto's fields.
+    let mut pos = 0usize;
+    let mut graph_span = None;
+    while pos < model.len() {
+        let (tag, p) = read_varint(model, pos)?;
+        let field = (tag >> 3) as u32;
+        let wire = (tag & 7) as u8;
+        pos = p;
+        match wire {
+            0 => {
+                let (_, p) = read_varint(model, pos)?;
+                pos = p;
+            }
+            2 => {
+                let (len, p) = read_varint(model, pos)?;
+                let start = p;
+                let end = start + len as usize;
+                if field == 7 {
+                    graph_span = Some((start, end));
+                }
+                pos = end;
+            }
+            5 => pos += 4,
+            1 => pos += 8,
+            w => return Err(format!("unexpected wire type {w} in ModelProto")),
+        }
+    }
+    let (gstart, gend) = graph_span.ok_or("no graph field in ModelProto")?;
+    let graph = &model[gstart..gend];
+
+    // Scan the graph: collect the Ceil node's output name and the existing
+    // graph outputs (for idempotency).
+    let mut ceil_outputs: Vec<String> = Vec::new();
+    let mut existing_outputs: Vec<String> = Vec::new();
+    let mut pos = 0usize;
+    while pos < graph.len() {
+        let (tag, p) = read_varint(graph, pos)?;
+        let field = (tag >> 3) as u32;
+        let wire = (tag & 7) as u8;
+        pos = p;
+        match wire {
+            0 => {
+                let (_, p) = read_varint(graph, pos)?;
+                pos = p;
+            }
+            2 => {
+                let (len, p) = read_varint(graph, pos)?;
+                let start = p;
+                let end = start + len as usize;
+                match field {
+                    1 => {
+                        // NodeProto: op_type (4, string), output (2, string).
+                        let node = &graph[start..end];
+                        let (op, outs) = scan_node(node)?;
+                        if op == "Ceil" {
+                            ceil_outputs.extend(outs);
+                        }
+                    }
+                    12 => {
+                        // ValueInfoProto: name (1, string).
+                        if let Some(name) = scan_value_info_name(&graph[start..end])? {
+                            existing_outputs.push(name);
+                        }
+                    }
+                    _ => {}
+                }
+                pos = end;
+            }
+            5 => pos += 4,
+            1 => pos += 8,
+            w => return Err(format!("unexpected wire type {w} in GraphProto")),
+        }
+    }
+
+    let ceil = match ceil_outputs.as_slice() {
+        [] => return Err("no Ceil node found — not a Piper VITS voice?".into()),
+        [one] => one.clone(),
+        many => {
+            return Err(format!(
+                "multiple Ceil tensors, cannot autodetect: {many:?}"
+            ))
+        }
+    };
+    if existing_outputs.iter().any(|n| n == &ceil) {
+        return Ok(model.to_vec()); // already patched
+    }
+
+    // Encode ValueInfoProto { name = ceil } and wrap it as graph field 12.
+    let mut vi = Vec::new();
+    vi.push(1 << 3 | 2);
+    write_varint(&mut vi, ceil.len() as u64);
+    vi.extend_from_slice(ceil.as_bytes());
+    let mut appended = Vec::new();
+    appended.push(12 << 3 | 2);
+    write_varint(&mut appended, vi.len() as u64);
+    appended.extend_from_slice(&vi);
+
+    // Re-emit the ModelProto stream, copying every field and growing the graph
+    // field by the appended output.
+    let mut out = Vec::with_capacity(model.len() + appended.len() + 8);
+    let mut pos = 0usize;
+    while pos < model.len() {
+        let field_start = pos;
+        let (tag, p) = read_varint(model, pos)?;
+        let field = (tag >> 3) as u32;
+        let wire = (tag & 7) as u8;
+        pos = p;
+        match wire {
+            2 => {
+                let (len, p) = read_varint(model, pos)?;
+                let start = p;
+                let end = start + len as usize;
+                if field == 7 {
+                    write_varint(&mut out, tag);
+                    write_varint(&mut out, len + appended.len() as u64);
+                    out.extend_from_slice(&model[start..end]);
+                    out.extend_from_slice(&appended);
+                } else {
+                    out.extend_from_slice(&model[field_start..end]);
+                }
+                pos = end;
+            }
+            0 => {
+                let (_, p) = read_varint(model, pos)?;
+                out.extend_from_slice(&model[field_start..p]);
+                pos = p;
+            }
+            5 => {
+                out.extend_from_slice(&model[field_start..pos + 4]);
+                pos += 4;
+            }
+            1 => {
+                out.extend_from_slice(&model[field_start..pos + 8]);
+                pos += 8;
+            }
+            w => return Err(format!("unexpected wire type {w} in ModelProto")),
+        }
+    }
+    Ok(out)
+}
+
+/// NodeProto: return (op_type, output names).
+fn scan_node(node: &[u8]) -> Result<(String, Vec<String>), String> {
+    let mut op = String::new();
+    let mut outs = Vec::new();
+    let mut pos = 0usize;
+    while pos < node.len() {
+        let (tag, p) = read_varint(node, pos)?;
+        let field = (tag >> 3) as u32;
+        let wire = (tag & 7) as u8;
+        pos = p;
+        match wire {
+            0 => {
+                let (_, p) = read_varint(node, pos)?;
+                pos = p;
+            }
+            2 => {
+                let (len, p) = read_varint(node, pos)?;
+                let start = p;
+                let end = start + len as usize;
+                match field {
+                    2 => outs.push(String::from_utf8_lossy(&node[start..end]).into_owned()),
+                    4 => op = String::from_utf8_lossy(&node[start..end]).into_owned(),
+                    _ => {}
+                }
+                pos = end;
+            }
+            5 => pos += 4,
+            1 => pos += 8,
+            w => return Err(format!("unexpected wire type {w} in NodeProto")),
+        }
+    }
+    Ok((op, outs))
+}
+
+/// ValueInfoProto: return the name (field 1) if present.
+fn scan_value_info_name(vi: &[u8]) -> Result<Option<String>, String> {
+    let mut pos = 0usize;
+    while pos < vi.len() {
+        let (tag, p) = read_varint(vi, pos)?;
+        let field = (tag >> 3) as u32;
+        let wire = (tag & 7) as u8;
+        pos = p;
+        match wire {
+            0 => {
+                let (_, p) = read_varint(vi, pos)?;
+                pos = p;
+            }
+            2 => {
+                let (len, p) = read_varint(vi, pos)?;
+                let start = p;
+                let end = start + len as usize;
+                if field == 1 {
+                    return Ok(Some(String::from_utf8_lossy(&vi[start..end]).into_owned()));
+                }
+                pos = end;
+            }
+            5 => pos += 4,
+            1 => pos += 8,
+            w => return Err(format!("unexpected wire type {w} in ValueInfoProto")),
+        }
+    }
+    Ok(None)
+}
+
+fn read_varint(buf: &[u8], mut pos: usize) -> Result<(u64, usize), String> {
+    let mut value = 0u64;
+    let mut shift = 0u32;
+    loop {
+        let byte = *buf.get(pos).ok_or("varint past end of buffer")?;
+        pos += 1;
+        value |= u64::from(byte & 0x7f) << shift;
+        if byte & 0x80 == 0 {
+            return Ok((value, pos));
+        }
+        shift += 7;
+        if shift >= 64 {
+            return Err("varint too long".into());
+        }
+    }
+}
+
+fn write_varint(out: &mut Vec<u8>, mut value: u64) {
+    loop {
+        let byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value == 0 {
+            out.push(byte);
+            return;
+        }
+        out.push(byte | 0x80);
+    }
+}

--- a/crates/interop/vizij-piper/src/lib.rs
+++ b/crates/interop/vizij-piper/src/lib.rs
@@ -1,0 +1,224 @@
+//! Piper text-to-speech with phoneme alignments, over `libpiper` (FFI).
+//!
+//! Fully local: no network and no credentials at run time. The build script
+//! provisions everything (libpiper, espeak-ng data, a patched default voice)
+//! and bakes the paths in, so [`Synthesizer::new_default`] works with zero
+//! configuration; `PIPER_VOICE` / `PIPER_VOICE_CONFIG` / `PIPER_ESPEAK_DATA`
+//! override the defaults at run time.
+//!
+//! Alignments are per-phoneme sample counts produced in the same synthesis
+//! pass (no second alignment step). Two libpiper quirks found during
+//! validation are handled here:
+//! - `PIPER_DONE` can arrive with the final chunk still filled — a naive
+//!   break-on-DONE loop drops the last sentence;
+//! - the chunk's `phonemes` buffer is cumulative across sentences while
+//!   ids/alignments are per-sentence — decode past what previous chunks
+//!   consumed.
+
+#![allow(non_upper_case_globals, non_camel_case_types, non_snake_case)]
+
+mod ffi {
+    #![allow(dead_code, clippy::all)]
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+}
+
+use std::ffi::CString;
+
+/// One phoneme (or punctuation/marker pseudo-phoneme) with its timing.
+///
+/// Phonemes are espeak-ng symbols, not any viseme vocabulary — mapping them to
+/// mouth shapes is the caller's decision. Markers (`^` BOS, `$` EOS, stress and
+/// punctuation) appear in the stream and carry real durations; treat them as
+/// the rest pose.
+#[derive(Debug, Clone)]
+pub struct PhonemeEvent {
+    pub phoneme: String,
+    /// Start of the phoneme, in samples from the utterance start.
+    pub start_samples: i64,
+    /// Duration in samples.
+    pub dur_samples: i64,
+}
+
+/// Synthesized speech: mono float32 PCM plus the aligned phoneme timeline.
+pub struct Synthesis {
+    pub samples: Vec<f32>,
+    pub sample_rate: u32,
+    pub events: Vec<PhonemeEvent>,
+}
+
+/// A loaded Piper voice.
+pub struct Synthesizer {
+    raw: *mut ffi::piper_synthesizer,
+}
+
+// The synthesizer is used behind a lock by one caller at a time; libpiper has
+// no thread affinity (plain onnxruntime + espeak calls), it is just not
+// re-entrant — which the exclusive &mut receiver already guarantees.
+unsafe impl Send for Synthesizer {}
+
+impl Synthesizer {
+    /// The build-provisioned default voice and espeak data, overridable via
+    /// `PIPER_VOICE` / `PIPER_VOICE_CONFIG` / `PIPER_ESPEAK_DATA`.
+    pub fn new_default() -> Result<Self, String> {
+        let voice = std::env::var("PIPER_VOICE")
+            .unwrap_or_else(|_| env!("VIZIJ_PIPER_DEFAULT_VOICE").to_string());
+        let config = std::env::var("PIPER_VOICE_CONFIG")
+            .unwrap_or_else(|_| env!("VIZIJ_PIPER_DEFAULT_VOICE_CONFIG").to_string());
+        let espeak = std::env::var("PIPER_ESPEAK_DATA")
+            .unwrap_or_else(|_| env!("VIZIJ_PIPER_DEFAULT_ESPEAK_DATA").to_string());
+        Self::new(&voice, Some(&config), &espeak)
+    }
+
+    pub fn new(model: &str, config: Option<&str>, espeak_data: &str) -> Result<Self, String> {
+        let m = CString::new(model).map_err(|e| e.to_string())?;
+        let c = match config {
+            Some(c) => Some(CString::new(c).map_err(|e| e.to_string())?),
+            None => None,
+        };
+        let e = CString::new(espeak_data).map_err(|e| e.to_string())?;
+        let raw = unsafe {
+            ffi::piper_create(
+                m.as_ptr(),
+                c.as_ref().map_or(std::ptr::null(), |c| c.as_ptr()),
+                e.as_ptr(),
+            )
+        };
+        if raw.is_null() {
+            Err(format!("piper_create failed (model {model})"))
+        } else {
+            Ok(Self { raw })
+        }
+    }
+
+    /// Synthesize `text` in one pass: audio plus the aligned phoneme timeline.
+    ///
+    /// Blocking (model inference) — call it off any latency-sensitive thread.
+    pub fn synthesize(&mut self, text: &str) -> Result<Synthesis, String> {
+        let t = CString::new(text).map_err(|e| e.to_string())?;
+        let opts = unsafe { ffi::piper_default_synthesize_options(self.raw) };
+        let rc = unsafe { ffi::piper_synthesize_start(self.raw, t.as_ptr(), &opts) };
+        if rc != ffi::PIPER_OK as i32 {
+            return Err(format!("piper_synthesize_start failed: {rc}"));
+        }
+
+        let mut pcm: Vec<f32> = Vec::new();
+        let mut events: Vec<PhonemeEvent> = Vec::new();
+        let mut rate: u32 = 0;
+        let mut cursor: i64 = 0;
+        let mut phon_seen: usize = 0;
+
+        loop {
+            let mut chunk: ffi::piper_audio_chunk = unsafe { std::mem::zeroed() };
+            let rc = unsafe { ffi::piper_synthesize_next(self.raw, &mut chunk) };
+            // PIPER_DONE can carry the final chunk — consume before breaking.
+            if rc == ffi::PIPER_DONE as i32 && chunk.num_samples == 0 {
+                break;
+            }
+            if rc != ffi::PIPER_OK as i32 && rc != ffi::PIPER_DONE as i32 {
+                return Err(format!("piper_synthesize_next failed: {rc}"));
+            }
+            let done = rc == ffi::PIPER_DONE as i32;
+
+            rate = chunk.sample_rate as u32;
+            // The chunk's pointers die on the next call — copy out immediately.
+            let s = unsafe { std::slice::from_raw_parts(chunk.samples, chunk.num_samples) };
+            pcm.extend_from_slice(s);
+
+            if chunk.num_alignments > 0 {
+                if chunk.num_alignments != chunk.num_phoneme_ids {
+                    return Err("alignments and phoneme_ids are not parallel".into());
+                }
+                let phon_all =
+                    unsafe { std::slice::from_raw_parts(chunk.phonemes, chunk.num_phonemes) };
+                let aligns =
+                    unsafe { std::slice::from_raw_parts(chunk.alignments, chunk.num_alignments) };
+                // The phonemes buffer is cumulative — take only the new tail.
+                let phon = &phon_all[phon_seen.min(phon_all.len())..];
+                phon_seen = phon_all.len();
+                decode_groups(phon, aligns, &mut cursor, &mut events)?;
+            }
+
+            if done {
+                break;
+            }
+        }
+        Ok(Synthesis {
+            samples: pcm,
+            sample_rate: rate,
+            events,
+        })
+    }
+}
+
+impl Drop for Synthesizer {
+    fn drop(&mut self) {
+        unsafe { ffi::piper_free(self.raw) }
+    }
+}
+
+/// The documented grouping scheme (piper.h): `phonemes` repeats each codepoint
+/// once per corresponding id, groups separated by 0; `alignments` holds one
+/// sample count per id, so a phoneme's duration is the SUM of its group.
+fn decode_groups(
+    phon: &[u32],
+    aligns: &[std::os::raw::c_int],
+    cursor: &mut i64,
+    out: &mut Vec<PhonemeEvent>,
+) -> Result<(), String> {
+    let mut i = 0usize;
+    let mut a = 0usize;
+    while i < phon.len() {
+        if phon[i] == 0 {
+            i += 1;
+            continue; // group separator
+        }
+        let cp = phon[i];
+        let mut n = 0usize;
+        while i + n < phon.len() && phon[i + n] == cp {
+            n += 1;
+        }
+        if a + n > aligns.len() {
+            return Err("alignment array shorter than phoneme groups".into());
+        }
+        let dur: i64 = aligns[a..a + n].iter().map(|&x| x as i64).sum();
+        out.push(PhonemeEvent {
+            phoneme: char::from_u32(cp).map(String::from).unwrap_or_default(),
+            start_samples: *cursor,
+            dur_samples: dur,
+        });
+        *cursor += dur;
+        i += n;
+        a += n;
+    }
+    // Trailing ids past the final phoneme group (if any) still occupy time.
+    if a < aligns.len() {
+        let dur: i64 = aligns[a..].iter().map(|&x| x as i64).sum();
+        *cursor += dur;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// End-to-end over the build-provisioned artifacts: the Rust ONNX patch
+    /// yields alignments, and they reconcile exactly against the audio.
+    #[test]
+    fn default_voice_aligns_exactly() {
+        let mut synth = Synthesizer::new_default().expect("default synthesizer");
+        let s = synth.synthesize("The blue fish swam.").expect("synthesize");
+        assert!(s.sample_rate > 0);
+        assert!(
+            !s.events.is_empty(),
+            "the patched voice must emit alignments"
+        );
+        let aligned: i64 = s.events.iter().map(|e| e.dur_samples).sum();
+        assert_eq!(aligned, s.samples.len() as i64, "alignments must reconcile");
+        // Real phonemes present, not only markers.
+        assert!(s
+            .events
+            .iter()
+            .any(|e| e.phoneme == "f" || e.phoneme == "b"));
+    }
+}

--- a/crates/vizij/Cargo.toml
+++ b/crates/vizij/Cargo.toml
@@ -65,10 +65,14 @@ vizij-arora-behavior = { path = "../interop/vizij-arora-behavior" }
 # dependency and no nightly. Its generated `Value` conversions marshal the calls.
 vizij-animation-module = { path = "../interop/vizij-animation-module" }
 
-# The TTS module (`tts.rs`): `reqwest` reaches the Vizij TTS provider over HTTP;
-# `soloud` plays the audio whose playhead the viseme cursor follows.
+# The TTS modules: `reqwest` reaches the Vizij TTS cloud provider over HTTP;
+# `soloud` plays the audio whose playhead the viseme cursor follows (both
+# providers). `vizij-piper` is the local provider (feature `tts-piper`); its
+# build self-provisions libpiper and a patched default voice, so no
+# configuration is needed — note it links GPLv3 code into the binary.
 reqwest = { version = "0.13", features = ["json"] }
 soloud = "1"
+vizij-piper = { path = "../interop/vizij-piper", optional = true }
 
 [dev-dependencies]
 # The interpreter-module SPAWN/HALT codecs and RunPolicy the device test
@@ -90,3 +94,7 @@ ros2 = ["dep:arora-bridge-ros2"]
 # connector), configured from the environment (DEVICE_OWNERS, …). Needs
 # arora-studio-bridge-client 6.1.0+ (firestore 0.50 / gcloud-sdk 0.30.2).
 studio = ["arora/studio-bridge"]
+# Swap the TTS provider: the local Piper module (`tts_piper.rs`) instead of the
+# cloud module (`tts.rs`). Same `say` contract; fully offline at run time; the
+# first build downloads and prepares everything it needs.
+tts-piper = ["dep:vizij-piper"]

--- a/crates/vizij/build.rs
+++ b/crates/vizij/build.rs
@@ -1,0 +1,17 @@
+//! Under `tts-piper`, bake the Piper install's rpath into this binary: the
+//! dylibs (libpiper, onnxruntime) live in vizij-piper's cache install, and a
+//! dependency's `rustc-link-arg` does not reach the consumer's link — so the
+//! path arrives over the DEP_PIPER_* metadata channel and the rpath is added
+//! here.
+
+use std::env;
+
+fn main() {
+    if env::var("CARGO_FEATURE_TTS_PIPER").is_err() {
+        return;
+    }
+    let install =
+        env::var("DEP_PIPER_INSTALL_DIR").expect("vizij-piper exports DEP_PIPER_INSTALL_DIR");
+    println!("cargo:rustc-link-arg=-Wl,-rpath,{install}");
+    println!("cargo:rustc-link-arg=-Wl,-rpath,{install}/lib");
+}

--- a/crates/vizij/build.rs
+++ b/crates/vizij/build.rs
@@ -12,6 +12,13 @@ fn main() {
     }
     let install =
         env::var("DEP_PIPER_INSTALL_DIR").expect("vizij-piper exports DEP_PIPER_INSTALL_DIR");
+    // Linux: emit old-style DT_RPATH (not DT_RUNPATH). RUNPATH is not searched
+    // for TRANSITIVE dependencies — libpiper.so's own libonnxruntime.so.1 needs
+    // the executable's path to be visible down the load chain (macOS dyld does
+    // this by default).
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("linux") {
+        println!("cargo:rustc-link-arg=-Wl,--disable-new-dtags");
+    }
     println!("cargo:rustc-link-arg=-Wl,-rpath,{install}");
     println!("cargo:rustc-link-arg=-Wl,-rpath,{install}/lib");
 }

--- a/crates/vizij/src/device.rs
+++ b/crates/vizij/src/device.rs
@@ -19,7 +19,10 @@ use vizij_arora_store::BlackboardStore;
 use crate::animation;
 use crate::gaze;
 use crate::meta::FaceMeta;
+#[cfg(not(feature = "tts-piper"))]
 use crate::tts;
+#[cfg(feature = "tts-piper")]
+use crate::tts_piper;
 
 /// A running face device. Both handles share storage with the device's own
 /// (they are sibling clones), so the view reads the rig and the store live.
@@ -277,17 +280,20 @@ pub(crate) fn builder_for(
         gaze::look_at_id(),
         gaze::look_at_fragment_from(embedded_skills),
     );
-    Some(
-        arora::Arora::builder()
-            .with_hal(Box::new(rig))
-            .with_data_store(Box::new(store))
-            .with_behavior_interpreter(Box::new(graph))
-            .with_host_module(animation::host_module())
-            .with_host_module(gaze::host_module())
-            // The TTS module: the described `say` action (poll-on-tick, viseme
-            // out-param), synthesized through the Vizij TTS provider.
-            .with_host_module(tts::host_module()),
-    )
+    let builder = arora::Arora::builder()
+        .with_hal(Box::new(rig))
+        .with_data_store(Box::new(store))
+        .with_behavior_interpreter(Box::new(graph))
+        .with_host_module(animation::host_module())
+        .with_host_module(gaze::host_module());
+    // The TTS module: the described `say` action (poll-on-tick, viseme
+    // out-param). One provider per build, same contract (`tts_api`): the cloud
+    // provider by default, the local Piper provider under `tts-piper`.
+    #[cfg(not(feature = "tts-piper"))]
+    let builder = builder.with_host_module(tts::host_module());
+    #[cfg(feature = "tts-piper")]
+    let builder = builder.with_host_module(tts_piper::host_module());
+    Some(builder)
 }
 
 /// The operator flow, generation by generation: each `g` (load GLB) stops the

--- a/crates/vizij/src/main.rs
+++ b/crates/vizij/src/main.rs
@@ -20,7 +20,13 @@ mod meta;
 #[cfg(all(test, feature = "ros2"))]
 mod ros2_tests;
 mod snapshot;
+// The TTS provider modules share one contract (`tts_api`); the `tts-piper`
+// feature swaps which provider this build registers.
+#[cfg(not(feature = "tts-piper"))]
 mod tts;
+mod tts_api;
+#[cfg(feature = "tts-piper")]
+mod tts_piper;
 mod view;
 
 /// Vizij: render a GLB face natively over an arora device.

--- a/crates/vizij/src/tts.rs
+++ b/crates/vizij/src/tts.rs
@@ -20,44 +20,27 @@ use std::task::{Context, Poll, Waker};
 use std::time::{Duration, Instant};
 
 use arora::{HostModule, ModuleBuilder};
-use arora_behavior_tree_types::STATUS_ENUMERATION_ID;
 use arora_types::call::{Call, CallError, CallResult};
 use arora_types::gen_uuid_from_str;
-use arora_types::record::module::frozen::{Function, Parameter};
-use arora_types::record::ty::{FrozenScalar, FrozenTy, PrimitiveKind};
-use arora_types::record::{FrozenReference, Version};
 use arora_types::value::{StructureField, Value};
 use serde::{Deserialize, Serialize};
 use soloud::*;
 use uuid::Uuid;
 use vizij_graph_core::task;
 
+use crate::tts_api::{
+    say_id, say_signature, text_param_id, viseme_param_id, voice_param_id, SILENCE_VISEME,
+};
+
 /// Default provider: the same Vizij TTS cloud function the web demo
 /// (`@vizij/speech-react`'s `fetchVisemeData`) calls — AWS Polly behind an HTTP
 /// endpoint, so the module needs no credentials. Overridable via `API_URL`.
 const DEFAULT_API_BASE: &str = "https://us-central1-semio-vizij.cloudfunctions.net/api";
 const DEFAULT_VOICE: &str = "Ruth";
-/// The rest / silence viseme (AWS Polly viseme set), written when nothing speaks.
-const SILENCE_VISEME: &str = "sil";
 
 /// The tts module's id on the device.
 pub fn module_id() -> Uuid {
     gen_uuid_from_str("tts-module")
-}
-
-/// The `say` function's id.
-pub fn say_id() -> Uuid {
-    gen_uuid_from_str("say")
-}
-
-fn text_param_id() -> Uuid {
-    gen_uuid_from_str("say.text")
-}
-fn voice_param_id() -> Uuid {
-    gen_uuid_from_str("say.voice")
-}
-fn viseme_param_id() -> Uuid {
-    gen_uuid_from_str("say.viseme")
 }
 
 /// A handle for spawning: reuse the ambient runtime if one is active, otherwise a
@@ -115,38 +98,6 @@ pub fn host_module() -> HostModule {
     ModuleBuilder::new(module_id())
         .described_function(say_id(), "say", say_signature(), say)
         .build()
-}
-
-/// `say(text, voice) -> Status`, with a mutable `viseme` out-parameter. The
-/// `Status` return is the task-run marker a bridge exposes as an action.
-fn say_signature() -> Function {
-    let mut parameters = HashMap::new();
-    let mut parameter_ordering = Vec::new();
-    for (id, name, kind, mutable) in [
-        (text_param_id(), "text", PrimitiveKind::String, false),
-        (voice_param_id(), "voice", PrimitiveKind::String, false),
-        (viseme_param_id(), "viseme", PrimitiveKind::String, true),
-    ] {
-        parameter_ordering.push(id);
-        parameters.insert(
-            id,
-            Parameter {
-                name: name.to_string(),
-                ty: FrozenTy::from(kind),
-                mutable,
-            },
-        );
-    }
-    Function {
-        parameters,
-        parameter_ordering,
-        return_ty: FrozenTy::FrozenScalar(FrozenScalar {
-            reference: FrozenReference {
-                id: STATUS_ENUMERATION_ID,
-                version: Version::parse("1.0.0").expect("a valid version"),
-            },
-        }),
-    }
 }
 
 /// Speak `text` in `voice`, streaming the current viseme. Re-invoked each tick

--- a/crates/vizij/src/tts_api.rs
+++ b/crates/vizij/src/tts_api.rs
@@ -1,0 +1,71 @@
+//! The `say` contract shared by every TTS provider module.
+//!
+//! Providers are sibling host modules with the SAME function id, parameter ids,
+//! and signature — a behavior references `say` without caring which provider the
+//! build registered (the `tts-piper` feature swaps them; exactly one exists per
+//! build). Only the module id differs, so a bridge can still tell providers
+//! apart in DescribeMethods.
+//!
+//! The `viseme` out-parameter is a string whose vocabulary is the provider's
+//! (AWS Polly viseme codes for the cloud provider, espeak-ng phonemes for
+//! Piper); mapping it to face poses is the caller's job. Both providers write
+//! [`SILENCE_VISEME`] at rest.
+
+use std::collections::HashMap;
+
+use arora_behavior_tree_types::STATUS_ENUMERATION_ID;
+use arora_types::gen_uuid_from_str;
+use arora_types::record::module::frozen::{Function, Parameter};
+use arora_types::record::ty::{FrozenScalar, FrozenTy, PrimitiveKind};
+use arora_types::record::{FrozenReference, Version};
+use uuid::Uuid;
+
+/// The rest token, written whenever nothing is speaking (both vocabularies).
+pub const SILENCE_VISEME: &str = "sil";
+
+/// The `say` function's id — identical across providers.
+pub fn say_id() -> Uuid {
+    gen_uuid_from_str("say")
+}
+
+pub fn text_param_id() -> Uuid {
+    gen_uuid_from_str("say.text")
+}
+pub fn voice_param_id() -> Uuid {
+    gen_uuid_from_str("say.voice")
+}
+pub fn viseme_param_id() -> Uuid {
+    gen_uuid_from_str("say.viseme")
+}
+
+/// `say(text, voice) -> Status`, with a mutable `viseme` out-parameter. The
+/// `Status` return is the task-run marker a bridge exposes as an action.
+pub fn say_signature() -> Function {
+    let mut parameters = HashMap::new();
+    let mut parameter_ordering = Vec::new();
+    for (id, name, kind, mutable) in [
+        (text_param_id(), "text", PrimitiveKind::String, false),
+        (voice_param_id(), "voice", PrimitiveKind::String, false),
+        (viseme_param_id(), "viseme", PrimitiveKind::String, true),
+    ] {
+        parameter_ordering.push(id);
+        parameters.insert(
+            id,
+            Parameter {
+                name: name.to_string(),
+                ty: FrozenTy::from(kind),
+                mutable,
+            },
+        );
+    }
+    Function {
+        parameters,
+        parameter_ordering,
+        return_ty: FrozenTy::FrozenScalar(FrozenScalar {
+            reference: FrozenReference {
+                id: STATUS_ENUMERATION_ID,
+                version: Version::parse("1.0.0").expect("a valid version"),
+            },
+        }),
+    }
+}

--- a/crates/vizij/src/tts_piper.rs
+++ b/crates/vizij/src/tts_piper.rs
@@ -1,0 +1,272 @@
+//! The Piper TTS provider: `say(text, voice) -> Status`, fully local.
+//!
+//! Same contract as the cloud provider ([`crate::tts_api`]) — a drop-in swap
+//! selected by the `tts-piper` build feature. No network and no credentials at
+//! run time: the `vizij-piper` build provisions libpiper and a patched default
+//! voice, so a plain `cargo build --features tts-piper` is the whole setup.
+//!
+//! The `viseme` out-parameter carries the espeak-ng **phoneme** at the audio
+//! playhead (this provider's vocabulary; the cloud provider emits AWS Polly
+//! viseme codes). Markers and punctuation — BOS `^`, EOS `$`, stress marks,
+//! `.`/`,` — normalize to the shared rest token `sil`; real phonemes pass
+//! through raw for the caller to map.
+//!
+//! Piper's voice is chosen at build/run time (`PIPER_VOICE`); the `voice`
+//! call parameter names Polly voices and is ignored here (logged), keeping
+//! call sites portable across providers.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::hash::{Hash, Hasher};
+use std::pin::Pin;
+use std::sync::{Arc, LazyLock, Mutex};
+use std::task::{Context, Poll, Waker};
+use std::time::{Duration, Instant};
+
+use arora::{HostModule, ModuleBuilder};
+use arora_types::call::{Call, CallError, CallResult};
+use arora_types::gen_uuid_from_str;
+use arora_types::value::{StructureField, Value};
+use soloud::*;
+use uuid::Uuid;
+use vizij_graph_core::task;
+use vizij_piper::{PhonemeEvent, Synthesizer};
+
+use crate::tts_api::{
+    say_id, say_signature, text_param_id, viseme_param_id, voice_param_id, SILENCE_VISEME,
+};
+
+/// The Piper tts module's id on the device — distinct from the cloud module so
+/// DescribeMethods shows which provider this build carries.
+pub fn module_id() -> Uuid {
+    gen_uuid_from_str("tts-piper-module")
+}
+
+/// A handle for spawning: reuse the ambient runtime if one is active, otherwise a
+/// dedicated one. Only a `Handle` is needed.
+static TOKIO_HANDLE: LazyLock<tokio::runtime::Handle> = LazyLock::new(|| {
+    tokio::runtime::Handle::try_current().unwrap_or_else(|_| {
+        Box::leak(Box::new(
+            tokio::runtime::Runtime::new().expect("a tokio runtime"),
+        ))
+        .handle()
+        .clone()
+    })
+});
+
+/// The loaded voice, created on first use (a model load) and reused. One
+/// utterance synthesizes at a time; the lock serializes access.
+static SYNTH: LazyLock<Mutex<Option<Synthesizer>>> = LazyLock::new(|| Mutex::new(None));
+
+/// Live utterances, keyed by content so concurrent `say`s do not share a slot
+/// (the module ABI hands the closure no per-run id — same trade-off as the
+/// cloud provider).
+static RUNS: LazyLock<Mutex<HashMap<u64, Run>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// One live utterance.
+struct Run {
+    /// The synthesis+playback task; its output is the terminal status `Value`.
+    handle: tokio::task::JoinHandle<Value>,
+    /// The phoneme at the audio playhead, advanced by the task and sampled by
+    /// the closure each tick.
+    viseme: Arc<Mutex<String>>,
+}
+
+/// The Piper tts module: the described `say` action — the same signature the
+/// cloud provider describes, discoverable over `DescribeMethods`.
+pub fn host_module() -> HostModule {
+    ModuleBuilder::new(module_id())
+        .described_function(say_id(), "say", say_signature(), say)
+        .build()
+}
+
+/// Speak `text`, streaming the phoneme at the playhead. Re-invoked each tick
+/// while `Running`; keeps its state in [`RUNS`], keyed by content.
+fn say(call: Call) -> Result<CallResult, CallError> {
+    let text = match arg_string(&call, text_param_id()) {
+        Some(text) => text,
+        None => return Ok(status_only(task::failure())),
+    };
+    if let Some(voice) = arg_string(&call, voice_param_id()) {
+        if !voice.is_empty() {
+            log::debug!(
+                "tts-piper: the voice parameter ({voice}) is ignored — \
+                 the Piper voice is chosen at build/run time (PIPER_VOICE)"
+            );
+        }
+    }
+    let key = utterance_key(&text);
+    let mut runs = match RUNS.lock() {
+        Ok(runs) => runs,
+        Err(_) => return Ok(status_only(task::failure())),
+    };
+
+    // First tick: spawn synthesis + playback off the tick thread. Later ticks
+    // find the run and fall through to the poll.
+    let run = runs.entry(key).or_insert_with(|| spawn_say(text));
+
+    // The phoneme at the playhead, advanced by the playback task.
+    let current = run
+        .viseme
+        .lock()
+        .map(|cur| cur.clone())
+        .unwrap_or_else(|_| SILENCE_VISEME.to_string());
+
+    // Poll the run's `JoinHandle` (a `Future`) once — the tick loop is the
+    // executor, a no-op waker suffices, and a terminal result drops the run so
+    // the completed handle is never polled again.
+    let mut cx = Context::from_waker(Waker::noop());
+    match Future::poll(Pin::new(&mut run.handle), &mut cx) {
+        Poll::Pending => Ok(with_viseme(task::running(), &current)),
+        Poll::Ready(Ok(status)) => {
+            runs.remove(&key);
+            Ok(with_viseme(status, SILENCE_VISEME))
+        }
+        Poll::Ready(Err(_join_error)) => {
+            runs.remove(&key);
+            Ok(with_viseme(task::failure(), SILENCE_VISEME))
+        }
+    }
+}
+
+/// Spawn synthesis (local, blocking inference on the blocking pool) + playback,
+/// and return the run. The playback loop advances the shared phoneme cell at
+/// the playhead; the tick only samples the cell and polls the handle.
+fn spawn_say(text: String) -> Run {
+    let viseme = Arc::new(Mutex::new(SILENCE_VISEME.to_string()));
+    let viseme_task = viseme.clone();
+    let handle = TOKIO_HANDLE.spawn(async move {
+        // Synthesize off the async workers: model inference is CPU-bound.
+        let synthesis = tokio::task::spawn_blocking(move || {
+            let mut guard = SYNTH.lock().ok()?;
+            if guard.is_none() {
+                match Synthesizer::new_default() {
+                    Ok(s) => *guard = Some(s),
+                    Err(e) => {
+                        log::error!("tts-piper: {e}");
+                        return None;
+                    }
+                }
+            }
+            let synth = guard.as_mut().expect("just created");
+            match synth.synthesize(&text) {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    log::error!("tts-piper: synthesis failed: {e}");
+                    None
+                }
+            }
+        })
+        .await
+        .ok()
+        .flatten();
+        let synthesis = match synthesis {
+            Some(s) => s,
+            None => return task::failure(),
+        };
+
+        // Play the utterance; advance the phoneme cursor by the playhead.
+        let sl = match Soloud::default() {
+            Ok(sl) => sl,
+            Err(_) => return task::failure(),
+        };
+        let mut wav = audio::WavStream::default();
+        if wav
+            .load_mem(&wav_bytes(&synthesis.samples, synthesis.sample_rate))
+            .is_err()
+        {
+            return task::failure();
+        }
+        let rate = synthesis.sample_rate as u64;
+        let start = Instant::now();
+        sl.play(&wav);
+        let mut next = 0usize;
+        let events = &synthesis.events;
+        while sl.voice_count() > 0 {
+            let elapsed_samples = start.elapsed().as_millis() as u64 * rate / 1000;
+            while next < events.len() && (events[next].start_samples as u64) <= elapsed_samples {
+                if let Ok(mut cur) = viseme_task.lock() {
+                    *cur = cursor_token(&events[next]);
+                }
+                next += 1;
+            }
+            tokio::time::sleep(Duration::from_millis(15)).await;
+        }
+        if let Ok(mut cur) = viseme_task.lock() {
+            *cur = SILENCE_VISEME.to_string();
+        }
+        task::success()
+    });
+    Run { handle, viseme }
+}
+
+/// The out-param token for an event: real phonemes pass through raw; markers,
+/// stress and punctuation pseudo-phonemes become the rest token.
+fn cursor_token(event: &PhonemeEvent) -> String {
+    match event.phoneme.as_str() {
+        "" | " " | "^" | "$" | "_" | "." | "," | ";" | ":" | "!" | "?" | "ˈ" | "ˌ" | "ː" => {
+            SILENCE_VISEME.to_string()
+        }
+        phoneme => phoneme.to_string(),
+    }
+}
+
+/// Wrap mono float32 PCM as an in-memory 16-bit WAV for soloud.
+fn wav_bytes(samples: &[f32], rate: u32) -> Vec<u8> {
+    let data_len = samples.len() * 2;
+    let mut out = Vec::with_capacity(44 + data_len);
+    out.extend_from_slice(b"RIFF");
+    out.extend_from_slice(&(36 + data_len as u32).to_le_bytes());
+    out.extend_from_slice(b"WAVEfmt ");
+    out.extend_from_slice(&16u32.to_le_bytes()); // PCM header size
+    out.extend_from_slice(&1u16.to_le_bytes()); // PCM
+    out.extend_from_slice(&1u16.to_le_bytes()); // mono
+    out.extend_from_slice(&rate.to_le_bytes());
+    out.extend_from_slice(&(rate * 2).to_le_bytes()); // byte rate
+    out.extend_from_slice(&2u16.to_le_bytes()); // block align
+    out.extend_from_slice(&16u16.to_le_bytes()); // bits per sample
+    out.extend_from_slice(b"data");
+    out.extend_from_slice(&(data_len as u32).to_le_bytes());
+    for s in samples {
+        out.extend_from_slice(&((s.clamp(-1.0, 1.0) * 32767.0).round() as i16).to_le_bytes());
+    }
+    out
+}
+
+/// A result carrying only the status (no viseme output).
+fn status_only(status: Value) -> CallResult {
+    CallResult {
+        ret: status,
+        mutated: Vec::new(),
+    }
+}
+
+/// A result carrying the status plus the current token in the out-parameter.
+fn with_viseme(status: Value, viseme: &str) -> CallResult {
+    CallResult {
+        ret: status,
+        mutated: vec![StructureField {
+            id: viseme_param_id(),
+            value: Box::new(Value::String(viseme.to_string())),
+        }],
+    }
+}
+
+/// Read a string argument by its parameter id (order-independent).
+fn arg_string(call: &Call, id: Uuid) -> Option<String> {
+    match call.args.iter().find(|field| field.id == id) {
+        Some(field) => match field.value.as_ref() {
+            Value::String(s) => Some(s.clone()),
+            _ => None,
+        },
+        None => None,
+    }
+}
+
+/// The run key for an utterance — content-keyed, same trade-off as the cloud
+/// provider (no per-run id in the module ABI).
+fn utterance_key(text: &str) -> u64 {
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    text.hash(&mut h);
+    h.finish()
+}


### PR DESCRIPTION
The second `say` provider for [VIZ-94](https://linear.app/semio-ai/issue/VIZ-94): **Piper, fully local** — no network, no credentials, no configuration. The point Victor asked to challenge: how easy is it to swap or extend providers.

## The no-brainer build
`cargo build --features tts-piper` is the whole setup. `vizij-piper`'s build script self-provisions everything, cached in `~/.cache/vizij-piper` (survives `cargo clean`; override `VIZIJ_PIPER_CACHE`):
- downloads a **pinned** piper1-gpl and cmake-builds libpiper (espeak-ng + prebuilt onnxruntime);
- downloads the default voice (`en_US-lessac-medium`) from Hugging Face;
- **patches it for alignments in pure Rust** — upstream's Python patch is a one-line ONNX graph edit (mark the `Ceil` tensor as a graph output), reimplemented as a minimal protobuf surgery, so no Python anywhere;
- bakes every path in as compile-time defaults (`PIPER_VOICE` / `PIPER_VOICE_CONFIG` / `PIPER_ESPEAK_DATA` override at run time).

## Same API, consumer-side switch
- `tts_api.rs`: the shared `say(text, voice) → Status` + `viseme` out-param contract — same function id, param ids, and signature for both providers; behaviors don't care which one the build carries. The cloud module now uses it too.
- The **`tts-piper` feature lives on the vizij app** (the consumer), swapping which module `builder_for` registers. Exactly one provider per build.
- The `viseme` out-param carries the **espeak-ng phoneme** at the audio playhead (raw — mapping stays with the caller, per the validation guide), with markers/punctuation normalized to the shared rest token `sil`.

## Hard-won build knowledge (all documented in build.rs)
- espeak-ng's data compiler **truncates paths beyond ~160 bytes** (silent, looks like `Bad vowel file`) → short cache layout + a loud guard;
- it resolves `../phsource` against `ESPEAK_DATA_PATH`'s parent → pre-planted symlinks;
- its data build **races under parallel make**, and cargo re-parallelizes children via the `MAKEFLAGS` jobserver → sequential build with the env scrubbed;
- libpiper's cmake drops its `download/` dir in the CWD → pinned to the cache.
- The FFI wrapper carries both libpiper defects found during validation (DONE-carried final chunk; cumulative `phonemes` buffer).

## Verified
- `cargo test -p vizij-piper`: synthesis over the provisioned artifacts, **alignments reconcile exactly** against the audio.
- clippy `-D warnings` green on: the piper crate, vizij default (cloud), and vizij `--features tts-piper`.

## Notes
- **GPL boundary**: default builds stay GPL-free; enabling `tts-piper` links GPLv3 (libpiper/espeak-ng) — cleared per the bootstrap guide's licensing review. Voice MODEL_CARD licensing to record per shipped voice.
- **CI cost**: `--all-features` jobs will run the provisioning (~5–8 min first time per runner; cached locally). If CI time becomes annoying, an actions cache on `~/.cache/vizij-piper` is the follow-up.
- Android (Piper is the plan there) rides the same crate later — onnxruntime ships Android prebuilts; not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)