### PR TITLE
docs: app-first README; ROS4HRI docs cover the served skill plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,102 +85,15 @@ The rest of this README covers developing in the workspace itself.
 
 ## Table of Contents
 
-1. [Workspace Layout](#workspace-layout)
-2. [Domain Stacks](#domain-stacks)
-3. [Toolchain & Requirements](#toolchain--requirements)
-4. [Setup](#setup)
-5. [Common Workflows](#common-workflows)
-6. [Testing](#testing)
-7. [Publishing & Versioning](#publishing--versioning)
+1. [Toolchain & Requirements](#toolchain--requirements)
+2. [Setup](#setup)
+3. [Common Workflows](#common-workflows)
+4. [Testing](#testing)
+5. [Publishing & Versioning](#publishing--versioning)
+6. [Workspace Layout](#workspace-layout)
+7. [Domain Stacks](#domain-stacks)
 8. [Development Tips](#development-tips)
 9. [Reference Documentation](#reference-documentation)
-
----
-
-## Workspace Layout
-
-```
-vizij-rs/
-├─ crates/
-│  ├─ api/
-│  │  ├─ vizij-api-core            # Shared Value/Shape/TypedPath types
-│  │  └─ vizij-api-wasm            # wasm-bindgen helpers for Value/WriteBatch JSON
-│  ├─ animation/
-│  │  ├─ vizij-animation-core      # Deterministic animation engine
-│  │  └─ vizij-animation-wasm      # wasm-bindgen binding
-│  ├─ node-graph/
-│  │  ├─ vizij-graph-core          # Data-flow node graph evaluator
-│  │  ├─ vizij-graph-wasm          # wasm-bindgen binding
-│  │  └─ vizij-graph-registry-export # Registry export utility used by npm tooling
-│  ├─ interop/                     # Adapters that run the Vizij stacks on Arora seams
-│  │  ├─ vizij-arora               # Vizij↔Arora Value interop (identity + Shape.meta sidecar)
-│  │  ├─ vizij-arora-store         # Vizij Blackboard exposed as an Arora DataStore
-│  │  ├─ vizij-arora-hal           # Vizij rig presented as an Arora HAL
-│  │  ├─ vizij-arora-behavior      # Vizij node graph as an Arora behavior interpreter
-│  │  ├─ vizij-arora-host          # Bundle composition, face standard & ROS4HRI profile, skills
-│  │  ├─ vizij-arora-web           # Browser wasm cdylib: Vizij runtime as an Arora device
-│  │  └─ vizij-animation-module    # vizij-animation-core packaged as an Arora wasm module
-│  ├─ tools/
-│  │  └─ vizij-bundle              # Face-GLB bundle tool: inspect/pack/validate, embed standard profiles
-│  ├─ vizij                        # The native app: cargo run shows a face, running an arora
-│  └─ test-fixtures/
-│     └─ vizij-test-fixtures       # Loads JSON fixtures referenced across stacks
-├─ npm/
-│  ├─ @vizij/animation-module      # vizij-animation-core built as an Arora wasm module (assets)
-│  ├─ @vizij/animation             # Stable ESM wrapper around `vizij-animation-wasm`
-│  ├─ @vizij/node-graph            # Wrapper around `vizij-graph-wasm`
-│  ├─ @vizij/runtime               # Browser Vizij runtime as an Arora device (wasm bindings)
-│  ├─ @vizij/test-fixtures         # Browser bundle of shared JSON fixtures
-│  ├─ @vizij/value-json            # Shared JSON coercion helpers
-│  └─ @vizij/wasm-loader           # Loader that enforces ABI compatibility
-├─ fixtures/                       # Sample graphs and animations (+ manifest)
-└─ scripts/                        # Build, watch, and release helpers
-```
-
-The major runtime crates and npm packages include dedicated READMEs with domain-specific guidance; the top-level README focuses on cross-cutting processes.
-
----
-
-## Domain Stacks
-
-Each domain ships as a **core crate** with deterministic runtime logic plus a
-**WASM binding** re-exported through the matching `npm/@vizij/*` wrapper
-package.
-
-| Stack          | Core Crate               | WASM Binding               | npm wrapper                  |
-| -------------- | ------------------------ | -------------------------- | ---------------------------- |
-| Animation      | `vizij-animation-core`   | `vizij-animation-wasm`     | `@vizij/animation`      |
-| Node graph     | `vizij-graph-core`       | `vizij-graph-wasm`         | `@vizij/node-graph`     |
-| Test fixtures  | `vizij-test-fixtures`    | —                          | `@vizij/test-fixtures`       |
-
-Shared API crates (`vizij-api-core`, `vizij-api-wasm`) provide the Value/Shape/TypedPath contract that keeps the stacks interoperable.
-`vizij-test-fixtures` exposes the JSON assets defined under `fixtures/`, while `vizij-graph-registry-export` supports registry generation for the node-graph npm tooling.
-
-Each WASM crate exposes a stable `abi_version()` (currently `2`); the npm wrappers verify this at runtime and instruct you to rebuild if versions drift.
-
-### Interop (Arora)
-
-The `crates/interop/*` family adapts the Vizij stacks onto Arora runtime seams so a Vizij runtime can run as an Arora device (browser or native). These crates are internal to the workspace; only the wasm-facing ones ship an npm package.
-
-| Crate | Purpose | npm package |
-| ------------------------ | ---------------------------------------------------------------------- | -------------------------- |
-| `vizij-arora`            | Vizij↔Arora `Value` interop: identity passthroughs + `Shape.meta` sidecar helpers. | — |
-| `vizij-arora-store`      | Vizij Blackboard exposed as an Arora `DataStore`.                      | — |
-| `vizij-arora-hal`        | Vizij rig presented as an Arora HAL.                                   | — |
-| `vizij-arora-behavior`   | Vizij node graph driven as an Arora behavior interpreter.              | — |
-| `vizij-arora-host`       | Composes a face's bundle graphs; hosts the [face standard](docs/face-standard.md) vocabulary, the [ROS4HRI](docs/ros4hri.md) profile, and the skills registry. | — |
-| `vizij-arora-web`        | Browser wasm cdylib composing a Vizij runtime as an Arora device.      | `@vizij/runtime` |
-| `vizij-animation-module` | `vizij-animation-core` packaged as an Arora wasm module.               | `@vizij/animation-module` |
-
-### Support Packages
-
-| Package | Purpose |
-|---------|---------|
-| `@vizij/value-json` | TypeScript helpers that normalise Value/Shape payloads to match `vizij-api-core`. |
-| `@vizij/test-fixtures` | Workspace package that bundles the shared fixture manifest + JSON for browsers and Node tooling. |
-| `@vizij/wasm-loader` | Shared loader that caches wasm-bindgen modules, resolves `file://` URLs, and enforces ABI checks. |
-
-These packages build quickly (`pnpm run build:shared`) and should be rebuilt whenever fixtures or API contracts change.
 
 ---
 
@@ -383,6 +296,93 @@ Each domain stack keeps the Rust crate, WASM crate, and npm wrapper versions in 
 5. After the workflow finishes, pull your feature branch so you have the auto-generated release commit locally.
 
 Use `scripts/dry-run-release.sh` to sanity-check the end-to-end flow (builds, wasm bundling, npm pack contents) before pushing real releases.
+
+---
+
+## Workspace Layout
+
+```
+vizij-rs/
+├─ crates/
+│  ├─ api/
+│  │  ├─ vizij-api-core            # Shared Value/Shape/TypedPath types
+│  │  └─ vizij-api-wasm            # wasm-bindgen helpers for Value/WriteBatch JSON
+│  ├─ animation/
+│  │  ├─ vizij-animation-core      # Deterministic animation engine
+│  │  └─ vizij-animation-wasm      # wasm-bindgen binding
+│  ├─ node-graph/
+│  │  ├─ vizij-graph-core          # Data-flow node graph evaluator
+│  │  ├─ vizij-graph-wasm          # wasm-bindgen binding
+│  │  └─ vizij-graph-registry-export # Registry export utility used by npm tooling
+│  ├─ interop/                     # Adapters that run the Vizij stacks on Arora seams
+│  │  ├─ vizij-arora               # Vizij↔Arora Value interop (identity + Shape.meta sidecar)
+│  │  ├─ vizij-arora-store         # Vizij Blackboard exposed as an Arora DataStore
+│  │  ├─ vizij-arora-hal           # Vizij rig presented as an Arora HAL
+│  │  ├─ vizij-arora-behavior      # Vizij node graph as an Arora behavior interpreter
+│  │  ├─ vizij-arora-host          # Bundle composition, face standard & ROS4HRI profile, skills
+│  │  ├─ vizij-arora-web           # Browser wasm cdylib: Vizij runtime as an Arora device
+│  │  └─ vizij-animation-module    # vizij-animation-core packaged as an Arora wasm module
+│  ├─ tools/
+│  │  └─ vizij-bundle              # Face-GLB bundle tool: inspect/pack/validate, embed standard profiles
+│  ├─ vizij                        # The native app: cargo run shows a face, running an arora
+│  └─ test-fixtures/
+│     └─ vizij-test-fixtures       # Loads JSON fixtures referenced across stacks
+├─ npm/
+│  ├─ @vizij/animation-module      # vizij-animation-core built as an Arora wasm module (assets)
+│  ├─ @vizij/animation             # Stable ESM wrapper around `vizij-animation-wasm`
+│  ├─ @vizij/node-graph            # Wrapper around `vizij-graph-wasm`
+│  ├─ @vizij/runtime               # Browser Vizij runtime as an Arora device (wasm bindings)
+│  ├─ @vizij/test-fixtures         # Browser bundle of shared JSON fixtures
+│  ├─ @vizij/value-json            # Shared JSON coercion helpers
+│  └─ @vizij/wasm-loader           # Loader that enforces ABI compatibility
+├─ fixtures/                       # Sample graphs and animations (+ manifest)
+└─ scripts/                        # Build, watch, and release helpers
+```
+
+The major runtime crates and npm packages include dedicated READMEs with domain-specific guidance; the top-level README focuses on cross-cutting processes.
+
+---
+
+## Domain Stacks
+
+Each domain ships as a **core crate** with deterministic runtime logic plus a
+**WASM binding** re-exported through the matching `npm/@vizij/*` wrapper
+package.
+
+| Stack          | Core Crate               | WASM Binding               | npm wrapper                  |
+| -------------- | ------------------------ | -------------------------- | ---------------------------- |
+| Animation      | `vizij-animation-core`   | `vizij-animation-wasm`     | `@vizij/animation`      |
+| Node graph     | `vizij-graph-core`       | `vizij-graph-wasm`         | `@vizij/node-graph`     |
+| Test fixtures  | `vizij-test-fixtures`    | —                          | `@vizij/test-fixtures`       |
+
+Shared API crates (`vizij-api-core`, `vizij-api-wasm`) provide the Value/Shape/TypedPath contract that keeps the stacks interoperable.
+`vizij-test-fixtures` exposes the JSON assets defined under `fixtures/`, while `vizij-graph-registry-export` supports registry generation for the node-graph npm tooling.
+
+Each WASM crate exposes a stable `abi_version()` (currently `2`); the npm wrappers verify this at runtime and instruct you to rebuild if versions drift.
+
+### Interop (Arora)
+
+The `crates/interop/*` family adapts the Vizij stacks onto Arora runtime seams so a Vizij runtime can run as an Arora device (browser or native). These crates are internal to the workspace; only the wasm-facing ones ship an npm package.
+
+| Crate | Purpose | npm package |
+| ------------------------ | ---------------------------------------------------------------------- | -------------------------- |
+| `vizij-arora`            | Vizij↔Arora `Value` interop: identity passthroughs + `Shape.meta` sidecar helpers. | — |
+| `vizij-arora-store`      | Vizij Blackboard exposed as an Arora `DataStore`.                      | — |
+| `vizij-arora-hal`        | Vizij rig presented as an Arora HAL.                                   | — |
+| `vizij-arora-behavior`   | Vizij node graph driven as an Arora behavior interpreter.              | — |
+| `vizij-arora-host`       | Composes a face's bundle graphs; hosts the [face standard](docs/face-standard.md) vocabulary, the [ROS4HRI](docs/ros4hri.md) profile, and the skills registry. | — |
+| `vizij-arora-web`        | Browser wasm cdylib composing a Vizij runtime as an Arora device.      | `@vizij/runtime` |
+| `vizij-animation-module` | `vizij-animation-core` packaged as an Arora wasm module.               | `@vizij/animation-module` |
+
+### Support Packages
+
+| Package | Purpose |
+|---------|---------|
+| `@vizij/value-json` | TypeScript helpers that normalise Value/Shape payloads to match `vizij-api-core`. |
+| `@vizij/test-fixtures` | Workspace package that bundles the shared fixture manifest + JSON for browsers and Node tooling. |
+| `@vizij/wasm-loader` | Shared loader that caches wasm-bindgen modules, resolves `file://` URLs, and enforces ABI checks. |
+
+These packages build quickly (`pnpm run build:shared`) and should be rebuilt whenever fixtures or API contracts change.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,85 @@
-# Vizij RS Workspace
+# Vizij
 
-> **Rust cores and WASM bridges for Vizij’s real‑time animation platform.**
+> **Give your robot a face.** Vizij renders and drives expressive, animated
+> faces — as a native app, in the browser, or headless on a robot — from one
+> portable face asset.
 
-This repository contains the Rust source for Vizij’s animation, node graph, and orchestration stacks together with the tooling needed to surface them in web applications. Each domain ships as a trio of crates:
+The heart of this repository is the **`vizij` app**: point it at a face GLB and
+it runs the face as a live device — rendering it, executing its behavior
+graphs, and serving its control surfaces.
 
-- a **core crate** with deterministic runtime logic,
-- and a **WASM binding** that is re-exported through the matching `npm/@vizij/*` wrapper package.
+## Run it
 
-A separate `crates/interop/*` family adapts these stacks onto [Arora](#interop-arora) runtime seams.
+```bash
+cargo run -p vizij -- --glb path/to/face.glb
+```
 
-What you read here should give you everything you need to build, test, and publish those artifacts.
+A window opens with the face — alive, not a picture. By default the app:
+
+- executes the face's own graphs from the embedded `VIZIJ_bundle` (rig, pose
+  drivers, programs — the authored idle program autoplays);
+- exposes the **[face standard](docs/face-standard.md)** vocabulary: write a
+  `standard/vizij/*` control (gaze, expressions, visemes, FACS muscles) and the
+  face performs it, whatever its rig;
+- composes the **[ROS4HRI](docs/ros4hri.md) profile**, so the face understands
+  the ROS4HRI face vocabulary out of the box (`--no-ros4hri` opts out);
+- serves arora's local WebSocket bridge for live control and inspection.
+
+### On a ROS 2 robot
+
+Build with the `ros2` feature and attach the bridge:
+
+```bash
+cargo run -p vizij --features ros2 -- --glb path/to/face.glb --ros2
+```
+
+The device joins the ROS graph as a drop-in ROS4HRI face renderer:
+
+- **typed topic endpoints** — `/robot_face/{expression,look_at,tts}` and
+  `/expressive_face/{look_at,speech}` land on the face's `standard/ros4hri/*`
+  keys;
+- **the `/skill/look_at` action** (`interaction_skills/LookAt`) — goal-driven
+  gaze with tracking, glances, reset, priorities, and standard error codes;
+- **every store key as a data topic** under `/<namespace>/keys/<path>`.
+
+[ROS4HRI support](docs/ros4hri.md) documents the full contract;
+[the app README](crates/vizij/README.md) documents every flag.
+
+### Headless
+
+```bash
+cargo run -p vizij -- --glb path/to/face.glb --snapshot out.png --size 763x760
+cargo run -p vizij -- --glb path/to/face.glb --headless
+```
+
+One frame rendered offscreen to PNG, or a windowless device streaming rendered
+frames into the store — same behavior, no display.
+
+## What it supports
+
+| Capability | Where it's documented |
+|---|---|
+| The face-standard control vocabulary (gaze & lids, expressions, visemes, FACS muscle tier) | [face standard](docs/face-standard.md) |
+| ROS4HRI: typed face topics **and** the `/skill/look_at` gaze action | [ROS4HRI support](docs/ros4hri.md) |
+| Skills: goal-driven behaviors shipped as editable graph fragments, overridable per face | [ROS4HRI support](docs/ros4hri.md#the-look_at-skill) |
+| Animation clips + node-graph programs from the face's `VIZIJ_bundle` | [the app README](crates/vizij/README.md) |
+| Bridges: local WebSocket (always on), ROS 2 (`--ros2`), Semio Studio (`--studio`) | [the app README](crates/vizij/README.md) |
+| Headless rendering: one-shot snapshots or frames-to-store | [the app README](crates/vizij/README.md) |
+| Face assets as GLB bundles: inspect, pack, validate coverage (L0–L3) | [`vizij-bundle`](crates/tools/vizij-bundle/README.md) |
+
+## Find your use case
+
+| I want to… | Start here |
+|---|---|
+| Show a face on a robot, drive it from ROS 2 | the [`vizij` app](crates/vizij/README.md) + [ROS4HRI support](docs/ros4hri.md) |
+| Author or edit a face (design, rig, animate, program) | the **authoring app** in [vizij-web](https://github.com/vizij-ai/vizij-web) (`apps/vizij-authoring`) |
+| Show a face on a desktop, kiosk, or Android tablet | **[vizij-standalone](https://github.com/vizij-ai/vizij-web/tree/main/apps/vizij-standalone)** (vizij-web) |
+| Embed a live face in my own web app | [`@vizij/runtime`](npm/@vizij/runtime/README.md) (the browser device) + the React packages in [vizij-web](https://github.com/vizij-ai/vizij-web) |
+| Pilot faces from [Semio Studio](https://studio.semio.ai) | the `--studio` flag ([app README](crates/vizij/README.md)) or the standalone's studio-bridge build |
+| Pack, validate, or embed profiles into face assets | [`vizij-bundle`](crates/tools/vizij-bundle/README.md) |
+| Use the animation or node-graph engine on its own | [vizij-animation-core](crates/animation/vizij-animation-core/README.md) / [vizij-graph-core](crates/node-graph/vizij-graph-core/README.md), or their [npm wrappers](#domain-stacks) |
+
+The rest of this README covers developing in the workspace itself.
 
 ---
 
@@ -17,14 +87,13 @@ What you read here should give you everything you need to build, test, and publi
 
 1. [Workspace Layout](#workspace-layout)
 2. [Domain Stacks](#domain-stacks)
-3. [Face Standard & ROS4HRI](#face-standard--ros4hri)
-4. [Toolchain & Requirements](#toolchain--requirements)
-5. [Setup](#setup)
-6. [Common Workflows](#common-workflows)
-7. [Testing](#testing)
-8. [Publishing & Versioning](#publishing--versioning)
-9. [Development Tips](#development-tips)
-10. [Reference Documentation](#reference-documentation)
+3. [Toolchain & Requirements](#toolchain--requirements)
+4. [Setup](#setup)
+5. [Common Workflows](#common-workflows)
+6. [Testing](#testing)
+7. [Publishing & Versioning](#publishing--versioning)
+8. [Development Tips](#development-tips)
+9. [Reference Documentation](#reference-documentation)
 
 ---
 
@@ -48,7 +117,7 @@ vizij-rs/
 │  │  ├─ vizij-arora-store         # Vizij Blackboard exposed as an Arora DataStore
 │  │  ├─ vizij-arora-hal           # Vizij rig presented as an Arora HAL
 │  │  ├─ vizij-arora-behavior      # Vizij node graph as an Arora behavior interpreter
-│  │  ├─ vizij-arora-host          # Bundle composition + the face standard & ROS4HRI profile
+│  │  ├─ vizij-arora-host          # Bundle composition, face standard & ROS4HRI profile, skills
 │  │  ├─ vizij-arora-web           # Browser wasm cdylib: Vizij runtime as an Arora device
 │  │  └─ vizij-animation-module    # vizij-animation-core packaged as an Arora wasm module
 │  ├─ tools/
@@ -58,8 +127,8 @@ vizij-rs/
 │     └─ vizij-test-fixtures       # Loads JSON fixtures referenced across stacks
 ├─ npm/
 │  ├─ @vizij/animation-module      # vizij-animation-core built as an Arora wasm module (assets)
-│  ├─ @vizij/animation        # Stable ESM wrapper around `vizij-animation-wasm`
-│  ├─ @vizij/node-graph       # Wrapper around `vizij-graph-wasm`
+│  ├─ @vizij/animation             # Stable ESM wrapper around `vizij-animation-wasm`
+│  ├─ @vizij/node-graph            # Wrapper around `vizij-graph-wasm`
 │  ├─ @vizij/runtime               # Browser Vizij runtime as an Arora device (wasm bindings)
 │  ├─ @vizij/test-fixtures         # Browser bundle of shared JSON fixtures
 │  ├─ @vizij/value-json            # Shared JSON coercion helpers
@@ -73,6 +142,10 @@ The major runtime crates and npm packages include dedicated READMEs with domain-
 ---
 
 ## Domain Stacks
+
+Each domain ships as a **core crate** with deterministic runtime logic plus a
+**WASM binding** re-exported through the matching `npm/@vizij/*` wrapper
+package.
 
 | Stack          | Core Crate               | WASM Binding               | npm wrapper                  |
 | -------------- | ------------------------ | -------------------------- | ---------------------------- |
@@ -95,7 +168,7 @@ The `crates/interop/*` family adapts the Vizij stacks onto Arora runtime seams s
 | `vizij-arora-store`      | Vizij Blackboard exposed as an Arora `DataStore`.                      | — |
 | `vizij-arora-hal`        | Vizij rig presented as an Arora HAL.                                   | — |
 | `vizij-arora-behavior`   | Vizij node graph driven as an Arora behavior interpreter.              | — |
-| `vizij-arora-host`       | Composes a face's bundle graphs; hosts the [face standard](docs/face-standard.md) vocabulary and the [ROS4HRI](docs/ros4hri.md) profile. | — |
+| `vizij-arora-host`       | Composes a face's bundle graphs; hosts the [face standard](docs/face-standard.md) vocabulary, the [ROS4HRI](docs/ros4hri.md) profile, and the skills registry. | — |
 | `vizij-arora-web`        | Browser wasm cdylib composing a Vizij runtime as an Arora device.      | `@vizij/runtime` |
 | `vizij-animation-module` | `vizij-animation-core` packaged as an Arora wasm module.               | `@vizij/animation-module` |
 
@@ -108,32 +181,6 @@ The `crates/interop/*` family adapts the Vizij stacks onto Arora runtime seams s
 | `@vizij/wasm-loader` | Shared loader that caches wasm-bindgen modules, resolves `file://` URLs, and enforces ABI checks. |
 
 These packages build quickly (`pnpm run build:shared`) and should be rebuilt whenever fixtures or API contracts change.
-
----
-
-## Face Standard & ROS4HRI
-
-Vizij faces are driven through a **named-control vocabulary on the store**, the
-`standard/vizij/*` [face standard](docs/face-standard.md): gaze & lids,
-expressions and visemes, and a fine muscle tier (one control per FACS action
-unit / ARKit blendshape). A caller writes a control; the face's own graphs turn
-it into the motion of its particular rig — so the same command drives any face.
-
-On top of it, Vizij ships a built-in **[ROS4HRI](docs/ros4hri.md) profile**: a
-graph mapping ROS4HRI's face vocabulary (`hri_msgs/Expression`,
-`FacialActionUnits`, gaze, plus a viseme extension) onto the standard. It is
-on by default in the `vizij` binary (`--no-ros4hri` opts out) and opt-in for
-library callers. The profile is a canonical, editable asset
-(`crates/interop/vizij-arora-host/profiles/ros4hri.json`) that
-[`vizij-bundle`](crates/tools/vizij-bundle/README.md) can embed into a face GLB
-and [`@vizij/runtime`](npm/@vizij/runtime/README.md) serves to authoring apps.
-
-- **[Face standard](docs/face-standard.md)** — the control vocabulary (the three
-  tiers, the expression/viseme/muscle tables).
-- **[ROS4HRI support](docs/ros4hri.md)** — the profile, its `standard/ros4hri/*`
-  key contract, and how to enable and embed it.
-- **[`vizij-bundle`](crates/tools/vizij-bundle/README.md)** — inspect, pack,
-  `validate` coverage (L0–L3), and `add-standard` a profile into a face.
 
 ---
 
@@ -267,7 +314,6 @@ Per-crate runs are equally useful:
 ```bash
 cargo test -p vizij-graph-core
 cargo test -p vizij-animation-core
-cargo test -p vizij-graph-core
 ```
 
 The wrapper packages exercise their generated bindings through package-level test scripts:
@@ -365,13 +411,13 @@ Use `scripts/dry-run-release.sh` to sanity-check the end-to-end flow (builds, wa
 
 ### Crate & Package Guides
 
+- [vizij/README](crates/vizij/README.md) — the native app (the `vizij` binary)
+- [Face standard](docs/face-standard.md) & [ROS4HRI support](docs/ros4hri.md)
+- [vizij-bundle/README](crates/tools/vizij-bundle/README.md) — the face-GLB bundle tool
 - [vizij-animation-core/README](crates/animation/vizij-animation-core/README.md)
 - [vizij-graph-core/README](crates/node-graph/vizij-graph-core/README.md)
 - [vizij-api-core/README](crates/api/vizij-api-core/README.md)
 - [vizij-test-fixtures/README](crates/test-fixtures/vizij-test-fixtures/README.md)
-- [vizij/README](crates/vizij/README.md) — the native app (the `vizij` binary)
-- [vizij-bundle/README](crates/tools/vizij-bundle/README.md) — the face-GLB bundle tool
-- [Face standard](docs/face-standard.md) & [ROS4HRI support](docs/ros4hri.md)
 - [@vizij/node-graph/README](npm/@vizij/node-graph/README.md)
 - [@vizij/animation/README](npm/@vizij/animation/README.md)
 - [@vizij/value-json/README](npm/@vizij/value-json/README.md)

--- a/crates/vizij/README.md
+++ b/crates/vizij/README.md
@@ -60,8 +60,21 @@ WS bridge):
 
 | Flag | Feature | Effect |
 |---|---|---|
-| `--ros2 [namespace][:domain]` | `ros2` | expose the device's keys over ROS 2 topics |
+| `--ros2 [namespace][:domain]` | `ros2` | join the ROS graph as a ROS4HRI face (see below) |
 | `--studio` | `studio` | attach the Semio Studio bridge (configured from the environment) |
+
+`--ros2` attaches [`arora-bridge-ros2`](https://github.com/semio-ai/arora-sdk/tree/main/crates/arora-bridge-ros2)
+with its ROS4HRI exposure preset:
+
+- the typed face topics — `/robot_face/{expression,look_at,tts}` and
+  `/expressive_face/{look_at,speech}` — routed onto the profile's
+  `standard/ros4hri/*` keys;
+- the **`/skill/look_at`** action server (`interaction_skills/LookAt`):
+  track / glance / reset policies, priority preemption, standard error codes;
+- every store key as a data topic under `/<namespace>/keys/<path>`.
+
+[ROS4HRI support](../../docs/ros4hri.md) documents the key contract, the
+per-channel behavior, and the skill's semantics.
 
 ## Lighting model
 

--- a/docs/ros4hri.md
+++ b/docs/ros4hri.md
@@ -5,20 +5,28 @@ human-robot-interaction standard, as a **built-in profile**: a graph that maps
 the ROS4HRI face vocabulary onto the [Vizij face standard](face-standard.md), so
 a ROS4HRI face command drives any compliant Vizij face.
 
-This is **topic-level** support. Vizij consumes the ROS4HRI face-command
-vocabulary (expressions, action units, gaze, and — as a Vizij extension —
-visemes); it does not (yet) speak ROS4HRI's services or actions.
+Support spans both ROS4HRI planes:
+
+- **Topics** — the face-command vocabulary (expressions, action units, gaze,
+  and — as a Vizij extension — visemes) lands on the profile's
+  `standard/ros4hri/*` keys through typed topic endpoints.
+- **The skill plane** — the device serves ROS4HRI's gaze skill as a native
+  ROS 2 action server, [`/skill/look_at`](#the-look_at-skill)
+  (`interaction_skills/LookAt` — the standard's only action; `set_expression`
+  is, per the standard, a topic).
 
 ## How it fits together
 
 ```
-ROS4HRI topics ──(a ROS bridge)──▶ standard/ros4hri/* store keys
-                                          │
-                                   ros4hri profile graph
-                                          │
-                                   standard/vizij/* controls
-                                          │
-                                   the face's own rig graph ──▶ morphs / bones
+ROS4HRI topics ──(typed bridge endpoints)──▶ standard/ros4hri/* store keys
+                                                    │
+                                             ros4hri profile graph
+                                                    │
+                                             standard/vizij/* controls
+                                                    │
+                                             the face's own rig graph ──▶ morphs / bones
+
+/skill/look_at action ──(bridge skill plane)──▶ look_at task run ──▶ standard/ros4hri/gaze/* keys
 ```
 
 The profile is one layer in that chain: it reads the `standard/ros4hri/*` keys a
@@ -26,14 +34,18 @@ bridge writes and produces `standard/vizij/*` controls. It is
 asset-independent — it only writes standard control paths; what an expression or
 a viseme *looks like* stays with the face.
 
-> **The ROS bridge that writes `standard/ros4hri/*` from live ROS 2 topics is
-> the `arora-bridge-ros2` side, not this repo.** The ROS4HRI message vocabulary
-> (`hri_msgs/Expression`, `FacialActionUnits`, `Gaze`, …) is available as typed
-> ROS 2 messages in
-> [`arora-msgs-ros2`](https://github.com/semio-ai/arora-sdk/tree/main/crates/arora-msgs-ros2);
-> the typed-topic exposure that lands those onto these keys is a planned
-> bridge feature. Until then, drive the keys directly (any behavior or test can
-> write them) — the profile behaves identically regardless of who writes them.
+> **The ROS side lives in
+> [`arora-bridge-ros2`](https://github.com/semio-ai/arora-sdk/tree/main/crates/arora-bridge-ros2),
+> not this repo.** Its `ExposureProfile::ros4hri()` preset subscribes the typed
+> face topics — PAL's `/robot_face/{expression,look_at,tts}` and IIIA's
+> `/expressive_face/{look_at,speech}` — and routes their fields onto these keys,
+> and binds the [`/skill/look_at`](#the-look_at-skill) action. The `vizij`
+> binary wires the preset automatically when run with `--ros2`. The message
+> vocabulary (`hri_msgs`, `geometry_msgs`, `interaction_skills`, …) ships as
+> typed ROS 2 messages in
+> [`arora-msgs-ros2`](https://github.com/semio-ai/arora-sdk/tree/main/crates/arora-msgs-ros2).
+> Without a bridge, drive the keys directly (any behavior or test can write
+> them) — the profile behaves identically regardless of who writes them.
 
 ## The `standard/ros4hri/*` key contract
 
@@ -70,6 +82,46 @@ What a bridge (or a test) writes:
 
 All continuous channels pass through a ~200 ms exponential smoother — the
 incumbent ROS4HRI face's dynamics.
+
+## The `look_at` skill
+
+With the ROS 2 bridge attached, the device serves ROS4HRI's gaze skill as a
+standard ROS 2 action server on **`/skill/look_at`**
+(`interaction_skills/LookAt`). The goal is the standard's:
+`meta` (`std_skills/Meta`: caller + priority), `policy`, and `target`
+(`geometry_msgs/PointStamped`).
+
+```bash
+ros2 action send_goal /skill/look_at interaction_skills/action/LookAt \
+  "{meta: {priority: 128}, policy: '', target: {header: {frame_id: face}, point: {x: 1.0, y: 0.3, z: 0.1}}}"
+```
+
+| Policy | Behaviour |
+|---|---|
+| *(empty)* | track `target` continuously; runs until cancelled or preempted |
+| `glance` | look at `target`, then succeed once the gaze settles (~0.6 s dwell) |
+| `reset` | return the gaze to rest, then succeed once settled |
+| `random`, `social`, `auto` | not implemented — the goal aborts with `ROS_ENOTSUP` (134) |
+
+Semantics, per the standard:
+
+- **One active goal per skill.** A new goal with `meta.priority` at or above
+  the active one **preempts it** (the preempted goal returns `ROS_EINTR`, 4);
+  a lower-priority goal is rejected at `send_goal`.
+- **Cancel** halts the run; the result carries `ROS_ECANCELED` (125). Success
+  is `ROS_ENOERR` (0).
+- To move a tracked target, send a new goal at the same (or higher) priority:
+  it replaces the active one, which returns `ROS_EINTR`.
+
+The behavior itself is not compiled in — it is a **graph fragment asset**
+([`skills/look_at.json`](../crates/interop/vizij-arora-host/skills/look_at.json)
+in `vizij-arora-host`), grafted into the device's graph per run. Like the
+profile, it is canonical JSON: regenerable (`vizij-bundle export-skill
+look_at`), drift-tested, and **overridable per face** — a face GLB embedding a
+`skill::look_at` graph entry runs its own copy instead of the built-in.
+[`@vizij/runtime`](../npm/@vizij/runtime/README.md) exposes the registry
+(`skills()`, `skillSource(id)`), and the vizij-web authoring app embeds and
+edits skill fragments from **File → Skills**.
 
 ## Enabling it
 
@@ -117,5 +169,9 @@ them: gaze & lids (L0), expressions (L1), visemes (L2), muscle/AU (L3).
 - [The Vizij face standard](face-standard.md) — the target vocabulary.
 - [`vizij-bundle`](../crates/tools/vizij-bundle/README.md) — bundle, validate,
   and export profiles.
+- [`arora-bridge-ros2`](https://github.com/semio-ai/arora-sdk/tree/main/crates/arora-bridge-ros2) —
+  the bridge serving the typed endpoints and the skill plane
+  (`ExposureProfile`, `ActionBinding`).
 - [`arora-msgs-ros2`](https://github.com/semio-ai/arora-sdk/tree/main/crates/arora-msgs-ros2) —
-  the ROS4HRI (`hri_msgs`) message vocabulary as typed ROS 2 messages.
+  the ROS4HRI (`hri_msgs`, `interaction_skills`) message vocabulary as typed
+  ROS 2 messages.


### PR DESCRIPTION
The root README leads with the **vizij app**: how to run it, what a default run gives you (the face's own graphs, the face standard, the **ROS4HRI profile composed by default**, the local WS bridge), the ROS 2 surface (typed face topics + the `/skill/look_at` action + data topics), and headless. A capability table and a use-case table drive the links — including to [vizij-web](https://github.com/vizij-ai/vizij-web)'s authoring app and vizij-standalone. Contributor material follows, leading with toolchain + setup; the workspace layout moved down with the rest of the structural detail.

**docs/ros4hri.md** now documents what is served rather than the pre-skill state: both planes up front, the typed-endpoint reality of `ExposureProfile::ros4hri()` (replacing the stale "planned bridge feature" note), and a new **`look_at` skill** section — the goal contract, a copy-pasteable `ros2 action send_goal`, the policy table, priority preemption + error codes, and the overridable fragment asset (`skill::look_at`, `skills()`/`skillSource()`, File → Skills).

**crates/vizij/README.md** details what `--ros2` actually attaches.

All statements verified against `profile.rs` (the preset's endpoints/binding), `device.rs` (the app wiring), and the vendored `LookAt.action`/`std_skills` definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)