### PR TITLE
ci: publish-crates authenticates via crates.io Trusted Publishing

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -3,8 +3,17 @@ name: publish-crates
 # Publishes the publishable Rust crates to crates.io, in dependency order,
 # skipping any crate whose current version is already on the index — so a run
 # is always safe to repeat.
+#
+# Authentication is crates.io Trusted Publishing (OIDC, no long-lived token):
+# every published crate carries a Trusted Publisher config on crates.io naming
+# this repository and this workflow file. A brand-new crate needs its config
+# created (as a pending publisher) before its first publish.
 on:
   workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   publish:
@@ -12,9 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       - name: Publish (ordered, skip-if-published)
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           set -euo pipefail
           crates="vizij-api-core vizij-graph-core vizij-arora-host vizij-arora-behavior"


### PR DESCRIPTION
The stored `CARGO_REGISTRY_TOKEN` is rejected by crates.io (403 on the first real publish attempt), so the workflow now mints a temporary token per run via OIDC (`rust-lang/crates-io-auth-action`) — no long-lived secret. Prerequisite: a (pending) Trusted Publisher config on crates.io per crate (owner `vizij-ai`, repo `vizij-rs`, workflow `publish-crates.yml`, no environment) for vizij-api-core / vizij-graph-core / vizij-arora-host / vizij-arora-behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)