### PR TITLE
feat(interop): publish-ready interop crates; gaze contract moves to vizij-arora-behavior

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,8 +1,10 @@
 name: publish-crates
+
+# Publishes the publishable Rust crates to crates.io, in dependency order,
+# skipping any crate whose current version is already on the index — so a run
+# is always safe to repeat.
 on:
-  push:
-    tags:
-      - 'crates/*@*'
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -10,14 +12,25 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-      - name: Set credentials
+      - name: Publish (ordered, skip-if-published)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          mkdir -p ~/.cargo
-          cat > ~/.cargo/credentials <<EOF
-          [registry]
-          token = "${{ secrets.CARGO_REGISTRY_TOKEN }}"
-          EOF
-      - name: Publish crates
-        run: cargo workspaces publish --from-git --yes --no-verify
+          set -euo pipefail
+          crates="vizij-api-core vizij-graph-core vizij-arora-host vizij-arora-behavior"
+          for crate in $crates; do
+            version=$(cargo metadata --format-version 1 --no-deps \
+              | jq -r ".packages[] | select(.name==\"$crate\") | .version")
+            if curl -fsS "https://crates.io/api/v1/crates/$crate/$version" >/dev/null 2>&1; then
+              echo "$crate@$version already published — skipping"
+              continue
+            fi
+            echo "publishing $crate@$version"
+            cargo publish -p "$crate"
+            # The next crate's publish verifies against the index; wait until
+            # this one is visible there.
+            until curl -fsS "https://crates.io/api/v1/crates/$crate/$version" >/dev/null 2>&1; do
+              echo "waiting for $crate@$version to appear on the index…"
+              sleep 10
+            done
+          done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10909,11 +10909,13 @@ dependencies = [
 
 [[package]]
 name = "vizij-arora-behavior"
-version = "0.0.0"
+version = "1.0.0"
 dependencies = [
  "arora-behavior",
+ "arora-behavior-tree-types",
  "arora-simple-data-store",
  "arora-types",
+ "log",
  "serde",
  "serde_json",
  "uuid",
@@ -10938,7 +10940,7 @@ dependencies = [
 
 [[package]]
 name = "vizij-arora-host"
-version = "0.0.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "arora-behavior",

--- a/crates/api/vizij-api-core/Cargo.toml
+++ b/crates/api/vizij-api-core/Cargo.toml
@@ -2,7 +2,10 @@
 name = "vizij-api-core"
 version = "1.0.0"
 edition = "2021"
-publish = false
+license = "MIT OR Apache-2.0"
+description = "Vizij's shared Value/Shape/TypedPath contract, kept interoperable across the animation and node-graph stacks."
+repository = "https://github.com/vizij-ai/vizij-rs"
+readme = "README.md"
 
 [dependencies]
 arora-types = "2"

--- a/crates/interop/vizij-arora-behavior/Cargo.toml
+++ b/crates/interop/vizij-arora-behavior/Cargo.toml
@@ -1,21 +1,24 @@
 [package]
 name = "vizij-arora-behavior"
-version = "0.0.0"
+version = "1.0.0"
 edition.workspace = true
-publish = false
+license = "MIT OR Apache-2.0"
 description = "A Vizij node graph driven as an Arora behavior interpreter (ProcessingGraph)."
+repository = "https://github.com/vizij-ai/vizij-rs"
 
 [dependencies]
 arora-behavior = "8"
+# Declares the `Status` enumeration id the gaze contract's signature returns.
+arora-behavior-tree-types = "1"
 arora-types = "2"
+log = "0.4"
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = "1"
-vizij-api-core = { path = "../../api/vizij-api-core" }
-vizij-graph-core = { path = "../../node-graph/vizij-graph-core" }
+vizij-api-core = { version = "1", path = "../../api/vizij-api-core" }
+vizij-graph-core = { version = "1", path = "../../node-graph/vizij-graph-core" }
+# The skill fragments (the gaze contract grafts the shipped look_at asset).
+vizij-arora-host = { version = "1", path = "../vizij-arora-host" }
 
 [dev-dependencies]
 arora-simple-data-store = "2"
-# The real skill fragments, so the graft path is proven against the shipped
-# look_at asset rather than a synthetic one.
-vizij-arora-host = { path = "../vizij-arora-host" }

--- a/crates/interop/vizij-arora-behavior/src/gaze.rs
+++ b/crates/interop/vizij-arora-behavior/src/gaze.rs
@@ -1,0 +1,103 @@
+//! The gaze skill's exterior contract: the described `look_at` function a
+//! device registers, and the fragment that implements it.
+//!
+//! The behavior is data — `vizij-arora-host`'s look_at skill fragment,
+//! grafted per run by the interpreter ([`TaskFragment`]) — so the module
+//! here carries only the contract: the described signature a bridge
+//! discovers (DescribeMethods) and an exposure profile binds to the ROS4HRI
+//! `/skill/look_at` action (`interaction_skills/LookAt`). Signature and
+//! fragment derive from one parameter list
+//! ([`skills::LOOK_AT_PARAMS`](vizij_arora_host::skills::LOOK_AT_PARAMS)),
+//! so they cannot drift.
+
+use std::collections::HashMap;
+
+use arora_behavior_tree_types::STATUS_ENUMERATION_ID;
+use arora_types::gen_uuid_from_str;
+use arora_types::record::module::frozen::{Function, Parameter};
+use arora_types::record::ty::{FrozenScalar, FrozenTy, PrimitiveKind};
+use arora_types::record::{FrozenReference, Version};
+use uuid::Uuid;
+use vizij_arora_host::skills;
+
+use crate::TaskFragment;
+
+/// The gaze module's id on the device.
+pub fn module_id() -> Uuid {
+    gen_uuid_from_str("gaze-module")
+}
+
+/// The look_at function's id.
+pub fn look_at_id() -> Uuid {
+    gen_uuid_from_str(skills::LOOK_AT_FUNCTION)
+}
+
+/// The look_at task fragment, parsed from the shipped asset — what the
+/// device's interpreter grafts per goal.
+pub fn look_at_fragment() -> TaskFragment {
+    TaskFragment::parse(skills::LOOK_AT_JSON, look_at_parameters())
+        .expect("the shipped look_at asset parses")
+}
+
+/// The look_at fragment the device registers, honoring the face's pinned
+/// override: a bundle-embedded `skill::look_at` fragment replaces the shipped
+/// behavior (the `standard::<id>` precedence, applied to the skill plane). An
+/// embedded fragment that does not hold the task contract is refused loudly
+/// and the built-in serves.
+pub fn look_at_fragment_from(embedded: &[(String, serde_json::Value)]) -> TaskFragment {
+    if let Some((_, spec)) = embedded
+        .iter()
+        .find(|(id, _)| id == skills::LOOK_AT_FUNCTION)
+    {
+        match TaskFragment::parse(&spec.to_string(), look_at_parameters()) {
+            Ok(fragment) => {
+                log::info!("look_at: the face's embedded skill fragment overrides the built-in");
+                return fragment;
+            }
+            Err(e) => log::warn!("embedded look_at fragment refused ({e}); the built-in serves"),
+        }
+    }
+    look_at_fragment()
+}
+
+/// The parameter `id → name` map shared by the fragment and the signature.
+pub fn look_at_parameters() -> HashMap<Uuid, String> {
+    skills::LOOK_AT_PARAMS
+        .iter()
+        .map(|name| (gen_uuid_from_str(name), name.to_string()))
+        .collect()
+}
+
+/// The described look_at signature: `(policy, target, frame)` returning the
+/// behavior `Status` — the task-run marker a bridge exposes as an action.
+pub fn look_at_signature() -> Function {
+    let kinds = [
+        PrimitiveKind::String,   // policy
+        PrimitiveKind::ArrayF32, // target (vec3, meters, face frame)
+        PrimitiveKind::String,   // frame
+    ];
+    let mut parameters = HashMap::new();
+    let mut parameter_ordering = Vec::new();
+    for (name, kind) in skills::LOOK_AT_PARAMS.iter().zip(kinds) {
+        let id = gen_uuid_from_str(name);
+        parameter_ordering.push(id);
+        parameters.insert(
+            id,
+            Parameter {
+                name: name.to_string(),
+                ty: FrozenTy::from(kind),
+                mutable: false,
+            },
+        );
+    }
+    Function {
+        parameters,
+        parameter_ordering,
+        return_ty: FrozenTy::FrozenScalar(FrozenScalar {
+            reference: FrozenReference {
+                id: STATUS_ENUMERATION_ID,
+                version: Version::parse("1.0.0").expect("a valid version"),
+            },
+        }),
+    }
+}

--- a/crates/interop/vizij-arora-behavior/src/lib.rs
+++ b/crates/interop/vizij-arora-behavior/src/lib.rs
@@ -22,6 +22,7 @@
 //! [`ProcessingGraph::load`]: arora_behavior::BehaviorInterpreter::load
 //! [`ProcessingGraph::apply`]: arora_behavior::BehaviorInterpreter::apply
 
+pub mod gaze;
 pub mod graph_codec;
 
 use std::collections::HashMap;

--- a/crates/interop/vizij-arora-host/Cargo.toml
+++ b/crates/interop/vizij-arora-host/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "vizij-arora-host"
-version = "0.0.0"
+version = "1.0.0"
 edition.workspace = true
-publish = false
+license = "MIT OR Apache-2.0"
 description = "Portable Vizij host glue: compose the device behavior from graph sources, read the face bundle, pick the program to autoplay, and stage the neutral pose. Shared by the native app and vizij-arora-web (the browser runtime)."
+repository = "https://github.com/vizij-ai/vizij-rs"
 
 [dependencies]
-vizij-api-core = { path = "../../api/vizij-api-core" }
+vizij-api-core = { version = "1", path = "../../api/vizij-api-core" }
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 log = "0.4"

--- a/crates/vizij/src/gaze.rs
+++ b/crates/vizij/src/gaze.rs
@@ -1,106 +1,11 @@
-//! The gaze skill's exterior contract: the described `look_at` method the
-//! device registers, and the fragment that implements it.
-//!
-//! The behavior is data — `vizij-arora-host`'s look_at skill fragment,
-//! grafted per run by the interpreter ([`TaskFragment`]) — so the module
-//! here carries only the contract: the described signature a bridge
-//! discovers (DescribeMethods) and an exposure profile binds to the ROS4HRI
-//! `/skill/look_at` action (`interaction_skills/LookAt`). Signature and
-//! fragment derive from one parameter list ([`skills::LOOK_AT_PARAMS`]), so
-//! they cannot drift.
-
-use std::collections::HashMap;
+//! The gaze module this device registers: the portable look_at contract
+//! ([`vizij_arora_behavior::gaze`]) packaged as an arora host module.
 
 use arora::{HostModule, ModuleBuilder};
-use arora_behavior_tree_types::STATUS_ENUMERATION_ID;
 use arora_types::call::CallResult;
-use arora_types::gen_uuid_from_str;
-use arora_types::record::module::frozen::{Function, Parameter};
-use arora_types::record::ty::{FrozenScalar, FrozenTy, PrimitiveKind};
-use arora_types::record::{FrozenReference, Version};
-use uuid::Uuid;
-use vizij_arora_behavior::{task, TaskFragment};
+pub use vizij_arora_behavior::gaze::*;
+use vizij_arora_behavior::task;
 use vizij_arora_host::skills;
-
-/// The gaze module's id on the device.
-pub fn module_id() -> Uuid {
-    gen_uuid_from_str("gaze-module")
-}
-
-/// The look_at function's id.
-pub fn look_at_id() -> Uuid {
-    gen_uuid_from_str(skills::LOOK_AT_FUNCTION)
-}
-
-/// The look_at task fragment, parsed from the shipped asset — what the
-/// device's interpreter grafts per goal.
-pub fn look_at_fragment() -> TaskFragment {
-    TaskFragment::parse(skills::LOOK_AT_JSON, look_at_parameters())
-        .expect("the shipped look_at asset parses")
-}
-
-/// The look_at fragment the device registers, honoring the face's pinned
-/// override: a bundle-embedded `skill::look_at` fragment replaces the shipped
-/// behavior (the `standard::<id>` precedence, applied to the skill plane). An
-/// embedded fragment that does not hold the task contract is refused loudly
-/// and the built-in serves.
-pub fn look_at_fragment_from(embedded: &[(String, serde_json::Value)]) -> TaskFragment {
-    if let Some((_, spec)) = embedded
-        .iter()
-        .find(|(id, _)| id == skills::LOOK_AT_FUNCTION)
-    {
-        match TaskFragment::parse(&spec.to_string(), look_at_parameters()) {
-            Ok(fragment) => {
-                log::info!("look_at: the face's embedded skill fragment overrides the built-in");
-                return fragment;
-            }
-            Err(e) => log::warn!("embedded look_at fragment refused ({e}); the built-in serves"),
-        }
-    }
-    look_at_fragment()
-}
-
-/// The parameter `id → name` map shared by the fragment and the signature.
-fn look_at_parameters() -> HashMap<Uuid, String> {
-    skills::LOOK_AT_PARAMS
-        .iter()
-        .map(|name| (gen_uuid_from_str(name), name.to_string()))
-        .collect()
-}
-
-/// The described look_at signature: `(policy, target, frame)` returning the
-/// behavior `Status` — the task-run marker a bridge exposes as an action.
-fn look_at_signature() -> Function {
-    let kinds = [
-        PrimitiveKind::String,   // policy
-        PrimitiveKind::ArrayF32, // target (vec3, meters, face frame)
-        PrimitiveKind::String,   // frame
-    ];
-    let mut parameters = HashMap::new();
-    let mut parameter_ordering = Vec::new();
-    for (name, kind) in skills::LOOK_AT_PARAMS.iter().zip(kinds) {
-        let id = gen_uuid_from_str(name);
-        parameter_ordering.push(id);
-        parameters.insert(
-            id,
-            Parameter {
-                name: name.to_string(),
-                ty: FrozenTy::from(kind),
-                mutable: false,
-            },
-        );
-    }
-    Function {
-        parameters,
-        parameter_ordering,
-        return_ty: FrozenTy::FrozenScalar(FrozenScalar {
-            reference: FrozenReference {
-                id: STATUS_ENUMERATION_ID,
-                version: Version::parse("1.0.0").expect("a valid version"),
-            },
-        }),
-    }
-}
 
 /// The gaze module: the look_at contract, described so bridges discover it.
 /// The closure is only reached when the device did not register the fragment


### PR DESCRIPTION
Groundwork for external hosts serving the skill plane (first consumer: the vizij-web standalone, which will run the interpreter natively — the VIZ-96 follow-up made real).

- **vizij-api-core 1.0.0, vizij-arora-host 1.0.0, vizij-arora-behavior 1.0.0 become publishable**: `publish = false` dropped, license (MIT OR Apache-2.0, matching vizij-graph-core), repository, and `version =` on every path dep. vizij-graph-core (1.3.0) was already publish-ready.
- **The portable look_at contract moves down**: `vizij_arora_behavior::gaze` now owns module/function ids, the parameter map, the described signature, and fragment parsing (incl. the face-embedded `skill::look_at` override). The app's `gaze` module keeps only the arora `HostModule` packaging and re-exports the rest — its consumers are unchanged. The behavior crate's dev-dep on vizij-arora-host becomes a regular dep (host never depended on behavior, so the DAG stays clean).
- **publish-crates.yml becomes a working workflow**: the old tag-triggered flow invoked `cargo workspaces` without installing it and was never used (no `crates/*@*` tag exists). Now: `workflow_dispatch`, publishes the four crates in dependency order, skips any version already on the index (safe to re-run), waits for index visibility between crates.

Verified: `cargo build` of behavior/host/app + 44 interop tests green; `cargo package -p vizij-api-core` packages clean.

After merge: `gh workflow run publish-crates` publishes the four crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)